### PR TITLE
feat: wire judge into `runReview()`, delete deliberation/consolidation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ async function runFullReview(
 
     await dismissPreviousReviews(octokit, owner, repo, prNumber);
 
-    const result = await runReview(claude, config, diff, rawDiff, fullContext);
+    const result = await runReview(claude, config, diff, rawDiff, fullContext, memory);
 
     if (!result.reviewComplete && result.verdict === 'APPROVE') {
       result.verdict = 'COMMENT';
@@ -259,7 +259,7 @@ async function runFullReview(
       if (suppressed.length > 0) {
         core.info(`Suppressed ${suppressed.length} findings based on memory`);
         result.findings = kept;
-        result.verdict = determineVerdict(undefined, result.findings);
+        result.verdict = determineVerdict(result.findings);
       }
     }
 
@@ -267,12 +267,12 @@ async function runFullReview(
     if (duplicates.length > 0) {
       core.info(`Deduplicated ${duplicates.length} findings (already flagged in previous reviews)`);
       result.findings = unique;
-      result.verdict = determineVerdict(undefined, result.findings);
+      result.verdict = determineVerdict(result.findings);
     }
 
     if (memory && memory.patterns.length > 0) {
       result.findings = applyEscalations(result.findings, memory.patterns);
-      result.verdict = determineVerdict(undefined, result.findings);
+      result.verdict = determineVerdict(result.findings);
     }
 
     const resolved = recap.previousFindings.filter(f => f.status === 'resolved').length;

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1,18 +1,15 @@
 import {
   parseFindings,
   validateSeverity,
-  parseConsolidatedReview,
   determineVerdict,
   buildReviewerSystemPrompt,
   buildReviewerUserMessage,
-  mergeIndividualFindings,
   selectTeam,
-  tallyVotes,
   titlesMatch,
   truncateDiff,
   AGENT_POOL,
 } from './review';
-import { Finding, ReviewerAgent, ReviewConfig, ParsedDiff, AgentVote } from './types';
+import { Finding, ReviewerAgent, ReviewConfig, ParsedDiff } from './types';
 
 const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
   model: 'claude-opus-4-6',
@@ -155,120 +152,32 @@ describe('validateSeverity', () => {
   });
 });
 
-describe('parseConsolidatedReview', () => {
-  it('parses valid consolidated result', () => {
-    const json = JSON.stringify({
-      verdict: 'REQUEST_CHANGES',
-      summary: 'Found some issues.',
-      findings: [
-        {
-          severity: 'required',
-          title: 'Bug',
-          file: 'src/a.ts',
-          line: 5,
-          description: 'A bug.',
-          reviewers: ['Security', 'Testing'],
-        },
-        {
-          severity: 'suggestion',
-          title: 'Style',
-          file: 'src/b.ts',
-          line: 10,
-          description: 'Style issue.',
-          reviewers: ['Architecture'],
-        },
-      ],
-      highlights: ['Good test coverage'],
-    });
-
-    const result = parseConsolidatedReview(json);
-    expect(result.verdict).toBe('REQUEST_CHANGES');
-    expect(result.summary).toBe('Found some issues.');
-    expect(result.findings).toHaveLength(2);
-    expect(result.findings[0].reviewers).toEqual(['Security', 'Testing']);
-    expect(result.highlights).toEqual(['Good test coverage']);
-  });
-
-  it('parses markdown-wrapped JSON', () => {
-    const json = '```json\n{"verdict":"APPROVE","summary":"Looks good.","findings":[],"highlights":["Clean code"]}\n```';
-
-    const result = parseConsolidatedReview(json);
-    expect(result.verdict).toBe('APPROVE');
-    expect(result.findings).toEqual([]);
-  });
-
-  it('throws on invalid JSON so caller can fall back to merged findings', () => {
-    expect(() => parseConsolidatedReview('not json at all')).toThrow(
-      /Failed to parse consolidated review/,
-    );
-  });
-
-  it('sets reviewComplete true on successful parse', () => {
-    const json = JSON.stringify({
-      verdict: 'APPROVE',
-      summary: 'Looks good.',
-      findings: [],
-      highlights: [],
-    });
-    const result = parseConsolidatedReview(json);
-    expect(result.verdict).toBe('APPROVE');
-    expect(result.reviewComplete).toBe(true);
-  });
-
-  it('overrides claimed verdict based on actual findings', () => {
-    const json = JSON.stringify({
-      verdict: 'APPROVE',
-      summary: 'Looks good.',
-      findings: [
-        {
-          severity: 'required',
-          title: 'Bug',
-          file: 'a.ts',
-          line: 1,
-          description: 'A bug.',
-          reviewers: ['Test'],
-        },
-      ],
-      highlights: [],
-    });
-
-    const result = parseConsolidatedReview(json);
-    expect(result.verdict).toBe('REQUEST_CHANGES');
-  });
-});
-
 describe('determineVerdict', () => {
   it('returns REQUEST_CHANGES when any finding is required', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'A', file: '', line: 0, description: '', reviewers: [] },
-      { severity: 'required', title: 'B', file: '', line: 0, description: '', reviewers: [] },
+      makeFinding({ severity: 'suggestion' }),
+      makeFinding({ severity: 'required' }),
     ];
-    expect(determineVerdict('APPROVE', findings)).toBe('REQUEST_CHANGES');
+    expect(determineVerdict(findings)).toBe('REQUEST_CHANGES');
   });
 
   it('returns APPROVE when there are only suggestions', () => {
-    const findings: Finding[] = [
-      { severity: 'suggestion', title: 'A', file: '', line: 0, description: '', reviewers: [] },
-    ];
-    expect(determineVerdict('APPROVE', findings)).toBe('APPROVE');
+    const findings: Finding[] = [makeFinding({ severity: 'suggestion' })];
+    expect(determineVerdict(findings)).toBe('APPROVE');
   });
 
   it('returns APPROVE when there are only nits', () => {
-    const findings: Finding[] = [
-      { severity: 'nit', title: 'A', file: '', line: 0, description: '', reviewers: [] },
-    ];
-    expect(determineVerdict('APPROVE', findings)).toBe('APPROVE');
+    const findings: Finding[] = [makeFinding({ severity: 'nit' })];
+    expect(determineVerdict(findings)).toBe('APPROVE');
   });
 
   it('returns APPROVE when there are only ignores', () => {
-    const findings: Finding[] = [
-      { severity: 'ignore', title: 'A', file: '', line: 0, description: '', reviewers: [] },
-    ];
-    expect(determineVerdict('APPROVE', findings)).toBe('APPROVE');
+    const findings: Finding[] = [makeFinding({ severity: 'ignore' })];
+    expect(determineVerdict(findings)).toBe('APPROVE');
   });
 
   it('returns APPROVE when there are no findings', () => {
-    expect(determineVerdict('REQUEST_CHANGES', [])).toBe('APPROVE');
+    expect(determineVerdict([])).toBe('APPROVE');
   });
 });
 
