### PR TITLE
feat: add verbose logging of Claude responses and review findings

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -87,7 +87,12 @@ export class ClaudeClient {
         timeout: 300000,
       });
 
-      return { content: stdout.trim() };
+      const content = stdout.trim();
+      core.startGroup('Claude CLI response');
+      core.info(content);
+      core.endGroup();
+
+      return { content };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       core.warning(`Claude CLI failed: ${msg}`);
@@ -106,6 +111,11 @@ export class ClaudeClient {
     });
 
     const textBlocks = response.content.filter(b => b.type === 'text');
-    return { content: textBlocks.map(b => b.text).join('\n') };
+    const content = textBlocks.map(b => b.text).join('\n');
+    core.startGroup('Claude API response');
+    core.info(content);
+    core.endGroup();
+
+    return { content };
   }
 }

--- a/src/review.ts
+++ b/src/review.ts
@@ -10,7 +10,8 @@ export async function runReview(
   rawDiff: string,
   repoContext: string,
 ): Promise<ReviewResult> {
-  core.info(`Running ${config.reviewers.length} reviewer agents in parallel...`);
+  const reviewerNames = config.reviewers.map(r => r.name).join(', ');
+  core.info(`Running ${config.reviewers.length} reviewer agents in parallel: ${reviewerNames}`);
 
   const agentResults = await Promise.allSettled(
     config.reviewers.map(reviewer =>
@@ -24,7 +25,12 @@ export async function runReview(
     const reviewer = config.reviewers[i];
     if (result.status === 'fulfilled') {
       allFindings.push({ reviewer: reviewer.name, findings: result.value });
-      core.info(`${reviewer.name}: ${result.value.length} findings`);
+      core.startGroup(`Reviewer: ${reviewer.name}`);
+      core.info(`Findings: ${result.value.length}`);
+      for (const f of result.value) {
+        core.info(`  [${f.severity}] ${f.title} — ${f.file}:${f.line}`);
+      }
+      core.endGroup();
     } else {
       core.warning(`${reviewer.name} agent failed: ${result.reason}`);
     }
@@ -40,8 +46,19 @@ export async function runReview(
     };
   }
 
-  core.info('Running consolidation agent...');
-  return runConsolidationAgent(client, config, allFindings, rawDiff);
+  const totalFindings = allFindings.reduce((sum, af) => sum + af.findings.length, 0);
+  core.info(`Running consolidation agent with ${totalFindings} total findings...`);
+  const result = await runConsolidationAgent(client, config, allFindings, rawDiff);
+
+  core.startGroup('Consolidated Review');
+  core.info(`Verdict: ${result.verdict}`);
+  core.info(`Findings: ${result.findings.length}`);
+  for (const f of result.findings) {
+    core.info(`  [${f.severity}] ${f.title} — ${f.file}:${f.line}`);
+  }
+  core.endGroup();
+
+  return result;
 }
 
 async function runReviewerAgent(


### PR DESCRIPTION
## Summary

- Logs raw Claude CLI/API responses in collapsible groups in GitHub Actions logs
- Logs each reviewer agent's findings with severity, title, file, and line
- Logs the consolidated review verdict and final findings

Now you can expand each section in the action run to see exactly what Claude said.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions logging for Claude API interactions with detailed response information.
  * Improved code review output logging with reviewer names and per-finding details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->