### PR TITLE
fix: submit actual APPROVE review, include dotfiles, remove stale dist exclude

### DIFF
--- a/.claude-review.yml
+++ b/.claude-review.yml
@@ -4,7 +4,6 @@ auto_approve: true
 
 exclude_paths:
   - "*.lock"
-  - "dist/**"
 
 instructions: |
   This is a TypeScript GitHub Action project.

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -247,6 +247,20 @@ describe('filterFiles', () => {
     const result = filterFiles(files, ['*.py'], []);
     expect(result).toHaveLength(0);
   });
+
+  it('includes dotfiles with default include pattern', () => {
+    const dotfiles: DiffFile[] = [
+      { path: '.claude-review.yml', changeType: 'modified', hunks: [] },
+      { path: '.github/workflows/ci.yml', changeType: 'modified', hunks: [] },
+      { path: '.gitignore', changeType: 'modified', hunks: [] },
+      { path: 'src/main.ts', changeType: 'modified', hunks: [] },
+    ];
+    const result = filterFiles(dotfiles, ['**/*'], []);
+    expect(result).toHaveLength(4);
+    expect(result.map((f) => f.path)).toContain('.claude-review.yml');
+    expect(result.map((f) => f.path)).toContain('.github/workflows/ci.yml');
+    expect(result.map((f) => f.path)).toContain('.gitignore');
+  });
 });
 
 describe('isLineInDiff', () => {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -59,7 +59,7 @@ export function filterFiles(
   excludePaths: string[],
 ): DiffFile[] {
   return files.filter((file) => {
-    const matchOpts = { matchBase: true };
+    const matchOpts = { matchBase: true, dot: true };
 
     const included =
       includePaths.length === 0 ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,12 +153,14 @@ async function runFullReview(
 
     if (isDiffTooLarge(diff, config.max_diff_lines)) {
       core.warning(`Diff too large (${diff.totalAdditions + diff.totalDeletions} lines > ${config.max_diff_lines} max)`);
-      await updateProgressComment(octokit, owner, repo, progressCommentId, {
-        verdict: 'COMMENT',
+      const result = {
+        verdict: 'COMMENT' as const,
         summary: `Diff too large for automated review (${diff.totalAdditions + diff.totalDeletions} lines). Please request a manual review.`,
         findings: [],
         highlights: [],
-      });
+      };
+      await postReview(octokit, owner, repo, prNumber, commitSha, result);
+      await updateProgressComment(octokit, owner, repo, progressCommentId, result);
       return;
     }
 
@@ -167,12 +169,15 @@ async function runFullReview(
 
     if (filteredFiles.length === 0) {
       core.info('No reviewable files in diff');
-      await updateProgressComment(octokit, owner, repo, progressCommentId, {
-        verdict: 'APPROVE',
+      const result = {
+        verdict: 'APPROVE' as const,
         summary: 'No reviewable files in this PR (all filtered out by config).',
         findings: [],
         highlights: [],
-      });
+      };
+      await dismissPreviousReviews(octokit, owner, repo, prNumber);
+      await postReview(octokit, owner, repo, prNumber, commitSha, result);
+      await updateProgressComment(octokit, owner, repo, progressCommentId, result);
       return;
     }
 


### PR DESCRIPTION
## Summary

- Submits an actual GitHub APPROVE review (not just a comment) when no blocking findings or no reviewable files
- Adds `dot: true` to minimatch so dotfiles (`.claude-review.yml`, `.github/` etc.) are included in reviews
- Removes stale `dist/**` from `exclude_paths` since dist/ is no longer in git
- Posts a COMMENT review (not just a PR comment) for "diff too large" case