### PR TITLE
fix: COMMENT fallback drops inline comments to prevent cascading failure

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -261,14 +261,20 @@ export async function postReview(
       : 'The token may lack permission to request changes.';
     core.warning(`Failed to post ${event} review. ${hint} Falling back to COMMENT.`);
 
+    const findingSummary = validComments.map(c => {
+      const firstLine = c.body.split('\n')[0];
+      return `- ${firstLine} (\`${c.path}:${c.line}\`)`;
+    }).join('\n');
+    const fallbackBody = `${body}\n\n**Findings (could not post inline):**\n${findingSummary}`;
+
     const { data: review } = await octokit.rest.pulls.createReview({
       owner,
       repo,
       pull_number: prNumber,
       commit_id: commitSha,
       event: 'COMMENT',
-      body,
-      comments: validComments,
+      body: fallbackBody,
+      comments: [],
     });
 
     core.info(`Posted fallback COMMENT review #${review.id} (original verdict: ${result.verdict})`);


### PR DESCRIPTION
## Summary

- The COMMENT fallback when REQUEST_CHANGES/APPROVE fails was passing the SAME inline comments that caused the original failure
- Now the fallback uses `comments: []` and summarizes findings in the review body instead
- Fixes the "Server Error" cascading failure on both manki and fridi repos

Closes #103