### PR TITLE
feat: per-stage model selection (`models.reviewer` / `models.judge`)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_CONFIG, loadConfig, loadConfigFromContent } from './config';
+import { DEFAULT_CONFIG, loadConfig, loadConfigFromContent, resolveModel } from './config';
+import { ReviewConfig } from './types';
 
 // Suppress @actions/core output during tests
 jest.mock('@actions/core', () => ({
@@ -323,6 +324,43 @@ models:
 `;
       const config = loadConfigFromContent(yaml);
       expect(config.models?.reviewer).toBe('claude-sonnet-4-6');
+    });
+  });
+
+  describe('resolveModel', () => {
+    const baseConfig: ReviewConfig = {
+      ...DEFAULT_CONFIG,
+      model: 'claude-opus-4-6',
+    };
+
+    it('returns stage-specific model when configured', () => {
+      const config: ReviewConfig = {
+        ...baseConfig,
+        models: { reviewer: 'claude-sonnet-4-6', judge: 'claude-opus-4-6' },
+      };
+      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
+    });
+
+    it('falls back to config.model when models is undefined', () => {
+      const config: ReviewConfig = { ...baseConfig, models: undefined };
+      expect(resolveModel(config, 'reviewer')).toBe('claude-opus-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
+    });
+
+    it('falls back to config.model when stage key is missing', () => {
+      const config: ReviewConfig = {
+        ...baseConfig,
+        models: { reviewer: 'claude-sonnet-4-6' },
+      };
+      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
+    });
+
+    it('falls back to config.model when models is empty object', () => {
+      const config: ReviewConfig = { ...baseConfig, models: {} };
+      expect(resolveModel(config, 'reviewer')).toBe('claude-opus-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -271,6 +271,10 @@ export function loadConfigFromFile(filePath: string): ReviewConfig {
   return loadConfigFromContent(content);
 }
 
+export function resolveModel(config: ReviewConfig, stage: 'reviewer' | 'judge'): string {
+  return config.models?.[stage] || config.model;
+}
+
 export function loadConfig(yamlContent: string | undefined): ReviewConfig {
   if (!yamlContent) {
     core.info('No config content provided, using defaults');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit } from './auth';
 import { ClaudeClient } from './claude';
-import { loadConfig } from './config';
+import { loadConfig, resolveModel } from './config';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handlePRComment } from './interaction';
 import { loadMemory, buildMemoryContext, applySuppressions, applyEscalations, updatePattern, RepoMemory } from './memory';
@@ -159,6 +159,7 @@ async function runFullReview(
 
     if (modelOverride) {
       config.model = modelOverride;
+      config.models = undefined;
     }
 
     if (github.context.eventName === 'pull_request' && !config.auto_review) {
@@ -167,11 +168,16 @@ async function runFullReview(
       return;
     }
 
-    const claude = new ClaudeClient({
+    const authOptions = {
       oauthToken: oauthToken || undefined,
       apiKey: apiKey || undefined,
-      model: config.model,
-    });
+    };
+    const reviewerModel = resolveModel(config, 'reviewer');
+    const judgeModel = resolveModel(config, 'judge');
+    core.info(`Models — reviewer: ${reviewerModel}, judge: ${judgeModel}`);
+
+    const reviewerClient = new ClaudeClient({ ...authOptions, model: reviewerModel });
+    const judgeClient = new ClaudeClient({ ...authOptions, model: judgeModel });
 
     const rawDiff = await fetchPRDiff(octokit, owner, repo, prNumber);
     const diff = parsePRDiff(rawDiff);
@@ -236,7 +242,7 @@ async function runFullReview(
 
     if (recap.previousFindings.length > 0) {
       const autoResolved = await resolveAddressedThreads(
-        octokit, claude, owner, repo, prNumber,
+        octokit, judgeClient, owner, repo, prNumber,
         recap.previousFindings, diff,
       );
       if (autoResolved > 0) {
@@ -248,7 +254,7 @@ async function runFullReview(
 
     await dismissPreviousReviews(octokit, owner, repo, prNumber);
 
-    const result = await runReview(claude, config, diff, rawDiff, fullContext, memory);
+    const result = await runReview({ reviewer: reviewerClient, judge: judgeClient }, config, diff, rawDiff, fullContext, memory);
 
     if (!result.reviewComplete && result.verdict === 'APPROVE') {
       result.verdict = 'COMMENT';
@@ -401,11 +407,6 @@ async function handleInteraction(): Promise<void> {
   const configPathInput = core.getInput('config_path');
 
   const octokit = await getOctokit();
-  const claude = new ClaudeClient({
-    oauthToken: oauthToken || undefined,
-    apiKey: apiKey || undefined,
-    model: modelOverride || 'claude-opus-4-6',
-  });
 
   const { owner, repo } = github.context.repo;
   const prNumber = github.context.payload.issue?.number;
@@ -422,6 +423,13 @@ async function handleInteraction(): Promise<void> {
     configContent = await fetchConfigFile(octokit, owner, repo, baseRef, '.manki.yml');
   }
   const config = loadConfig(configContent ?? undefined);
+
+  const interactionModel = modelOverride || resolveModel(config, 'judge');
+  const claude = new ClaudeClient({
+    oauthToken: oauthToken || undefined,
+    apiKey: apiKey || undefined,
+    model: interactionModel,
+  });
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
   const memoryToken = config.memory?.enabled ? (core.getInput('memory_repo_token') || core.getInput('github_token', { required: true })) : undefined;
@@ -497,7 +505,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
   const claude = new ClaudeClient({
     oauthToken: oauthToken || undefined,
     apiKey: apiKey || undefined,
-    model: config.model,
+    model: resolveModel(config, 'judge'),
   });
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;

--- a/src/review.ts
+++ b/src/review.ts
@@ -119,8 +119,13 @@ export function selectTeam(
   return { level, agents: selected, lineCount };
 }
 
+export interface ReviewClients {
+  reviewer: ClaudeClient;
+  judge: ClaudeClient;
+}
+
 export async function runReview(
-  client: ClaudeClient,
+  clients: ReviewClients,
   config: ReviewConfig,
   diff: ParsedDiff,
   rawDiff: string,
@@ -133,7 +138,7 @@ export async function runReview(
   core.info(`Running ${team.agents.length} reviewer agents in parallel...`);
   const agentResults = await Promise.allSettled(
     team.agents.map(agent =>
-      runReviewerAgent(client, config, agent, rawDiff, repoContext)
+      runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext)
     )
   );
 
@@ -171,7 +176,7 @@ export async function runReview(
         memory: memory ?? undefined,
         repoContext,
       };
-      const judged = await runJudgeAgent(client, config, judgeInput);
+      const judged = await runJudgeAgent(clients.judge, config, judgeInput);
       finalFindings = judged.filter(f => f.severity !== 'ignore');
       core.info(`Judge complete: ${finalFindings.length} findings survived (${judged.length - finalFindings.length} ignored)`);
     } catch (error) {


### PR DESCRIPTION
## Summary

- `resolveModel(config, stage)` helper for model resolution with fallback chain
- `runReview()` now accepts `ReviewClients` with separate `reviewer` and `judge` clients
- `models.reviewer` (default Sonnet) for parallel reviewers, `models.judge` (default Opus) for judge
- Action `model` input overrides all stage models
- Interaction commands use judge model for better reasoning quality

Closes #113