### PR TITLE
fix: cancel in-progress review runs when PR is updated

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,6 +24,9 @@ jobs:
        contains(github.event.comment.body, '@claude') &&
        github.event.issue.pull_request) ||
       github.event_name == 'pull_request_review_comment'
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Claude Review runs three specialized reviewer agents in parallel — **Security 
 - **Custom bot identity**: GitHub App support lets reviews appear under your own app name and avatar
 - **Dual auth**: Works with Claude Max subscription (OAuth) or Anthropic API key
 - **Mention trigger**: Comment `@claude review` on any PR to trigger a review on demand
+- **Concurrent-safe**: New pushes to a PR automatically cancel any in-progress review for that PR
 
 ## Quick Start
 
@@ -62,6 +63,9 @@ jobs:
        contains(github.event.comment.body, '@claude') &&
        contains(github.event.comment.body, 'review') &&
        github.event.issue.pull_request)
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `concurrency` group to workflow, keyed by PR number
- New pushes cancel stale in-progress reviews for the same PR
- Different PRs still review in parallel

Closes #48