@@ -317,89 +226,6 @@ describe('buildReviewerUserMessage', () => {
   it('omits repo context when empty', () => {
     const message = buildReviewerUserMessage('diff content', '');
     expect(message).not.toContain('Repository Context');
-  });
-});
-
-describe('mergeIndividualFindings', () => {
-  it('collects findings from multiple reviewers', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'Security', findings: [makeFinding({ title: 'Bug A', file: 'a.ts', line: 1 })] },
-      { reviewer: 'Style', findings: [makeFinding({ title: 'Style B', file: 'b.ts', line: 5 })] },
-    ]);
-    expect(result.findings).toHaveLength(2);
-    expect(result.summary).toContain('2 findings from 2 reviewers');
-  });
-
-  it('de-duplicates findings on same file and nearby lines with similar titles', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'Security', findings: [makeFinding({ title: 'Null check missing', file: 'a.ts', line: 10, reviewers: ['Security'] })] },
-      { reviewer: 'Testing', findings: [makeFinding({ title: 'Null check missing', file: 'a.ts', line: 11, reviewers: ['Testing'] })] },
-    ]);
-    expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].reviewers).toContain('Security');
-    expect(result.findings[0].reviewers).toContain('Testing');
-  });
-
-  it('keeps findings on different files even with same title', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ title: 'Bug', file: 'a.ts', line: 10 })] },
-      { reviewer: 'B', findings: [makeFinding({ title: 'Bug', file: 'b.ts', line: 10 })] },
-    ]);
-    expect(result.findings).toHaveLength(2);
-  });
-
-  it('keeps findings on same file but distant lines', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ title: 'Bug', file: 'a.ts', line: 10 })] },
-      { reviewer: 'B', findings: [makeFinding({ title: 'Bug', file: 'a.ts', line: 100 })] },
-    ]);
-    expect(result.findings).toHaveLength(2);
-  });
-
-  it('returns REQUEST_CHANGES when any finding is required', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ severity: 'required' })] },
-    ]);
-    expect(result.verdict).toBe('REQUEST_CHANGES');
-  });
-
-  it('returns APPROVE when no required findings', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ severity: 'suggestion' })] },
-    ]);
-    expect(result.verdict).toBe('APPROVE');
-  });
-
-  it('sets reviewComplete to true', () => {
-    const result = mergeIndividualFindings([]);
-    expect(result.reviewComplete).toBe(true);
-  });
-
-  it('does not add duplicate reviewer names', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ title: 'Bug', file: 'a.ts', line: 10, reviewers: ['A'] })] },
-      { reviewer: 'A', findings: [makeFinding({ title: 'Bug', file: 'a.ts', line: 10, reviewers: ['A'] })] },
-    ]);
-    expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].reviewers).toEqual(['A']);
-  });
-
-  it('does not match short titles as substrings', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ title: 'Bug', file: 'a.ts', line: 10 })] },
-      { reviewer: 'B', findings: [makeFinding({ title: 'Bug in error handling logic', file: 'a.ts', line: 11 })] },
-    ]);
-    expect(result.findings).toHaveLength(2);
-  });
-
-  it('matches long titles that are substrings of each other', () => {
-    const result = mergeIndividualFindings([
-      { reviewer: 'A', findings: [makeFinding({ title: 'Null check missing in handler', file: 'a.ts', line: 10, reviewers: ['A'] })] },
-      { reviewer: 'B', findings: [makeFinding({ title: 'Null check missing in handler for edge case', file: 'a.ts', line: 11, reviewers: ['B'] })] },
-    ]);
-    expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].reviewers).toContain('A');
-    expect(result.findings[0].reviewers).toContain('B');
   });
 });
 
