### PR TITLE
fix: rename `need-human` to `needs-human` and improve AI prompt format

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -45,23 +45,27 @@ describe('formatFindingComment', () => {
     expect(comment).not.toContain('```suggestion');
   });
 
-  it('includes AI agent prompt in a collapsible details section', () => {
+  it('includes AI agent prompt in a collapsible details section with labeled fields', () => {
     const comment = formatFindingComment(baseFinding);
     expect(comment).toContain('<details>\n<summary>🤖 Prompt for AI Agents</summary>');
-    expect(comment).toContain(`In \`${baseFinding.file}\` around line ${baseFinding.line}`);
-    expect(comment).toContain(baseFinding.description);
+    expect(comment).toContain(`**File:** \`${baseFinding.file}\``);
+    expect(comment).toContain(`**Line:** ${baseFinding.line}`);
+    expect(comment).toContain(`**Finding:** ${baseFinding.title}`);
+    expect(comment).toContain(`**Severity:** ${baseFinding.severity}`);
+    expect(comment).toContain(`**Description:**\n${baseFinding.description}`);
+    expect(comment).toContain('> **Important:** Before applying this fix, validate the finding');
     expect(comment).not.toContain('<details open');
   });
 
-  it('includes suggested change in AI agent prompt when suggestedFix is present', () => {
+  it('includes suggested fix in AI agent prompt when suggestedFix is present', () => {
     const finding: Finding = { ...baseFinding, suggestedFix: 'if (value != null) { use(value); }' };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('Suggested change:\nif (value != null) { use(value); }');
+    expect(comment).toContain('**Suggested fix:**\n```\nif (value != null) { use(value); }\n```');
   });
 
-  it('omits suggested change from AI agent prompt when no suggestedFix', () => {
+  it('omits suggested fix from AI agent prompt when no suggestedFix', () => {
     const comment = formatFindingComment(baseFinding);
-    expect(comment).not.toContain('Suggested change:');
+    expect(comment).not.toContain('**Suggested fix:**\n```');
   });
 
   it('includes reviewer attribution', () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -294,11 +294,19 @@ function formatFindingComment(finding: Finding): string {
     comment += `\n\n<details>\n<summary>Suggested fix</summary>\n\n\`\`\`suggestion\n${finding.suggestedFix}\n\`\`\`\n</details>`;
   }
 
-  comment += `\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n\`\`\`\nIn \`${finding.file}\` around line ${finding.line}: ${finding.description}\n`;
+  comment += '\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n';
+  comment += `**File:** \`${finding.file}\`\n`;
+  comment += `**Line:** ${finding.line}\n`;
+  comment += `**Finding:** ${finding.title}\n`;
+  comment += `**Severity:** ${finding.severity}\n\n`;
+  comment += `**Description:**\n${finding.description}\n`;
+
   if (finding.suggestedFix) {
-    comment += `\nSuggested change:\n${finding.suggestedFix}\n`;
+    comment += `\n**Suggested fix:**\n\`\`\`\n${finding.suggestedFix}\n\`\`\`\n`;
   }
-  comment += `\`\`\`\n</details>`;
+
+  comment += '\n> **Important:** Before applying this fix, validate the finding in the broader context of the file and surrounding code. The review agent may have missed context that makes this a false positive.\n';
+  comment += '\n</details>';
 
   if (finding.reviewers.length > 0) {
     comment += `\n\n<sub>Flagged by: ${finding.reviewers.join(', ')}</sub>`;
@@ -330,7 +338,7 @@ export function buildNitIssueBody(
 
 The following non-blocking findings were identified during automated review. Please triage:
 - **Close this issue** if the findings aren't worth addressing
-- **Remove the \`need-human\` label** to signal the coordinator to implement fixes
+- **Remove the \`needs-human\` label** to signal the coordinator to implement fixes
 
 ${checklist}
 
@@ -352,7 +360,7 @@ export async function createNitIssue(
   const nits = findings.filter(f => f.severity === 'suggestion' || f.severity === 'question');
   if (nits.length === 0) return null;
 
-  const searchQuery = `repo:${owner}/${repo} is:issue "Review nits from PR #${prNumber}" label:need-human`;
+  const searchQuery = `repo:${owner}/${repo} is:issue "Review nits from PR #${prNumber}" label:needs-human`;
   const { data: existing } = await octokit.rest.search.issuesAndPullRequests({ q: searchQuery });
   if (existing.total_count > 0) {
     core.info(`Nit issue already exists for PR #${prNumber}: #${existing.items[0].number}`);
@@ -360,11 +368,11 @@ export async function createNitIssue(
   }
 
   try {
-    await octokit.rest.issues.getLabel({ owner, repo, name: 'need-human' });
+    await octokit.rest.issues.getLabel({ owner, repo, name: 'needs-human' });
   } catch {
     await octokit.rest.issues.createLabel({
       owner, repo,
-      name: 'need-human',
+      name: 'needs-human',
       description: 'Needs human triage before AI picks it up',
       color: 'FBCA04',
     });
@@ -376,7 +384,7 @@ export async function createNitIssue(
     owner, repo,
     title: `Review nits from PR #${prNumber}`,
     body,
-    labels: ['need-human'],
+    labels: ['needs-human'],
   });
 
   core.info(`Created nit issue #${issue.number} for PR #${prNumber} with ${nits.length} findings`);


### PR DESCRIPTION
## Summary

- Renames `need-human` label to `needs-human` everywhere (code, tests, docs)
- AI agent prompt in review comments is now multi-line with labeled fields (File, Line, Finding, Severity, Description)
- Adds validation instruction: "validate the finding in broader context before applying"

Closes #82, closes #86