### PR TITLE
fix: graceful fallback when `github_token` is omitted with App auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ inputs:
     description: 'Anthropic API key (alternative to OAuth token)'
     required: false
   github_token:
-    description: 'GitHub token for posting reviews and comments'
-    required: true
+    description: 'GitHub token for posting reviews and comments (not required when using GitHub App auth)'
+    required: false
   config_path:
     description: 'Path to .manki.yml config file'
     required: false

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: ['**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@octokit/auth-app$': '<rootDir>/src/__mocks__/@octokit/auth-app.ts',
+  },
 };

--- a/src/__mocks__/@octokit/auth-app.ts
+++ b/src/__mocks__/@octokit/auth-app.ts
@@ -1,0 +1,1 @@
+export const createAppAuth = jest.fn();

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,50 @@
+import * as core from '@actions/core';
+
+import { getMemoryToken } from './auth';
+
+jest.mock('@actions/core');
+jest.mock('@actions/github');
+
+const mockGetInput = core.getInput as jest.MockedFunction<typeof core.getInput>;
+
+describe('getMemoryToken', () => {
+  beforeEach(() => {
+    mockGetInput.mockReset();
+  });
+
+  it('returns memory_repo_token when set', () => {
+    mockGetInput.mockImplementation((name: string) => {
+      if (name === 'memory_repo_token') return 'memory-token-123';
+      if (name === 'github_token') return 'github-token-456';
+      return '';
+    });
+
+    expect(getMemoryToken()).toBe('memory-token-123');
+  });
+
+  it('falls back to github_token when memory_repo_token is empty', () => {
+    mockGetInput.mockImplementation((name: string) => {
+      if (name === 'memory_repo_token') return '';
+      if (name === 'github_token') return 'github-token-456';
+      return '';
+    });
+
+    expect(getMemoryToken()).toBe('github-token-456');
+  });
+
+  it('returns null when both tokens are empty', () => {
+    mockGetInput.mockImplementation(() => '');
+
+    expect(getMemoryToken()).toBeNull();
+  });
+
+  it('prefers memory_repo_token over github_token', () => {
+    mockGetInput.mockImplementation((name: string) => {
+      if (name === 'memory_repo_token') return 'memory-token';
+      if (name === 'github_token') return 'github-token';
+      return '';
+    });
+
+    expect(getMemoryToken()).toBe('memory-token');
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,7 +13,7 @@ type Octokit = ReturnType<typeof github.getOctokit>;
 export async function createAuthenticatedOctokit(): Promise<Octokit> {
   const appId = core.getInput('github_app_id');
   const privateKey = core.getInput('github_app_private_key');
-  const githubToken = core.getInput('github_token', { required: true });
+  const githubToken = core.getInput('github_token');
 
   if (appId && privateKey) {
     core.info('Using GitHub App authentication for custom bot identity');
@@ -21,8 +21,26 @@ export async function createAuthenticatedOctokit(): Promise<Octokit> {
     return github.getOctokit(token);
   }
 
+  if (!githubToken) {
+    throw new Error('No authentication configured. Provide either github_token or both github_app_id and github_app_private_key.');
+  }
+
   core.info('Using GITHUB_TOKEN (reviews will appear as github-actions[bot])');
   return github.getOctokit(githubToken);
+}
+
+/**
+ * Returns a token suitable for memory repo operations.
+ * Prefers memory_repo_token, falls back to github_token, returns null if neither is set.
+ */
+export function getMemoryToken(): string | null {
+  const memoryToken = core.getInput('memory_repo_token');
+  if (memoryToken) return memoryToken;
+
+  const githubToken = core.getInput('github_token');
+  if (githubToken) return githubToken;
+
+  return null;
 }
 
 async function getInstallationToken(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { createAuthenticatedOctokit } from './auth';
+import { createAuthenticatedOctokit, getMemoryToken } from './auth';
 import { ClaudeClient } from './claude';
 import { loadConfig, resolveModel } from './config';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
@@ -225,16 +225,20 @@ async function runFullReview(
     let memory: RepoMemory | null = null;
     let memoryContext = '';
     if (config.memory?.enabled) {
-      const memoryToken = core.getInput('memory_repo_token') || core.getInput('github_token', { required: true });
-      const memoryOctokit = github.getOctokit(memoryToken);
-      const memoryRepo = config.memory?.repo || `${owner}/review-memory`;
+      const memoryToken = getMemoryToken();
+      if (!memoryToken) {
+        core.warning('No memory token available — skipping memory load. Set memory_repo_token or github_token.');
+      } else {
+        const memoryOctokit = github.getOctokit(memoryToken);
+        const memoryRepo = config.memory?.repo || `${owner}/review-memory`;
 
-      try {
-        memory = await loadMemory(memoryOctokit, memoryRepo, repo);
-        memoryContext = buildMemoryContext(memory);
-        core.info(`Loaded memory: ${memory.learnings.length} learnings, ${memory.suppressions.length} suppressions`);
-      } catch (error) {
-        core.warning(`Failed to load review memory: ${error}`);
+        try {
+          memory = await loadMemory(memoryOctokit, memoryRepo, repo);
+          memoryContext = buildMemoryContext(memory);
+          core.info(`Loaded memory: ${memory.learnings.length} learnings, ${memory.suppressions.length} suppressions`);
+        } catch (error) {
+          core.warning(`Failed to load review memory: ${error}`);
+        }
       }
     }
 
@@ -326,18 +330,22 @@ async function runFullReview(
     }
 
     if (memory && config.memory?.enabled) {
-      const memoryToken = core.getInput('memory_repo_token') || core.getInput('github_token', { required: true });
-      const memoryOctokit = github.getOctokit(memoryToken);
-      const memoryRepo = config.memory?.repo || `${owner}/review-memory`;
+      const memoryToken = getMemoryToken();
+      if (!memoryToken) {
+        core.warning('No memory token available — skipping memory update. Set memory_repo_token or github_token.');
+      } else {
+        const memoryOctokit = github.getOctokit(memoryToken);
+        const memoryRepo = config.memory?.repo || `${owner}/review-memory`;
 
-      for (const finding of result.findings) {
-        try {
-          await updatePattern(memoryOctokit, memoryRepo, repo, finding.title, repo);
-        } catch (error) {
-          core.debug(`Failed to update pattern for "${finding.title}": ${error}`);
+        for (const finding of result.findings) {
+          try {
+            await updatePattern(memoryOctokit, memoryRepo, repo, finding.title, repo);
+          } catch (error) {
+            core.debug(`Failed to update pattern for "${finding.title}": ${error}`);
+          }
         }
+        core.info(`Updated ${result.findings.length} patterns in memory repo`);
       }
-      core.info(`Updated ${result.findings.length} patterns in memory repo`);
     }
 
     await updateProgressComment(octokit, owner, repo, progressCommentId, result);
@@ -451,7 +459,7 @@ async function handleInteraction(): Promise<void> {
   });
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
-  const memoryToken = config.memory?.enabled ? (core.getInput('memory_repo_token') || core.getInput('github_token', { required: true })) : undefined;
+  const memoryToken = config.memory?.enabled ? getMemoryToken() ?? undefined : undefined;
 
   await handlePRComment(octokit, claude, owner, repo, prNumber, memoryConfig, memoryToken, config);
 }
@@ -479,7 +487,7 @@ async function handleIssueInteraction(): Promise<void> {
   const config = loadConfig(configContent ?? undefined);
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
-  const memoryToken = config.memory?.enabled ? (core.getInput('memory_repo_token') || core.getInput('github_token', { required: true })) : undefined;
+  const memoryToken = config.memory?.enabled ? getMemoryToken() ?? undefined : undefined;
 
   await handlePRComment(octokit, null, owner, repo, issueNumber, memoryConfig, memoryToken, config);
 }
@@ -528,7 +536,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
   });
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
-  const memoryToken = config.memory?.enabled ? (core.getInput('memory_repo_token') || core.getInput('github_token', { required: true })) : undefined;
+  const memoryToken = config.memory?.enabled ? getMemoryToken() ?? undefined : undefined;
 
   await handleReviewCommentReply(octokit, claude, memoryConfig, memoryToken);
 


### PR DESCRIPTION
## Summary

- `github_token` changed from `required: true` to `required: false` in `action.yml`
- `createAuthenticatedOctokit()` no longer throws when `github_token` is missing (App auth path works)
- New `getMemoryToken()` helper replaces 5 duplicated fallback expressions that crashed
- Memory operations gracefully skip with a warning when no token is available

Closes #56