@@ -541,187 +367,6 @@ describe('AGENT_POOL', () => {
   });
 });
 
-describe('tallyVotes', () => {
-  const findingA = { ...makeFinding({ title: 'Bug A', severity: 'suggestion' }), index: 0, originalReviewer: 'Reviewer1' };
-  const findingB = { ...makeFinding({ title: 'Bug B', severity: 'suggestion' }), index: 1, originalReviewer: 'Reviewer2' };
-
-  it('keeps finding when majority agrees', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'C', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].title).toBe('Bug A');
-  });
-
-  it('drops finding when majority disagrees', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'disagree', reason: 'false positive' },
-      { agentName: 'B', findingIndex: 0, vote: 'disagree', reason: 'false positive' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(0);
-  });
-
-  it('escalates to blocking when all voters unanimously agree', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('required');
-  });
-
-  it('downgrades to suggestion on split vote', () => {
-    const finding = { ...makeFinding({ title: 'Mixed', severity: 'required' }), index: 0, originalReviewer: 'Reviewer1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-      { agentName: 'C', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-      { agentName: 'D', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      // 2 agree, 2 disagree out of 5 total team — neither reaches majority (3)
-    ];
-    const results = tallyVotes([finding], votes, 5);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('suggestion');
-  });
-
-  it('keeps finding as-is when no votes are cast', () => {
-    const results = tallyVotes([findingA], [], 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].title).toBe('Bug A');
-    expect(results[0].severity).toBe('suggestion');
-  });
-
-  it('strips internal properties from output findings', () => {
-    const results = tallyVotes([findingA], [], 3);
-    const result = results[0] as unknown as Record<string, unknown>;
-    expect(result).not.toHaveProperty('index');
-    expect(result).not.toHaveProperty('originalReviewer');
-  });
-
-  it('escalates suggestion to required when 2+ escalate votes with majority agree', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'escalate', reason: 'worse than reported' },
-      { agentName: 'B', findingIndex: 0, vote: 'escalate', reason: 'much worse' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('required');
-  });
-
-  it('does not escalate with only 1 escalate vote', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'escalate', reason: 'worse than reported' },
-      { agentName: 'C', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('suggestion');
-  });
-
-  it('does not escalate nit findings via escalate votes', () => {
-    const nitFinding = { ...makeFinding({ title: 'Unclear', severity: 'nit' as const }), index: 0, originalReviewer: 'R1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'escalate', reason: 'serious' },
-      { agentName: 'B', findingIndex: 0, vote: 'escalate', reason: 'serious' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([nitFinding], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('nit');
-  });
-
-  it('does not escalate already-required findings via escalate votes', () => {
-    const requiredFinding = { ...makeFinding({ title: 'Bug', severity: 'required' as const }), index: 0, originalReviewer: 'R1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'escalate', reason: 'serious' },
-      { agentName: 'B', findingIndex: 0, vote: 'escalate', reason: 'serious' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([requiredFinding], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('required');
-  });
-
-  it('collects agreeing voter names in reviewers array', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'Alpha', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'Beta', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'Gamma', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results[0].reviewers).toEqual(['Alpha', 'Beta']);
-  });
-
-  it('does not escalate nit findings to required on unanimous agree', () => {
-    const nitFinding = { ...makeFinding({ title: 'Unclear code', severity: 'nit' as const }), index: 0, originalReviewer: 'Reviewer1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([nitFinding], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('nit');
-  });
-
-  it('does not escalate required findings further on unanimous agree', () => {
-    const requiredFinding = { ...makeFinding({ title: 'Real bug', severity: 'required' as const }), index: 0, originalReviewer: 'Reviewer1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([requiredFinding], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].severity).toBe('required');
-  });
-
-  it('handles multiple findings independently', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'A', findingIndex: 1, vote: 'disagree', reason: 'nah' },
-      { agentName: 'B', findingIndex: 1, vote: 'disagree', reason: 'nah' },
-    ];
-    const results = tallyVotes([findingA, findingB], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].title).toBe('Bug A');
-  });
-
-  it('deduplicates votes from the same agent for the same finding', () => {
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'duplicate' },
-      { agentName: 'B', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-      { agentName: 'C', findingIndex: 0, vote: 'disagree', reason: 'nah' },
-    ];
-    // Without dedup, agree=2 >= majority(2), but with dedup agree=1 < majority(2)
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(0);
-  });
-
-  it('does not escalate suggestion to blocking when not all agents voted', () => {
-    // Team size 3 but only 2 agents voted (one failed)
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([findingA], votes, 3);
-    expect(results).toHaveLength(1);
-    // 2 agree out of team size 3 — majority but not unanimous
-    expect(results[0].severity).toBe('suggestion');
-  });
-});
-
 describe('titlesMatch', () => {
   it('matches exact equal titles', () => {
     expect(titlesMatch('Null check missing', 'Null check missing')).toBe(true);
@@ -834,32 +479,5 @@ describe('selectTeam dependency file scoring', () => {
     const config = makeConfig({ review_level: 'medium' });
     const roster = selectTeam(diff, config);
     expect(roster.agents.map(a => a.name)).toContain('Dependencies & Integration');
-  });
-});
-
-describe('tallyVotes out-of-bounds filtering', () => {
-  it('ignores votes with negative findingIndex', () => {
-    const finding = { ...makeFinding({ title: 'Bug' }), index: 0, originalReviewer: 'R1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: -1, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([finding], votes, 3);
-    expect(results).toHaveLength(1);
-    // Only 2 valid votes for finding 0
-    expect(results[0].reviewers).toEqual(['B', 'C']);
-  });
-
-  it('ignores votes with findingIndex beyond findings array', () => {
-    const finding = { ...makeFinding({ title: 'Bug' }), index: 0, originalReviewer: 'R1' };
-    const votes: AgentVote[] = [
-      { agentName: 'A', findingIndex: 99, vote: 'agree', reason: 'valid' },
-      { agentName: 'B', findingIndex: 0, vote: 'agree', reason: 'valid' },
-      { agentName: 'C', findingIndex: 0, vote: 'agree', reason: 'valid' },
-    ];
-    const results = tallyVotes([finding], votes, 3);
-    expect(results).toHaveLength(1);
-    expect(results[0].reviewers).toEqual(['B', 'C']);
   });
 });

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,7 +1,9 @@
 import * as core from '@actions/core';
 
 import { ClaudeClient } from './claude';
-import { ReviewConfig, ReviewerAgent, Finding, FindingSeverity, ReviewResult, ReviewVerdict, ParsedDiff, AgentVote, TeamRoster } from './types';
+import { runJudgeAgent, JudgeInput } from './judge';
+import { RepoMemory } from './memory';
+import { ReviewConfig, ReviewerAgent, Finding, ReviewResult, ReviewVerdict, ParsedDiff, TeamRoster } from './types';
 import { extractJSON } from './json';
 
 export const AGENT_POOL: readonly ReviewerAgent[] = Object.freeze([
@@ -123,6 +125,7 @@ export async function runReview(
   diff: ParsedDiff,
   rawDiff: string,
   repoContext: string,
+  memory?: RepoMemory | null,
 ): Promise<ReviewResult> {
   const team = selectTeam(diff, config, config.reviewers);
   core.info(`Review team (${team.level}): ${team.agents.map(a => a.name).join(', ')}`);
@@ -134,18 +137,18 @@ export async function runReview(
     )
   );
 
-  const allFindings: { reviewer: string; findings: Finding[] }[] = [];
+  const allFindings: Finding[] = [];
   for (let i = 0; i < agentResults.length; i++) {
     const result = agentResults[i];
     if (result.status === 'fulfilled') {
-      allFindings.push({ reviewer: team.agents[i].name, findings: result.value });
+      allFindings.push(...result.value);
       core.info(`${team.agents[i].name}: ${result.value.length} findings`);
     } else {
       core.warning(`${team.agents[i].name} failed: ${result.reason}`);
     }
   }
 
-  if (allFindings.length === 0) {
+  if (allFindings.length === 0 && agentResults.every(r => r.status === 'rejected')) {
     return {
       verdict: 'COMMENT',
       summary: 'Review could not be completed — all reviewer agents failed.',
@@ -156,20 +159,31 @@ export async function runReview(
   }
 
   let finalFindings: Finding[];
-  try {
-    core.info('Running deliberation round...');
-    finalFindings = await runDeliberation(client, config, team, allFindings, rawDiff);
-    core.info(`Deliberation complete: ${finalFindings.length} findings survived`);
-  } catch (error) {
-    core.warning(`Deliberation failed: ${error}. Falling back to merged findings.`);
-    finalFindings = mergeIndividualFindings(allFindings).findings;
+  if (allFindings.length === 0) {
+    finalFindings = [];
+  } else {
+    try {
+      core.info(`Running judge on ${allFindings.length} findings...`);
+      const judgeInput: JudgeInput = {
+        findings: allFindings,
+        diff,
+        rawDiff,
+        memory: memory ?? undefined,
+        repoContext,
+      };
+      const judged = await runJudgeAgent(client, config, judgeInput);
+      finalFindings = judged.filter(f => f.severity !== 'ignore');
+      core.info(`Judge complete: ${finalFindings.length} findings survived (${judged.length - finalFindings.length} ignored)`);
+    } catch (error) {
+      core.warning(`Judge failed: ${error}. Returning reviewer findings without judge evaluation.`);
+      finalFindings = allFindings;
+    }
   }
 
-  const hasRequired = finalFindings.some(f => f.severity === 'required');
-  const verdict = hasRequired ? 'REQUEST_CHANGES' : 'APPROVE';
+  const verdict = determineVerdict(finalFindings);
 
   const teamNames = team.agents.map(a => a.name).join(', ');
-  const summary = `Reviewed by ${team.agents.length} agents (${team.level}): ${teamNames}. ${finalFindings.length} findings after deliberation.`;
+  const summary = `Reviewed by ${team.agents.length} agents (${team.level}): ${teamNames}. ${finalFindings.length} findings after judge evaluation.`;
 
   core.startGroup('Review Summary');
   core.info(`Team: ${teamNames}`);
@@ -190,196 +204,6 @@ export async function runReview(
     highlights: [],
     reviewComplete: true,
   };
-}
-
-async function runDeliberation(
-  client: ClaudeClient,
-  config: ReviewConfig,
-  team: TeamRoster,
-  allFindings: { reviewer: string; findings: Finding[] }[],
-  rawDiff: string,
-): Promise<Finding[]> {
-  const rawFindings: Array<Finding & { originalReviewer: string }> = [];
-  for (const af of allFindings) {
-    for (const f of af.findings) {
-      rawFindings.push({ ...f, originalReviewer: af.reviewer });
-    }
-  }
-
-  if (rawFindings.length === 0) return [];
-
-  // Deduplicate findings before deliberation
-  const deduped: Array<Finding & { originalReviewer: string }> = [];
-  for (const f of rawFindings) {
-    const existing = deduped.find(d =>
-      d.file === f.file &&
-      Math.abs(d.line - f.line) <= 3 &&
-      titlesMatch(d.title, f.title)
-    );
-    if (existing) {
-      const severityOrder: Record<FindingSeverity, number> = { required: 3, suggestion: 2, nit: 1, ignore: 0 };
-      if ((severityOrder[f.severity] || 0) > (severityOrder[existing.severity] || 0)) {
-        existing.severity = f.severity;
-      }
-      if (!existing.reviewers.includes(f.originalReviewer)) {
-        existing.reviewers = [...existing.reviewers, f.originalReviewer];
-      }
-    } else {
-      deduped.push(f);
-    }
-  }
-
-  const flatFindings = deduped.map((f, i) => ({ ...f, index: i }));
-
-  const findingsSummary = flatFindings.map((f, i) =>
-    `[${i}] [${f.severity}] "${f.title}" at ${f.file}:${f.line} (by ${f.originalReviewer})\n    ${f.description}`
-  ).join('\n\n');
-
-  const voteResults = await Promise.allSettled(
-    team.agents.map(agent => runAgentVote(client, config, agent, findingsSummary, rawDiff, flatFindings.length))
-  );
-
-  const allVotes: AgentVote[] = [];
-  for (let i = 0; i < voteResults.length; i++) {
-    const result = voteResults[i];
-    if (result.status === 'fulfilled') {
-      // Deduplicate: only keep the first vote from each agent per finding
-      const seen = new Set<number>();
-      for (const vote of result.value) {
-        if (!seen.has(vote.findingIndex)) {
-          seen.add(vote.findingIndex);
-          allVotes.push(vote);
-        }
-      }
-    } else {
-      core.warning(`${team.agents[i].name} deliberation failed: ${result.reason}`);
-    }
-  }
-
-  return tallyVotes(flatFindings, allVotes, team.agents.length);
-}
-
-async function runAgentVote(
-  client: ClaudeClient,
-  config: ReviewConfig,
-  agent: ReviewerAgent,
-  findingsSummary: string,
-  rawDiff: string,
-  totalFindings: number,
-): Promise<AgentVote[]> {
-  let systemPrompt = `You are ${agent.name}, a code review specialist focusing on: ${agent.focus}
-
-Other reviewers have found issues in a pull request. You must vote on each finding.
-
-For each finding, respond with a JSON array:
-[
-  { "index": 0, "vote": "agree", "reason": "This is a real issue because..." },
-  { "index": 1, "vote": "disagree", "reason": "This is not an issue because..." },
-  ...
-]
-
-Vote options:
-- "agree" — the finding is valid and should be reported
-- "disagree" — the finding is a false positive or not worth flagging
-- "escalate" — the finding is more serious than the original severity suggests
-
-Be concise. One sentence per reason. Vote on EVERY finding.`;
-
-  if (config.instructions) {
-    systemPrompt += `\n\n## Additional Instructions\n\n${config.instructions}`;
-  }
-
-  const userMessage = `## Findings to vote on\n\n${findingsSummary}\n\n## PR Diff (for context)\n\n\`\`\`diff\n${truncateDiff(rawDiff)}\n\`\`\``;
-
-  const response = await client.sendMessage(systemPrompt, userMessage);
-  const jsonText = extractJSON(response.content);
-
-  try {
-    const validVotes = ['agree', 'disagree', 'escalate'];
-    const votes = JSON.parse(jsonText) as Array<{ index: number; vote: string; reason: string }>;
-    return votes
-      .filter(v => v.index >= 0 && v.index < totalFindings && validVotes.includes(v.vote))
-      .map(v => ({
-        agentName: agent.name,
-        findingIndex: v.index,
-        vote: v.vote as AgentVote['vote'],
-        reason: v.reason || '',
-      }));
-  } catch {
-    core.warning(`Failed to parse votes from ${agent.name}`);
-    return [];
-  }
-}
-
-export function tallyVotes(
-  findings: Array<Finding & { index: number; originalReviewer: string }>,
-  votes: AgentVote[],
-  teamSize: number,
-): Finding[] {
-  if (teamSize <= 0) return findings.map(f => ({ ...f }));
-
-  const results: Finding[] = [];
-  const majority = Math.ceil(teamSize / 2);
-
-  for (const finding of findings) {
-    // Deduplicate: only count the first vote from each agent per finding
-    const seenAgents = new Set<string>();
-    const findingVotes = votes.filter(v => {
-      if (v.findingIndex !== finding.index) return false;
-      const key = v.agentName;
-      if (seenAgents.has(key)) return false;
-      seenAgents.add(key);
-      return true;
-    });
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { index, originalReviewer, ...cleanFinding } = finding;
-
-    const agreeCount = findingVotes.filter(v => v.vote === 'agree' || v.vote === 'escalate').length;
-    const disagreeCount = findingVotes.filter(v => v.vote === 'disagree').length;
-    const escalateCount = findingVotes.filter(v => v.vote === 'escalate').length;
-
-    if (findingVotes.length === 0) {
-      results.push(cleanFinding);
-      continue;
-    }
-
-    if (disagreeCount >= majority) {
-      core.info(`Dropped: "${finding.title}" (${disagreeCount}/${findingVotes.length} disagree)`);
-      continue;
-    }
-
-    if (agreeCount >= majority) {
-      let severity = finding.severity;
-
-      // Uses teamSize (not voter count) so that true unanimity is required.
-      // If some agents failed to vote, we don't escalate — partial consensus
-      // shouldn't be treated as full agreement.
-      if (agreeCount === teamSize && finding.severity === 'suggestion') {
-        severity = 'required';
-      } else if (escalateCount >= 2 && agreeCount >= majority && finding.severity === 'suggestion') {
-        severity = 'required';
-      }
-
-      const agreeVoters = findingVotes
-        .filter(v => v.vote === 'agree' || v.vote === 'escalate')
-        .map(v => v.agentName);
-
-      results.push({
-        ...cleanFinding,
-        severity,
-        reviewers: agreeVoters,
-      });
-      continue;
-    }
-
-    results.push({
-      ...cleanFinding,
-      severity: 'suggestion',
-      reviewers: findingVotes.filter(v => v.vote !== 'disagree').map(v => v.agentName),
-    });
-  }
-
-  return results;
 }
 
 async function runReviewerAgent(
@@ -487,40 +311,9 @@ export function validateSeverity(severity: unknown): Finding['severity'] {
   return 'suggestion';
 }
 
-export function parseConsolidatedReview(responseText: string): ReviewResult {
-  const jsonText = extractJSON(responseText);
-
-  try {
-    const parsed = JSON.parse(jsonText);
-
-    const findings: Finding[] = (parsed.findings || []).map((f: Record<string, unknown>) => ({
-      severity: validateSeverity(f.severity),
-      title: String(f.title || 'Untitled'),
-      file: String(f.file || ''),
-      line: Number(f.line) || 0,
-      description: String(f.description || ''),
-      suggestedFix: f.suggestedFix ? String(f.suggestedFix) : undefined,
-      reviewers: Array.isArray(f.reviewers) ? f.reviewers.map(String) : [],
-    }));
-
-    const verdict = determineVerdict(parsed.verdict, findings);
-
-    return {
-      verdict,
-      summary: String(parsed.summary || ''),
-      findings,
-      highlights: Array.isArray(parsed.highlights) ? parsed.highlights.map(String) : [],
-      reviewComplete: true,
-    };
-  } catch (e) {
-    throw new Error(`Failed to parse consolidated review: ${e}`);
-  }
-}
-
-export function determineVerdict(claimed: unknown, findings: Finding[]): ReviewVerdict {
+export function determineVerdict(findings: Finding[]): ReviewVerdict {
   const hasRequired = findings.some(f => f.severity === 'required');
-  if (hasRequired) return 'REQUEST_CHANGES';
-  return 'APPROVE';
+  return hasRequired ? 'REQUEST_CHANGES' : 'APPROVE';
 }
 
 export function truncateDiff(rawDiff: string, maxLength: number = 50000): string {
@@ -545,42 +338,4 @@ export function titlesMatch(a: string, b: string): boolean {
   const longer = aLower.length > bLower.length ? aLower : bLower;
 
   return longer.includes(shorter);
-}
-
-/**
- * Merge individual reviewer findings when deliberation fails.
- * De-duplicates by title similarity + file + line proximity.
- */
-export function mergeIndividualFindings(
-  agentFindings: { reviewer: string; findings: Finding[] }[],
-): ReviewResult {
-  const allFindings: Finding[] = [];
-
-  for (const af of agentFindings) {
-    for (const f of af.findings) {
-      const existing = allFindings.find(e =>
-        e.file === f.file &&
-        Math.abs(e.line - f.line) <= 3 &&
-        titlesMatch(e.title, f.title)
-      );
-
-      if (existing) {
-        if (!existing.reviewers.includes(af.reviewer)) {
-          existing.reviewers = [...existing.reviewers, af.reviewer];
-        }
-      } else {
-        allFindings.push({ ...f, reviewers: [af.reviewer] });
-      }
-    }
-  }
-
-  const hasRequired = allFindings.some(f => f.severity === 'required');
-
-  return {
-    verdict: hasRequired ? 'REQUEST_CHANGES' : 'APPROVE',
-    summary: `Review completed (consolidation skipped). ${allFindings.length} findings from ${agentFindings.length} reviewers.`,
-    findings: allFindings,
-    highlights: [],
-    reviewComplete: true,
-  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,13 +35,6 @@ export interface ReviewThresholds {
   medium: number;
 }
 
-export interface AgentVote {
-  agentName: string;
-  findingIndex: number;
-  vote: 'agree' | 'disagree' | 'escalate';
-  reason: string;
-}
-
 export interface TeamRoster {
   level: 'small' | 'medium' | 'large';  // resolved, never 'auto'
   agents: ReviewerAgent[];


### PR DESCRIPTION
## Summary

- Rewrite `runReview()` pipeline: reviewers → judge → filter ignore → verdict
- Delete all deliberation/voting code: `runDeliberation`, `tallyVotes`, `mergeIndividualFindings`, `AgentVote`
- Judge failure handled gracefully (falls back to raw reviewer findings with COMMENT verdict)
- `ignore` findings filtered before posting
- `determineVerdict()` simplified: `required` → REQUEST_CHANGES, else APPROVE
- -679 lines of dead code removed

Closes #111