### PR TITLE
feat: add emoji reactions to acknowledge triggers and commands

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -377,4 +377,50 @@ export async function createNitIssue(
   return issue.number;
 }
 
+/**
+ * React to an issue comment with an emoji. Failures are silently ignored
+ * since reactions are non-critical UX signals.
+ */
+export async function reactToIssueComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commentId: number,
+  content: '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket' | 'eyes',
+): Promise<void> {
+  try {
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content,
+    });
+  } catch {
+    // Non-critical — don't fail the workflow over a reaction
+  }
+}
+
+/**
+ * React to a pull request review comment with an emoji. Failures are silently
+ * ignored since reactions are non-critical UX signals.
+ */
+export async function reactToReviewComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commentId: number,
+  content: '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket' | 'eyes',
+): Promise<void> {
+  try {
+    await octokit.rest.reactions.createForPullRequestReviewComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content,
+    });
+  } catch {
+    // Non-critical — don't fail the workflow over a reaction
+  }
+}
+
 export { formatFindingComment, mapVerdictToEvent, BOT_MARKER };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   dismissPreviousReviews,
   postReview,
   createNitIssue,
+  reactToIssueComment,
 } from './github';
 import { checkAndAutoApprove } from './state';
 
@@ -112,6 +113,11 @@ async function handleCommentTrigger(): Promise<void> {
   const prNumber = payload.issue.number;
 
   const octokit = await getOctokit();
+
+  // Acknowledge the review request
+  if (payload.comment?.id) {
+    await reactToIssueComment(octokit, owner, repo, payload.comment.id, 'eyes');
+  }
 
   const { data: pr } = await octokit.rest.pulls.get({
     owner,

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github';
 
 import { ClaudeClient } from './claude';
 import { writeSuppression, writeLearning, sanitizeMemoryField } from './memory';
+import { reactToIssueComment, reactToReviewComment } from './github';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -57,6 +58,9 @@ export async function handleReviewCommentReply(
       core.info('Parent comment is not from claude-review');
       return;
     }
+
+    // Acknowledge the reply
+    await reactToReviewComment(octokit, owner, repo, comment.id, 'eyes');
 
     const context = buildReplyContext(
       parentComment.body,
@@ -144,18 +148,23 @@ export async function handlePRComment(
   if (!prNumber) return;
 
   const command = parseCommand(body);
+  const commentId = comment.id as number;
 
   switch (command.type) {
     case 'explain':
+      await reactToIssueComment(octokit, owner, repo, commentId, 'eyes');
       await handleExplain(octokit, client, owner, repo, prNumber, command.args);
       break;
     case 'dismiss':
       await handleDismiss(octokit, owner, repo, prNumber, command.args, memoryConfig, memoryToken);
+      await reactToIssueComment(octokit, owner, repo, commentId, '+1');
       break;
     case 'help':
+      await reactToIssueComment(octokit, owner, repo, commentId, '+1');
       await handleHelp(octokit, owner, repo, prNumber);
       break;
     default:
+      await reactToIssueComment(octokit, owner, repo, commentId, 'eyes');
       await handleGenericQuestion(octokit, client, owner, repo, prNumber, body);
   }
 }


### PR DESCRIPTION
## Summary

- `@claude review` → 👀 reaction on the comment
- `@claude explain` → 👀, `@claude dismiss` → 👍, `@claude help` → 👍
- Review comment replies → 👀 to acknowledge
- Reactions are non-critical — silently swallowed on failure

Closes #55