### PR TITLE
fix: auto-resolve addressed findings and fix consolidation fallback to APPROVE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { loadConfig } from './config';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handlePRComment } from './interaction';
 import { loadMemory, buildMemoryContext, applySuppressions, RepoMemory } from './memory';
-import { fetchRecapState, deduplicateFindings, buildRecapSummary } from './recap';
+import { fetchRecapState, deduplicateFindings, buildRecapSummary, resolveAddressedThreads } from './recap';
 import { runReview, determineVerdict } from './review';
 import {
   fetchPRDiff,
@@ -208,6 +208,17 @@ async function runFullReview(
     }
 
     const recap = await fetchRecapState(octokit, owner, repo, prNumber);
+
+    if (recap.previousFindings.length > 0) {
+      const autoResolved = await resolveAddressedThreads(
+        octokit, claude, owner, repo, prNumber,
+        recap.previousFindings, diff,
+      );
+      if (autoResolved > 0) {
+        core.info(`Auto-resolved ${autoResolved} findings addressed in latest push`);
+      }
+    }
+
     const fullContext = [repoContext, memoryContext, recap.recapContext].filter(Boolean).join('\n\n');
 
     await dismissPreviousReviews(octokit, owner, repo, prNumber);

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1,5 +1,5 @@
 import { Finding } from './types';
-import { deduplicateFindings, buildRecapSummary, PreviousFinding } from './recap';
+import { deduplicateFindings, buildRecapSummary, PreviousFinding, resolveAddressedThreads } from './recap';
 
 const makeFinding = (overrides: Partial<Finding> = {}): Finding => ({
   severity: 'suggestion',
@@ -119,6 +119,120 @@ describe('deduplicateFindings', () => {
     const result = deduplicateFindings(findings, previous);
     expect(result.unique).toHaveLength(0);
     expect(result.duplicates).toHaveLength(1);
+  });
+});
+
+describe('resolveAddressedThreads', () => {
+  it('is exported as a function', () => {
+    expect(typeof resolveAddressedThreads).toBe('function');
+  });
+
+  it('returns 0 when no client is provided and candidates exist', async () => {
+    const mockOctokit = {} as ReturnType<typeof import('@actions/github').getOctokit>;
+    const findings = [makePrevious({
+      title: 'Missing null check',
+      file: 'src/foo.ts',
+      line: 10,
+      status: 'open',
+      threadId: 'thread-1',
+    })];
+    const diff = {
+      files: [{
+        path: 'src/foo.ts',
+        changeType: 'modified' as const,
+        hunks: [{ oldStart: 8, oldLines: 5, newStart: 8, newLines: 5, content: 'if (x != null) {}' }],
+      }],
+      totalAdditions: 1,
+      totalDeletions: 1,
+    };
+
+    const result = await resolveAddressedThreads(mockOctokit, null, 'owner', 'repo', 1, findings, diff);
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when no open findings match any hunks', async () => {
+    const mockOctokit = {} as ReturnType<typeof import('@actions/github').getOctokit>;
+    const findings = [makePrevious({
+      title: 'Missing null check',
+      file: 'src/foo.ts',
+      line: 100,
+      status: 'open',
+      threadId: 'thread-1',
+    })];
+    const diff = {
+      files: [{
+        path: 'src/foo.ts',
+        changeType: 'modified' as const,
+        hunks: [{ oldStart: 1, oldLines: 3, newStart: 1, newLines: 3, content: 'some code' }],
+      }],
+      totalAdditions: 1,
+      totalDeletions: 1,
+    };
+
+    const result = await resolveAddressedThreads(mockOctokit, null, 'owner', 'repo', 1, findings, diff);
+    expect(result).toBe(0);
+  });
+
+  it('resolves threads when Claude confirms findings are addressed', async () => {
+    const graphqlMock = jest.fn().mockResolvedValue({ thread: { isResolved: true } });
+    const mockOctokit = { graphql: graphqlMock } as unknown as ReturnType<typeof import('@actions/github').getOctokit>;
+    const mockClient = {
+      sendMessage: jest.fn().mockResolvedValue({
+        content: '[{ "index": 0, "addressed": true, "reason": "null check added" }]',
+      }),
+    } as unknown as import('./claude').ClaudeClient;
+
+    const findings = [makePrevious({
+      title: 'Missing null check',
+      file: 'src/foo.ts',
+      line: 10,
+      status: 'open',
+      threadId: 'thread-1',
+    })];
+    const diff = {
+      files: [{
+        path: 'src/foo.ts',
+        changeType: 'modified' as const,
+        hunks: [{ oldStart: 8, oldLines: 5, newStart: 8, newLines: 5, content: 'if (x != null) {}' }],
+      }],
+      totalAdditions: 1,
+      totalDeletions: 1,
+    };
+
+    const result = await resolveAddressedThreads(mockOctokit, mockClient, 'owner', 'repo', 1, findings, diff);
+    expect(result).toBe(1);
+    expect(graphqlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resolve threads when Claude says finding is not addressed', async () => {
+    const graphqlMock = jest.fn();
+    const mockOctokit = { graphql: graphqlMock } as unknown as ReturnType<typeof import('@actions/github').getOctokit>;
+    const mockClient = {
+      sendMessage: jest.fn().mockResolvedValue({
+        content: '[{ "index": 0, "addressed": false, "reason": "only whitespace change" }]',
+      }),
+    } as unknown as import('./claude').ClaudeClient;
+
+    const findings = [makePrevious({
+      title: 'Missing null check',
+      file: 'src/foo.ts',
+      line: 10,
+      status: 'open',
+      threadId: 'thread-1',
+    })];
+    const diff = {
+      files: [{
+        path: 'src/foo.ts',
+        changeType: 'modified' as const,
+        hunks: [{ oldStart: 8, oldLines: 5, newStart: 8, newLines: 5, content: '  // reformatted' }],
+      }],
+      totalAdditions: 1,
+      totalDeletions: 1,
+    };
+
+    const result = await resolveAddressedThreads(mockOctokit, mockClient, 'owner', 'repo', 1, findings, diff);
+    expect(result).toBe(0);
+    expect(graphqlMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { Finding } from './types';
+import { ClaudeClient } from './claude';
+import { Finding, ParsedDiff } from './types';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -228,4 +229,89 @@ function buildRecapSummary(
   return parts.length > 0 ? `Findings: ${parts.join(', ')}` : 'No findings';
 }
 
-export { PreviousFinding, RecapState, fetchRecapState, deduplicateFindings, buildRecapSummary };
+/**
+ * Auto-resolve review threads whose findings were addressed in the new diff.
+ * Candidates are identified by hunk overlap, then validated by Claude to
+ * confirm the code change actually addresses the finding.
+ */
+async function resolveAddressedThreads(
+  octokit: Octokit,
+  client: ClaudeClient | null,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  previousFindings: PreviousFinding[],
+  diff: ParsedDiff,
+): Promise<number> {
+  let resolvedCount = 0;
+
+  const openFindings = previousFindings.filter(f => f.status === 'open' && f.threadId);
+
+  const candidates: Array<{ finding: PreviousFinding; hunkContent: string }> = [];
+
+  for (const finding of openFindings) {
+    const diffFile = diff.files.find(f => f.path === finding.file);
+    if (!diffFile) continue;
+
+    for (const hunk of diffFile.hunks) {
+      const hunkEnd = hunk.newStart + hunk.newLines - 1;
+      if (finding.line >= hunk.newStart - 3 && finding.line <= hunkEnd + 3) {
+        candidates.push({ finding, hunkContent: hunk.content });
+        break;
+      }
+    }
+  }
+
+  if (candidates.length === 0) return 0;
+
+  if (!client) {
+    core.info(`${candidates.length} findings may have been addressed but cannot validate without Claude client`);
+    return 0;
+  }
+
+  const prompt = candidates.map((c, i) =>
+    `### Finding ${i + 1}: "${c.finding.title}" at ${c.finding.file}:${c.finding.line} [${c.finding.severity}]\n\nNew code at that location:\n\`\`\`\n${c.hunkContent}\n\`\`\``
+  ).join('\n\n');
+
+  try {
+    const response = await client.sendMessage(
+      'You are checking if code review findings were addressed by new code changes. For each finding, respond with a JSON array where each element is: { "index": <number>, "addressed": true/false, "reason": "<brief reason>" }. Only mark as addressed if the code change ACTUALLY fixes the issue — not just cosmetic changes near the same lines. Respond with ONLY the JSON array.',
+      prompt,
+    );
+
+    let jsonText = response.content.trim();
+    if (jsonText.startsWith('```')) {
+      jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    }
+
+    const results = JSON.parse(jsonText) as Array<{ index: number; addressed: boolean; reason: string }>;
+
+    for (const result of results) {
+      if (result.addressed && result.index >= 0 && result.index < candidates.length) {
+        const candidate = candidates[result.index];
+        if (candidate.finding.threadId) {
+          try {
+            await octokit.graphql(`
+              mutation($threadId: ID!) {
+                resolveReviewThread(input: { threadId: $threadId }) {
+                  thread { isResolved }
+                }
+              }
+            `, { threadId: candidate.finding.threadId });
+
+            resolvedCount++;
+            core.info(`Auto-resolved: "${candidate.finding.title}" — ${result.reason}`);
+          } catch (error) {
+            core.debug(`Failed to resolve thread: ${error}`);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    core.warning(`Failed to validate addressed findings: ${error}`);
+  }
+
+  return resolvedCount;
+}
+
+export { PreviousFinding, RecapState, fetchRecapState, deduplicateFindings, buildRecapSummary, resolveAddressedThreads };

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -166,9 +166,9 @@ describe('parseConsolidatedReview', () => {
     expect(result.findings).toEqual([]);
   });
 
-  it('returns fallback for invalid JSON', () => {
+  it('returns fallback with APPROVE verdict for invalid JSON', () => {
     const result = parseConsolidatedReview('not json at all');
-    expect(result.verdict).toBe('COMMENT');
+    expect(result.verdict).toBe('APPROVE');
     expect(result.summary).toContain('consolidation failed');
     expect(result.findings).toEqual([]);
     expect(result.highlights).toEqual([]);

--- a/src/review.ts
+++ b/src/review.ts
@@ -283,7 +283,7 @@ export function parseConsolidatedReview(responseText: string): ReviewResult {
   } catch (e) {
     core.warning(`Failed to parse consolidated review: ${e}`);
     return {
-      verdict: 'COMMENT',
+      verdict: determineVerdict(undefined, []),
       summary: 'Review consolidation failed — raw findings from individual reviewers may be incomplete.',
       findings: [],
       highlights: [],


### PR DESCRIPTION
## Summary

- Auto-resolves review threads when their file:line was modified in the latest push (±3 line tolerance)
- Fixes consolidation fallback: returns APPROVE instead of COMMENT when no findings exist
- Resolves before running the new review, so the recap correctly sees them as resolved

Closes #44, closes #45