### PR TITLE
fix: consolidation failure returns COMMENT instead of APPROVE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,7 @@ async function runFullReview(
         summary: `Diff too large for automated review (${diff.totalAdditions + diff.totalDeletions} lines). Please request a manual review.`,
         findings: [],
         highlights: [],
+        reviewComplete: true,
       };
       // Dismiss stale CHANGES_REQUESTED reviews before posting the skip comment
       try {
@@ -182,6 +183,7 @@ async function runFullReview(
         summary: 'No reviewable files in this PR (all filtered out by config).',
         findings: [],
         highlights: [],
+        reviewComplete: true,
       };
       await dismissPreviousReviews(octokit, owner, repo, prNumber);
       await postReview(octokit, owner, repo, prNumber, commitSha, result);
@@ -224,6 +226,10 @@ async function runFullReview(
     await dismissPreviousReviews(octokit, owner, repo, prNumber);
 
     const result = await runReview(claude, config, diff, rawDiff, fullContext);
+
+    if (!result.reviewComplete && result.verdict === 'APPROVE') {
+      result.verdict = 'COMMENT';
+    }
 
     if (memory && memory.suppressions.length > 0) {
       const { kept, suppressed } = applySuppressions(result.findings, memory.suppressions);
@@ -273,6 +279,7 @@ async function runFullReview(
       summary: `Review failed: ${msg}`,
       findings: [],
       highlights: [],
+      reviewComplete: false,
     });
   }
 }

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -166,12 +166,25 @@ describe('parseConsolidatedReview', () => {
     expect(result.findings).toEqual([]);
   });
 
-  it('returns fallback with APPROVE verdict for invalid JSON', () => {
+  it('returns fallback with COMMENT verdict and reviewComplete false for invalid JSON', () => {
     const result = parseConsolidatedReview('not json at all');
-    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdict).toBe('COMMENT');
     expect(result.summary).toContain('consolidation failed');
     expect(result.findings).toEqual([]);
     expect(result.highlights).toEqual([]);
+    expect(result.reviewComplete).toBe(false);
+  });
+
+  it('sets reviewComplete true on successful parse', () => {
+    const json = JSON.stringify({
+      verdict: 'APPROVE',
+      summary: 'Looks good.',
+      findings: [],
+      highlights: [],
+    });
+    const result = parseConsolidatedReview(json);
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.reviewComplete).toBe(true);
   });
 
   it('overrides claimed verdict based on actual findings', () => {

--- a/src/review.ts
+++ b/src/review.ts
@@ -53,6 +53,7 @@ export async function runReview(
       summary: 'Review could not be completed — all reviewer agents failed.',
       findings: [],
       highlights: [],
+      reviewComplete: false,
     };
   }
 
@@ -279,14 +280,16 @@ export function parseConsolidatedReview(responseText: string): ReviewResult {
       summary: String(parsed.summary || ''),
       findings,
       highlights: Array.isArray(parsed.highlights) ? parsed.highlights.map(String) : [],
+      reviewComplete: true,
     };
   } catch (e) {
     core.warning(`Failed to parse consolidated review: ${e}`);
     return {
-      verdict: determineVerdict(undefined, []),
+      verdict: 'COMMENT',
       summary: 'Review consolidation failed — raw findings from individual reviewers may be incomplete.',
       findings: [],
       highlights: [],
+      reviewComplete: false,
     };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface ReviewResult {
   summary: string;
   findings: Finding[];
   highlights: string[];
+  reviewComplete: boolean;
 }
 
 export interface ReviewerAgent {


### PR DESCRIPTION
## Summary

- Adds `reviewComplete` boolean to `ReviewResult` to distinguish "no findings" from "review failed"
- Consolidation failure → COMMENT (was incorrectly APPROVE)
- All agents failed → COMMENT with `reviewComplete: false`
- Only successful reviews with no blocking findings → APPROVE
- Safety net in `runFullReview` downgrades APPROVE to COMMENT if review didn't complete

Closes #50