### PR TITLE
fix: freeze v1 tag at pre-rebrand, only update v2 on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,9 @@ jobs:
           # Commit if there are changes
           git diff --staged --quiet || git commit -m "build: compile dist/ for ${TAG}"
 
-          # Force-update major version tags
-          for VTAG in v1 v2; do
-            git tag -fa "$VTAG" -m "Update $VTAG tag to $TAG"
-            git push origin "$VTAG" --force
-          done
+          # Force-update major version tag
+          git tag -fa "v2" -m "Update v2 tag to $TAG"
+          git push origin "v2" --force
 
       - name: Create GitHub Release
         run: |


### PR DESCRIPTION
## Summary

- Release workflow only updates `v2` tag now (removed `v1` from the loop)
- `v1` tag manually pointed to `v1.2.0` (last pre-rebrand release)
- Anyone on `@v1` stays on the old claude-review code, `@v2` gets Manki