### PR TITLE
fix: ensure proper REQUEST_CHANGES and APPROVE review events

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -144,7 +144,7 @@ export async function dismissPreviousReviews(
   });
 
   for (const review of reviews) {
-    if (review.body?.includes(BOT_MARKER) && review.state !== 'DISMISSED') {
+    if (review.body?.includes(BOT_MARKER) && review.state === 'CHANGES_REQUESTED') {
       try {
         await octokit.rest.pulls.dismissReview({
           owner,
@@ -185,18 +185,44 @@ export async function postReview(
 
   const body = `${BOT_MARKER}\n${result.summary}`;
 
-  const { data: review } = await octokit.rest.pulls.createReview({
-    owner,
-    repo,
-    pull_number: prNumber,
-    commit_id: commitSha,
-    event,
-    body,
-    comments,
-  });
+  core.info(`Posting review: ${event} with ${comments.length} inline comments`);
 
-  core.info(`Posted review #${review.id} with verdict ${result.verdict} and ${comments.length} inline comments`);
-  return review.id;
+  try {
+    const { data: review } = await octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      commit_id: commitSha,
+      event,
+      body,
+      comments,
+    });
+
+    core.info(`Posted review #${review.id} with verdict ${result.verdict}`);
+    return review.id;
+  } catch (error) {
+    if (event === 'COMMENT') {
+      throw error;
+    }
+
+    const hint = event === 'APPROVE'
+      ? 'Ensure "Allow GitHub Actions to create and approve pull requests" is enabled in repo settings.'
+      : 'The token may lack permission to request changes.';
+    core.warning(`Failed to post ${event} review. ${hint} Falling back to COMMENT.`);
+
+    const { data: review } = await octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      commit_id: commitSha,
+      event: 'COMMENT',
+      body,
+      comments,
+    });
+
+    core.info(`Posted fallback COMMENT review #${review.id} (original verdict: ${result.verdict})`);
+    return review.id;
+  }
 }
 
 function mapVerdictToEvent(verdict: ReviewVerdict): 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES' {

--- a/src/state.ts
+++ b/src/state.ts
@@ -123,16 +123,33 @@ async function checkAndAutoApprove(
     pull_number: prNumber,
   });
 
-  await octokit.rest.pulls.createReview({
-    owner,
-    repo,
-    pull_number: prNumber,
-    commit_id: pr.head.sha,
-    event: 'APPROVE',
-    body: `${BOT_MARKER}\nAll blocking issues have been resolved. Auto-approving.`,
-  });
+  const body = `${BOT_MARKER}\nAll blocking issues have been resolved. Auto-approving.`;
 
-  core.info('Auto-approved PR');
+  try {
+    await octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      commit_id: pr.head.sha,
+      event: 'APPROVE',
+      body,
+    });
+    core.info('Auto-approved PR');
+  } catch {
+    core.warning(
+      'Failed to auto-approve PR. Ensure "Allow GitHub Actions to create and approve pull requests" is enabled in repo settings. Falling back to COMMENT.',
+    );
+    await octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      commit_id: pr.head.sha,
+      event: 'COMMENT',
+      body,
+    });
+    core.info('Posted auto-approve as COMMENT (fallback)');
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Wraps review posting in try-catch with fallback to COMMENT if APPROVE/REQUEST_CHANGES fails (token permissions)
- Only attempts to dismiss CHANGES_REQUESTED reviews (not COMMENT/APPROVED which can't be dismissed)
- Adds helpful warning about "Allow GitHub Actions to create and approve pull requests" repo setting
- Same fallback pattern applied to auto-approve in `state.ts`

Closes #20