### PR TITLE
chore: bump version to 3.0.0 and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
           git diff --staged --quiet || git commit -m "build: compile dist/ for ${TAG}"
 
           # Force-update major version tag
-          git tag -fa "v2" -m "Update v2 tag to $TAG"
-          git push origin "v2" --force
+          git tag -fa "$MAJOR" -m "Update $MAJOR tag to $TAG"
+          git push origin "$MAJOR" --force
 
       - name: Create GitHub Release
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manki",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "description": "Multi-agent AI code review GitHub Action",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump package.json version from 0.1.0 to 3.0.0
- Fix release workflow to use dynamic major version tag (`$MAJOR`) instead of hardcoded `v2`

Closes #134