### PR TITLE
feat: judge agent core with prompt, parser, and context curation

### DIFF
--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1,0 +1,448 @@
+import {
+  buildJudgeSystemPrompt,
+  buildJudgeUserMessage,
+  extractCodeContext,
+  parseJudgeResponse,
+  filterMemoryForFindings,
+  runJudgeAgent,
+  JudgedFinding,
+  JudgeInput,
+} from './judge';
+import { RepoMemory, Learning, Suppression } from './memory';
+import { Finding, ReviewConfig, ParsedDiff, DiffFile, DiffHunk } from './types';
+
+const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
+  model: 'claude-opus-4-6',
+  auto_review: true,
+  auto_approve: true,
+  review_language: 'en',
+  include_paths: ['**/*'],
+  exclude_paths: [],
+  max_diff_lines: 10000,
+  reviewers: [],
+  review_level: 'auto',
+  review_thresholds: { small: 200, medium: 1000 },
+  instructions: '',
+  memory: { enabled: false, repo: '' },
+  ...overrides,
+});
+
+const makeFinding = (overrides: Partial<Finding> = {}): Finding => ({
+  severity: 'suggestion',
+  title: 'Unused variable',
+  file: 'src/index.ts',
+  line: 10,
+  description: 'Variable x is unused.',
+  reviewers: ['TestReviewer'],
+  ...overrides,
+});
+
+const makeHunk = (overrides: Partial<DiffHunk> = {}): DiffHunk => ({
+  oldStart: 1,
+  oldLines: 20,
+  newStart: 1,
+  newLines: 20,
+  content: Array.from({ length: 20 }, (_, i) => `+line ${i + 1}`).join('\n'),
+  ...overrides,
+});
+
+const makeDiffFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  path: 'src/index.ts',
+  changeType: 'modified',
+  hunks: [makeHunk()],
+  ...overrides,
+});
+
+const makeDiff = (files: DiffFile[] = [makeDiffFile()]): ParsedDiff => ({
+  files,
+  totalAdditions: 20,
+  totalDeletions: 0,
+});
+
+const makeLearning = (overrides: Partial<Learning> = {}): Learning => ({
+  id: 'l1',
+  content: 'Always check for null before accessing properties',
+  scope: 'repo',
+  source: 'repo#1',
+  created_at: '2025-01-01',
+  ...overrides,
+});
+
+const makeSuppression = (overrides: Partial<Suppression> = {}): Suppression => ({
+  id: 'sup-1',
+  pattern: 'unused variable',
+  reason: 'Intentional for future use',
+  created_by: 'dev',
+  created_at: '2025-01-01',
+  pr_ref: 'owner/repo#1',
+  ...overrides,
+});
+
+const makeMemory = (overrides: Partial<RepoMemory> = {}): RepoMemory => ({
+  learnings: [makeLearning()],
+  suppressions: [makeSuppression()],
+  patterns: [],
+  ...overrides,
+});
+
+describe('buildJudgeSystemPrompt', () => {
+  it('contains severity definitions', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('required');
+    expect(prompt).toContain('suggestion');
+    expect(prompt).toContain('nit');
+    expect(prompt).toContain('ignore');
+  });
+
+  it('contains evaluation criteria', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('Accuracy');
+    expect(prompt).toContain('Actionability');
+    expect(prompt).toContain('Severity');
+  });
+
+  it('includes project instructions when present', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig({ instructions: 'Use strict TypeScript.' }));
+    expect(prompt).toContain('Use strict TypeScript.');
+    expect(prompt).toContain('Project Instructions');
+  });
+
+  it('omits project instructions section when empty', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig({ instructions: '' }));
+    expect(prompt).not.toContain('Project Instructions');
+  });
+
+  it('defines the judge role', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('code review judge');
+  });
+});
+
+describe('buildJudgeUserMessage', () => {
+  it('includes finding details', () => {
+    const findings = [makeFinding({ title: 'Null pointer', file: 'src/app.ts', line: 42 })];
+    const msg = buildJudgeUserMessage(findings, new Map(), '');
+
+    expect(msg).toContain('Finding 1: Null pointer');
+    expect(msg).toContain('src/app.ts:42');
+    expect(msg).toContain('TestReviewer');
+  });
+
+  it('includes code context when available', () => {
+    const findings = [makeFinding()];
+    const ctx = new Map([['src/index.ts:10:Unused variable', '>>> 10: +line 10']]);
+    const msg = buildJudgeUserMessage(findings, ctx, '');
+
+    expect(msg).toContain('>>> 10: +line 10');
+    expect(msg).toContain('Code context');
+  });
+
+  it('includes memory context when provided', () => {
+    const findings = [makeFinding()];
+    const msg = buildJudgeUserMessage(findings, new Map(), 'Some memory context');
+
+    expect(msg).toContain('Project Memory');
+    expect(msg).toContain('Some memory context');
+  });
+
+  it('omits memory section when empty', () => {
+    const findings = [makeFinding()];
+    const msg = buildJudgeUserMessage(findings, new Map(), '');
+
+    expect(msg).not.toContain('Project Memory');
+  });
+
+  it('includes suggested fix when present', () => {
+    const findings = [makeFinding({ suggestedFix: 'Remove the variable.' })];
+    const msg = buildJudgeUserMessage(findings, new Map(), '');
+
+    expect(msg).toContain('Remove the variable.');
+    expect(msg).toContain('Suggested fix');
+  });
+
+  it('handles multiple findings', () => {
+    const findings = [
+      makeFinding({ title: 'Finding A' }),
+      makeFinding({ title: 'Finding B' }),
+    ];
+    const msg = buildJudgeUserMessage(findings, new Map(), '');
+
+    expect(msg).toContain('Finding 1: Finding A');
+    expect(msg).toContain('Finding 2: Finding B');
+    expect(msg).toContain('2 total');
+  });
+});
+
+describe('extractCodeContext', () => {
+  it('extracts context around the finding line', () => {
+    const finding = makeFinding({ file: 'src/index.ts', line: 10 });
+    const diff = makeDiff();
+
+    const ctx = extractCodeContext(finding, diff);
+    expect(ctx).toContain('>>> 10:');
+    expect(ctx).toContain('+line 10');
+  });
+
+  it('returns empty string when file not in diff', () => {
+    const finding = makeFinding({ file: 'src/other.ts', line: 5 });
+    const diff = makeDiff();
+
+    expect(extractCodeContext(finding, diff)).toBe('');
+  });
+
+  it('returns empty string when line not in any hunk', () => {
+    const finding = makeFinding({ file: 'src/index.ts', line: 100 });
+    const diff = makeDiff();
+
+    expect(extractCodeContext(finding, diff)).toBe('');
+  });
+
+  it('returns empty string for finding with no file', () => {
+    const finding = makeFinding({ file: '', line: 10 });
+    const diff = makeDiff();
+
+    expect(extractCodeContext(finding, diff)).toBe('');
+  });
+
+  it('returns empty string for finding with no line', () => {
+    const finding = makeFinding({ file: 'src/index.ts', line: 0 });
+    const diff = makeDiff();
+
+    expect(extractCodeContext(finding, diff)).toBe('');
+  });
+
+  it('clips context at hunk boundaries', () => {
+    const finding = makeFinding({ file: 'src/index.ts', line: 2 });
+    const diff = makeDiff();
+
+    const ctx = extractCodeContext(finding, diff);
+    expect(ctx).toContain('+line 1');
+    expect(ctx).toContain('>>> 2:');
+  });
+});
+
+describe('parseJudgeResponse', () => {
+  it('parses valid JSON array with all fields', () => {
+    const json = JSON.stringify([
+      { title: 'Bug found', severity: 'required', reasoning: 'This is a real bug.', confidence: 'high' },
+    ]);
+
+    const result = parseJudgeResponse(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Bug found');
+    expect(result[0].severity).toBe('required');
+    expect(result[0].reasoning).toBe('This is a real bug.');
+    expect(result[0].confidence).toBe('high');
+  });
+
+  it('parses JSON wrapped in markdown code fences', () => {
+    const json = '```json\n[{"title":"Bug","severity":"required","reasoning":"Real bug.","confidence":"high"}]\n```';
+
+    const result = parseJudgeResponse(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Bug');
+  });
+
+  it('defaults missing confidence to medium', () => {
+    const json = JSON.stringify([
+      { title: 'Test', severity: 'suggestion', reasoning: 'Okay.' },
+    ]);
+
+    const result = parseJudgeResponse(json);
+    expect(result[0].confidence).toBe('medium');
+  });
+
+  it('defaults invalid severity to suggestion', () => {
+    const json = JSON.stringify([
+      { title: 'Test', severity: 'critical', reasoning: 'Something.', confidence: 'high' },
+    ]);
+
+    const result = parseJudgeResponse(json);
+    expect(result[0].severity).toBe('suggestion');
+  });
+
+  it('returns empty array for empty response', () => {
+    const result = parseJudgeResponse('');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for malformed JSON', () => {
+    const result = parseJudgeResponse('not json {broken');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for non-array JSON', () => {
+    const result = parseJudgeResponse('{"not": "an array"}');
+    expect(result).toEqual([]);
+  });
+
+  it('handles missing title and reasoning gracefully', () => {
+    const json = JSON.stringify([{ severity: 'nit' }]);
+
+    const result = parseJudgeResponse(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Untitled');
+    expect(result[0].reasoning).toBe('');
+  });
+
+  it('parses multiple findings', () => {
+    const json = JSON.stringify([
+      { title: 'A', severity: 'required', reasoning: 'Bug.', confidence: 'high' },
+      { title: 'B', severity: 'ignore', reasoning: 'False positive.', confidence: 'low' },
+    ]);
+
+    const result = parseJudgeResponse(json);
+    expect(result).toHaveLength(2);
+    expect(result[0].severity).toBe('required');
+    expect(result[1].severity).toBe('ignore');
+  });
+});
+
+describe('filterMemoryForFindings', () => {
+  it('returns matching learnings by keyword', () => {
+    const findings = [makeFinding({ title: 'Null check missing', description: 'Missing null check on property access.' })];
+    const memory = makeMemory({
+      learnings: [makeLearning({ content: 'Always check for null before accessing properties' })],
+      suppressions: [],
+    });
+
+    const result = filterMemoryForFindings(findings, memory);
+    expect(result).toContain('null');
+    expect(result).toContain('Relevant Learnings');
+  });
+
+  it('returns matching suppressions', () => {
+    const findings = [makeFinding({ title: 'Unused variable detected' })];
+    const memory = makeMemory({
+      learnings: [],
+      suppressions: [makeSuppression({ pattern: 'unused variable' })],
+    });
+
+    const result = filterMemoryForFindings(findings, memory);
+    expect(result).toContain('unused variable');
+    expect(result).toContain('Relevant Suppressions');
+  });
+
+  it('returns empty string when nothing matches', () => {
+    const findings = [makeFinding({ title: 'Security vulnerability', description: 'SQL injection.' })];
+    const memory = makeMemory({
+      learnings: [makeLearning({ content: 'Use consistent naming conventions' })],
+      suppressions: [makeSuppression({ pattern: 'unused variable' })],
+    });
+
+    const result = filterMemoryForFindings(findings, memory);
+    expect(result).toBe('');
+  });
+
+  it('returns empty string for empty memory', () => {
+    const findings = [makeFinding()];
+    const memory = makeMemory({ learnings: [], suppressions: [] });
+
+    expect(filterMemoryForFindings(findings, memory)).toBe('');
+  });
+});
+
+describe('runJudgeAgent', () => {
+  const mockClient = {
+    sendMessage: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockClient.sendMessage.mockReset();
+  });
+
+  it('returns empty array for empty findings', async () => {
+    const input: JudgeInput = {
+      findings: [],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+    };
+
+    const result = await runJudgeAgent(mockClient as any, makeConfig(), input);
+    expect(result).toEqual([]);
+    expect(mockClient.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('calls client and returns updated findings', async () => {
+    const judgedResponse = JSON.stringify([
+      { title: 'Unused variable', severity: 'ignore', reasoning: 'False positive.', confidence: 'high' },
+    ]);
+    mockClient.sendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding()],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+    };
+
+    const result = await runJudgeAgent(mockClient as any, makeConfig(), input);
+    expect(result).toHaveLength(1);
+    expect(result[0].severity).toBe('ignore');
+    expect(result[0].judgeNotes).toBe('False positive.');
+    expect(result[0].judgeConfidence).toBe('high');
+    expect(mockClient.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns originals when judge response is empty', async () => {
+    mockClient.sendMessage.mockResolvedValue({ content: '' });
+
+    const finding = makeFinding({ severity: 'required' });
+    const input: JudgeInput = {
+      findings: [finding],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+    };
+
+    const result = await runJudgeAgent(mockClient as any, makeConfig(), input);
+    expect(result).toHaveLength(1);
+    expect(result[0].severity).toBe('required');
+    expect(result[0].judgeNotes).toBeUndefined();
+  });
+
+  it('matches judge findings by fuzzy title when order differs', async () => {
+    const judgedResponse = JSON.stringify([
+      { title: 'Different title', severity: 'nit', reasoning: 'Minor.', confidence: 'low' },
+      { title: 'Unused variable cleanup', severity: 'ignore', reasoning: 'Not real.', confidence: 'high' },
+    ]);
+    mockClient.sendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [
+        makeFinding({ title: 'Unused variable' }),
+        makeFinding({ title: 'Something completely different', file: 'b.ts', line: 5 }),
+      ],
+      diff: makeDiff([
+        makeDiffFile({ path: 'src/index.ts' }),
+        makeDiffFile({ path: 'b.ts' }),
+      ]),
+      rawDiff: '',
+      repoContext: '',
+    };
+
+    const result = await runJudgeAgent(mockClient as any, makeConfig(), input);
+    expect(result).toHaveLength(2);
+  });
+
+  it('includes memory context when memory is provided', async () => {
+    const judgedResponse = JSON.stringify([
+      { title: 'Unused variable', severity: 'ignore', reasoning: 'Suppressed.', confidence: 'high' },
+    ]);
+    mockClient.sendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding()],
+      diff: makeDiff(),
+      rawDiff: '',
+      memory: makeMemory(),
+      repoContext: '',
+    };
+
+    await runJudgeAgent(mockClient as any, makeConfig(), input);
+
+    const [, userMessage] = mockClient.sendMessage.mock.calls[0];
+    expect(userMessage).toContain('Relevant Suppressions');
+  });
+});

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -1,0 +1,336 @@
+import * as core from '@actions/core';
+
+import { ClaudeClient } from './claude';
+import { extractJSON } from './json';
+import {
+  filterLearningsForFinding,
+  filterSuppressionsForFinding,
+  sanitizeMemoryField,
+  Learning,
+  Suppression,
+  RepoMemory,
+} from './memory';
+import { validateSeverity } from './review';
+import { DiffFile, Finding, FindingSeverity, ReviewConfig, ParsedDiff } from './types';
+
+export interface JudgeInput {
+  findings: Finding[];
+  diff: ParsedDiff;
+  rawDiff: string;
+  memory?: RepoMemory;
+  repoContext: string;
+}
+
+export interface JudgeOutput {
+  findings: JudgedFinding[];
+}
+
+export interface JudgedFinding {
+  title: string;
+  severity: FindingSeverity;
+  reasoning: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+const CONTEXT_LINES = 10;
+
+export function buildJudgeSystemPrompt(config: ReviewConfig): string {
+  let prompt = `You are a code review judge. You evaluate findings from multiple specialist reviewers for accuracy, actionability, and severity.
+
+## Severity Scale
+
+- **required**: Bugs, security vulnerabilities, data corruption, crashes, incorrect behavior. These MUST be fixed before merge. Be conservative — only real bugs and security issues qualify.
+- **suggestion**: Code clarity, readability, minor optimizations, design improvements. Worth doing but not blocking.
+- **nit**: Typos, naming nitpicks, minor style issues. Entirely optional.
+- **ignore**: False positives, intentional patterns, reviewer misunderstandings. Will be dropped.
+
+## Evaluation Criteria
+
+For each finding, evaluate:
+
+1. **Accuracy**: Is the finding technically correct given the code context?
+2. **Actionability**: Can the developer fix this? Is the fix clear?
+3. **Severity**: Based on actual impact, not the reviewer's original assessment.
+
+## Guidelines
+
+- Be conservative with \`required\` — only real bugs and security issues.
+- Be liberal with \`ignore\` — actively filter noise and false positives.
+- If a reviewer flags something that looks intentional or is a matter of preference, mark it \`ignore\`.
+- If a finding is correct but overstated in severity, downgrade it.
+
+## Output Format
+
+Respond with ONLY a JSON array (no markdown fences, no explanation). Each element:
+
+\`\`\`
+[
+  {
+    "title": "Short title matching or close to the original finding title",
+    "severity": "required" | "suggestion" | "nit" | "ignore",
+    "reasoning": "1-2 sentences explaining your judgment",
+    "confidence": "high" | "medium" | "low"
+  }
+]
+\`\`\`
+
+Return one element per finding, in the same order as presented.`;
+
+  if (config.instructions) {
+    prompt += `\n\n## Project Instructions\n\n${config.instructions}`;
+  }
+
+  return prompt;
+}
+
+export function buildJudgeUserMessage(
+  findings: Finding[],
+  codeContextMap: Map<string, string>,
+  memoryContext: string,
+): string {
+  const parts: string[] = [];
+
+  parts.push(`## Findings to Evaluate (${findings.length} total)\n`);
+
+  for (let i = 0; i < findings.length; i++) {
+    const f = findings[i];
+    const ctx = codeContextMap.get(findingKey(f)) || '';
+
+    parts.push(`### Finding ${i + 1}: ${f.title}`);
+    parts.push(`- **Original severity**: ${f.severity}`);
+    parts.push(`- **File**: ${f.file}:${f.line}`);
+    parts.push(`- **Reviewers**: ${f.reviewers.join(', ')}`);
+    parts.push(`- **Description**: ${f.description}`);
+
+    if (f.suggestedFix) {
+      parts.push(`- **Suggested fix**: ${f.suggestedFix}`);
+    }
+
+    if (ctx) {
+      parts.push(`\n**Code context**:\n\`\`\`\n${ctx}\n\`\`\``);
+    }
+
+    parts.push('');
+  }
+
+  if (memoryContext) {
+    parts.push(`## Project Memory\n\n${memoryContext}`);
+  }
+
+  return parts.join('\n');
+}
+
+export function extractCodeContext(finding: Finding, diff: ParsedDiff): string {
+  if (!finding.file || !finding.line) return '';
+
+  const diffFile = diff.files.find(f => f.path === finding.file);
+  if (!diffFile) return '';
+
+  return extractHunkContext(diffFile, finding.line);
+}
+
+function extractHunkContext(diffFile: DiffFile, line: number): string {
+  const hunk = diffFile.hunks.find(h =>
+    line >= h.newStart && line <= h.newStart + h.newLines - 1,
+  );
+  if (!hunk) return '';
+
+  const lines = hunk.content.split('\n');
+  const offset = line - hunk.newStart;
+  const start = Math.max(0, offset - CONTEXT_LINES);
+  const end = Math.min(lines.length, offset + CONTEXT_LINES + 1);
+
+  const contextLines: string[] = [];
+  for (let i = start; i < end; i++) {
+    const lineNum = hunk.newStart + i;
+    const marker = i === offset ? '>>>' : '   ';
+    contextLines.push(`${marker} ${lineNum}: ${lines[i]}`);
+  }
+
+  return contextLines.join('\n');
+}
+
+export function filterMemoryForFindings(
+  findings: Finding[],
+  memory: RepoMemory,
+): string {
+  const relevantLearnings = filterLearningsForFindings(memory.learnings, findings);
+  const relevantSuppressions = filterSuppressionsForFindings(memory.suppressions, findings);
+
+  if (relevantLearnings.length === 0 && relevantSuppressions.length === 0) {
+    return '';
+  }
+
+  const parts: string[] = [];
+
+  if (relevantLearnings.length > 0) {
+    parts.push('### Relevant Learnings\n');
+    for (const l of relevantLearnings) {
+      parts.push(`- ${sanitizeMemoryField(l.content)}`);
+    }
+  }
+
+  if (relevantSuppressions.length > 0) {
+    parts.push('\n### Relevant Suppressions\n');
+    for (const s of relevantSuppressions) {
+      const scope = s.file_glob ? ` (files: ${s.file_glob})` : '';
+      parts.push(`- "${sanitizeMemoryField(s.pattern)}"${scope}: ${sanitizeMemoryField(s.reason)}`);
+    }
+  }
+
+  return parts.join('\n');
+}
+
+function filterLearningsForFindings(learnings: Learning[], findings: Finding[]): Learning[] {
+  const seen = new Set<string>();
+  const result: Learning[] = [];
+  for (const f of findings) {
+    for (const l of filterLearningsForFinding(learnings, f)) {
+      if (!seen.has(l.id)) {
+        seen.add(l.id);
+        result.push(l);
+      }
+    }
+  }
+  return result;
+}
+
+function filterSuppressionsForFindings(suppressions: Suppression[], findings: Finding[]): Suppression[] {
+  const seen = new Set<string>();
+  const result: Suppression[] = [];
+  for (const f of findings) {
+    for (const s of filterSuppressionsForFinding(suppressions, f)) {
+      if (!seen.has(s.id)) {
+        seen.add(s.id);
+        result.push(s);
+      }
+    }
+  }
+  return result;
+}
+
+export function parseJudgeResponse(responseText: string): JudgedFinding[] {
+  const jsonText = extractJSON(responseText);
+
+  try {
+    const parsed = JSON.parse(jsonText);
+    if (!Array.isArray(parsed)) {
+      core.warning(`Judge did not return an array, got: ${typeof parsed}`);
+      return [];
+    }
+
+    return parsed.map((f: Record<string, unknown>) => ({
+      title: String(f.title || 'Untitled'),
+      severity: validateSeverity(f.severity),
+      reasoning: String(f.reasoning || ''),
+      confidence: validateConfidence(f.confidence),
+    }));
+  } catch (e) {
+    core.warning(`Failed to parse judge response: ${e}`);
+    return [];
+  }
+}
+
+function validateConfidence(value: unknown): 'high' | 'medium' | 'low' {
+  if (value === 'high' || value === 'medium' || value === 'low') {
+    return value;
+  }
+  return 'medium';
+}
+
+export async function runJudgeAgent(
+  client: ClaudeClient,
+  config: ReviewConfig,
+  input: JudgeInput,
+): Promise<Finding[]> {
+  const { findings, diff, memory } = input;
+
+  if (findings.length === 0) return [];
+
+  const codeContextMap = new Map<string, string>();
+  for (const f of findings) {
+    const ctx = extractCodeContext(f, diff);
+    if (ctx) {
+      codeContextMap.set(findingKey(f), ctx);
+    }
+  }
+
+  const memoryContext = memory
+    ? filterMemoryForFindings(findings, memory)
+    : '';
+
+  const systemPrompt = buildJudgeSystemPrompt(config);
+  const userMessage = buildJudgeUserMessage(findings, codeContextMap, memoryContext);
+
+  const response = await client.sendMessage(systemPrompt, userMessage);
+  const judged = parseJudgeResponse(response.content);
+
+  if (judged.length === 0) {
+    core.warning('Judge returned no findings — returning originals unchanged');
+    return findings;
+  }
+
+  return mapJudgedToFindings(findings, judged);
+}
+
+function mapJudgedToFindings(original: Finding[], judged: JudgedFinding[]): Finding[] {
+  const result: Finding[] = [];
+
+  for (let i = 0; i < original.length; i++) {
+    const finding = { ...original[i] };
+
+    // Match by position first (judge returns findings in same order)
+    let match: JudgedFinding | undefined;
+    if (i < judged.length) {
+      match = judged[i];
+    }
+
+    // Fall back to fuzzy title match if position doesn't seem right
+    if (match && !titlesRelated(finding.title, match.title)) {
+      const titleMatch = judged.find(j => titlesRelated(finding.title, j.title));
+      if (titleMatch) {
+        match = titleMatch;
+      }
+    }
+
+    if (match) {
+      finding.severity = match.severity;
+      finding.judgeNotes = match.reasoning;
+      finding.judgeConfidence = match.confidence;
+    }
+
+    result.push(finding);
+  }
+
+  return result;
+}
+
+function titlesRelated(a: string, b: string): boolean {
+  const aLower = a.toLowerCase();
+  const bLower = b.toLowerCase();
+
+  if (aLower === bLower) return true;
+
+  const shorter = aLower.length <= bLower.length ? aLower : bLower;
+  const longer = aLower.length > bLower.length ? aLower : bLower;
+
+  if (shorter.length >= 5 && longer.includes(shorter)) return true;
+
+  // Check word overlap
+  const aWords = new Set(aLower.split(/\s+/).filter(w => w.length >= 3));
+  const bWords = new Set(bLower.split(/\s+/).filter(w => w.length >= 3));
+  if (aWords.size === 0 || bWords.size === 0) return false;
+
+  let overlap = 0;
+  for (const w of aWords) {
+    if (bWords.has(w)) overlap++;
+  }
+
+  const minSize = Math.min(aWords.size, bWords.size);
+  return overlap >= minSize * 0.5;
+}
+
+function findingKey(f: Finding): string {
+  return `${f.file}:${f.line}:${f.title}`;
+}
+

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -1,4 +1,16 @@
-import { applySuppressions, applyEscalations, matchesSuppression, buildMemoryContext, sanitizeMemoryField, Suppression, Pattern, RepoMemory } from './memory';
+import {
+  applySuppressions,
+  applyEscalations,
+  matchesSuppression,
+  buildMemoryContext,
+  sanitizeMemoryField,
+  filterLearningsForFinding,
+  filterSuppressionsForFinding,
+  Suppression,
+  Pattern,
+  Learning,
+  RepoMemory,
+} from './memory';
 import { Finding } from './types';
 
 const makeFinding = (overrides: Partial<Finding> = {}): Finding => ({
@@ -277,6 +289,7 @@ describe('buildMemoryContext', () => {
   });
 });
 
+
 const makePattern = (overrides: Partial<Pattern> = {}): Pattern => ({
   id: 'pat-1',
   finding_title: 'unused variable',
@@ -347,5 +360,74 @@ describe('applyEscalations', () => {
     const result = applyEscalations(findings, patterns);
     expect(result).toHaveLength(1);
     expect(result[0].severity).toBe('suggestion');
+  });
+});
+
+const makeLearning = (overrides: Partial<Learning> = {}): Learning => ({
+  id: 'l1',
+  content: 'Always check for null before accessing properties',
+  scope: 'repo',
+  source: 'repo#1',
+  created_at: '2025-01-01',
+  ...overrides,
+});
+
+describe('filterLearningsForFinding', () => {
+  it('returns learnings with keyword overlap', () => {
+    const finding = makeFinding({ title: 'Missing null check', description: 'No null guard on property access.' });
+    const learnings = [makeLearning({ content: 'Always check for null before accessing properties' })];
+
+    const result = filterLearningsForFinding(learnings, finding);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty when no keywords match', () => {
+    const finding = makeFinding({ title: 'SQL injection', description: 'User input not sanitized.' });
+    const learnings = [makeLearning({ content: 'Use consistent naming conventions' })];
+
+    const result = filterLearningsForFinding(learnings, finding);
+    expect(result).toHaveLength(0);
+  });
+
+  it('ignores short words (fewer than 4 characters)', () => {
+    const finding = makeFinding({ title: 'A bad bug', description: 'It is bad.' });
+    const learnings = [makeLearning({ content: 'bad code is bad' })];
+
+    const result = filterLearningsForFinding(learnings, finding);
+    expect(result).toHaveLength(0);
+  });
+
+  it('matches case-insensitively', () => {
+    const finding = makeFinding({ title: 'VARIABLE unused', description: 'Remove unused variable.' });
+    const learnings = [makeLearning({ content: 'Unused variables should be cleaned up' })];
+
+    const result = filterLearningsForFinding(learnings, finding);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('filterSuppressionsForFinding', () => {
+  it('returns suppressions that match the finding', () => {
+    const finding = makeFinding({ title: 'Unused variable detected' });
+    const suppressions = [makeSuppression({ pattern: 'unused variable' })];
+
+    const result = filterSuppressionsForFinding(suppressions, finding);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty when no suppressions match', () => {
+    const finding = makeFinding({ title: 'Security vulnerability' });
+    const suppressions = [makeSuppression({ pattern: 'unused variable' })];
+
+    const result = filterSuppressionsForFinding(suppressions, finding);
+    expect(result).toHaveLength(0);
+  });
+
+  it('respects file glob', () => {
+    const finding = makeFinding({ title: 'Unused variable', file: 'lib/other.ts' });
+    const suppressions = [makeSuppression({ pattern: 'unused variable', file_glob: 'src/**' })];
+
+    const result = filterSuppressionsForFinding(suppressions, finding);
+    expect(result).toHaveLength(0);
   });
 });

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -218,6 +218,31 @@ export function buildMemoryContext(memory: RepoMemory): string {
 }
 
 /**
+ * Filter learnings to those relevant to a specific finding,
+ * matching by keyword overlap between the finding and learning content.
+ */
+export function filterLearningsForFinding(learnings: Learning[], finding: Finding): Learning[] {
+  const text = `${finding.title} ${finding.description}`.toLowerCase();
+  const keywords = text.split(/\s+/)
+    .map(w => w.replace(/[^a-z0-9]/g, ''))
+    .filter(w => w.length >= 4);
+
+  if (keywords.length === 0) return [];
+
+  return learnings.filter(l => {
+    const contentLower = l.content.toLowerCase();
+    return keywords.some(kw => contentLower.includes(kw));
+  });
+}
+
+/**
+ * Filter suppressions to those that match a specific finding.
+ */
+export function filterSuppressionsForFinding(suppressions: Suppression[], finding: Finding): Suppression[] {
+  return suppressions.filter(s => matchesSuppression(finding, s));
+}
+
+/**
  * Write a suppression to the memory repo.
  */
 export async function writeSuppression(


### PR DESCRIPTION
## Summary

- New `src/judge.ts` module: single judge agent that evaluates all reviewer findings in one batch API call
- Judge evaluates accuracy, actionability, and severity for each finding with per-finding curated code context
- Per-finding memory filtering: relevant learnings and suppressions matched per finding
- New memory helpers: `filterLearningsForFinding()` and `filterSuppressionsForFinding()`
- 42 new tests covering prompt building, response parsing, context extraction, memory filtering, and full pipeline

Closes #110