### PR TITLE
chore: enable review memory

### DIFF
--- a/.claude-review.yml
+++ b/.claude-review.yml
@@ -10,3 +10,7 @@ instructions: |
   This is a TypeScript GitHub Action project.
   Focus on: correct GitHub API usage, proper error handling, TypeScript type safety.
   The action processes untrusted PR content — flag any potential prompt injection vectors.
+
+memory:
+  enabled: true
+  repo: "xdustinface/review-memory"


### PR DESCRIPTION
## Summary

- Enables review memory in `.claude-review.yml` pointing to `xdustinface/review-memory`
- Memory repo has been seeded with initial learnings and global conventions

The next review will load learnings from the memory repo and inject them into reviewer prompts.