### PR TITLE
feat: fetch full file content for changed files as reviewer context

### DIFF
--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -1,4 +1,21 @@
+import { spawn } from 'child_process';
+import Anthropic from '@anthropic-ai/sdk';
+
 import { ClaudeClient } from './claude';
+
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+  spawn: jest.fn(),
+}));
+
+jest.mock('@anthropic-ai/sdk');
+
+jest.mock('util', () => ({
+  ...jest.requireActual('util'),
+  promisify: () => jest.fn().mockResolvedValue({ stdout: '/usr/bin/claude' }),
+}));
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
 
 describe('ClaudeClient', () => {
   it('throws without either token', () => {
@@ -30,4 +47,129 @@ describe('ClaudeClient', () => {
   // integration in the GitHub Action workflow rather than unit tests. Mocking
   // child_process.spawn deeply enough to exercise those paths reliably would
   // couple tests to implementation details without catching real regressions.
+});
+
+describe('sendMessage effort option (CLI path)', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+  });
+
+  function setupSpawnMock(stdout: string): void {
+    const proc = {
+      stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+
+    // Simulate stdout data and close event
+    proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data') {
+        setTimeout(() => cb(Buffer.from(stdout)), 0);
+      }
+    });
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+      if (event === 'close') {
+        setTimeout(() => cb(0, null), 5);
+      }
+    });
+
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+  }
+
+  it('includes --effort flag when effort option is set', async () => {
+    setupSpawnMock('response text');
+    const client = new ClaudeClient({ oauthToken: 'token', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user', { effort: 'high' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs).toContain('--effort');
+    expect(spawnArgs[spawnArgs.indexOf('--effort') + 1]).toBe('high');
+  });
+
+  it('omits --effort flag when no options provided', async () => {
+    setupSpawnMock('response text');
+    const client = new ClaudeClient({ oauthToken: 'token', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user');
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs).not.toContain('--effort');
+  });
+
+  it('omits --effort flag when effort is undefined', async () => {
+    setupSpawnMock('response text');
+    const client = new ClaudeClient({ oauthToken: 'token', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user', {});
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs).not.toContain('--effort');
+  });
+});
+
+describe('sendMessage effort option (API path)', () => {
+  let mockCreate: jest.Mock;
+
+  beforeEach(() => {
+    mockCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'response' }],
+    });
+    (Anthropic as unknown as jest.Mock).mockImplementation(() => ({
+      messages: { create: mockCreate },
+    }));
+  });
+
+  it('includes thinking param when effort is high', async () => {
+    const client = new ClaudeClient({ apiKey: 'sk-key', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user', { effort: 'high' });
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 10000 });
+    expect(params.max_tokens).toBe(32768);
+  });
+
+  it('includes thinking param when effort is max', async () => {
+    const client = new ClaudeClient({ apiKey: 'sk-key', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user', { effort: 'max' });
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 16000 });
+    expect(params.max_tokens).toBe(32768);
+  });
+
+  it('includes thinking param when effort is medium', async () => {
+    const client = new ClaudeClient({ apiKey: 'sk-key', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user', { effort: 'medium' });
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+    expect(params.max_tokens).toBe(32768);
+  });
+
+  it('omits thinking param when effort is low', async () => {
+    const client = new ClaudeClient({ apiKey: 'sk-key', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user', { effort: 'low' });
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.thinking).toBeUndefined();
+    expect(params.max_tokens).toBe(16384);
+  });
+
+  it('omits thinking param when no options provided', async () => {
+    const client = new ClaudeClient({ apiKey: 'sk-key', model: 'claude-opus-4-6' });
+
+    await client.sendMessage('system', 'user');
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.thinking).toBeUndefined();
+    expect(params.max_tokens).toBe(16384);
+  });
 });

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -17,6 +17,10 @@ export interface ClaudeResponse {
   content: string;
 }
 
+export interface SendMessageOptions {
+  effort?: 'low' | 'medium' | 'high' | 'max';
+}
+
 export class ClaudeClient {
   private oauthToken?: string;
   private apiKey?: string;
@@ -38,11 +42,11 @@ export class ClaudeClient {
     }
   }
 
-  async sendMessage(systemPrompt: string, userMessage: string): Promise<ClaudeResponse> {
+  async sendMessage(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<ClaudeResponse> {
     if (this.oauthToken) {
-      return this.sendViaOAuth(systemPrompt, userMessage);
+      return this.sendViaOAuth(systemPrompt, userMessage, options);
     }
-    return this.sendViaAPI(systemPrompt, userMessage);
+    return this.sendViaAPI(systemPrompt, userMessage, options);
   }
 
   private async ensureCLI(): Promise<string> {
@@ -70,17 +74,23 @@ export class ClaudeClient {
     }
   }
 
-  private async sendViaOAuth(systemPrompt: string, userMessage: string): Promise<ClaudeResponse> {
+  private async sendViaOAuth(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<ClaudeResponse> {
     const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
     const cliPath = await this.ensureCLI();
 
     return new Promise((resolve, reject) => {
       // -p enables pipe mode — reads prompt from stdin when no argument follows
-      const child = spawn(cliPath, [
+      const args = [
         '-p',
         '--output-format', 'text',
         '--model', this.model,
-      ], {
+      ];
+
+      if (options?.effort) {
+        args.push('--effort', options.effort);
+      }
+
+      const child = spawn(cliPath, args, {
         env: {
           // process.env is spread intentionally — Claude CLI requires PATH, HOME, and other system vars.
           // CLAUDE_CODE_OAUTH_TOKEN is added conditionally. Secrets should be managed via GitHub Actions secret masking.
@@ -207,18 +217,28 @@ export class ClaudeClient {
     });
   }
 
-  private async sendViaAPI(systemPrompt: string, userMessage: string): Promise<ClaudeResponse> {
+  private async sendViaAPI(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<ClaudeResponse> {
     if (!this.anthropic) throw new Error('Anthropic client not initialized');
 
-    const response = await this.anthropic.messages.create({
+    const useThinking = options?.effort && options.effort !== 'low';
+    const budgetMap: Record<string, number> = { medium: 5000, high: 10000, max: 16000 };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params: any = {
       model: this.model,
-      max_tokens: 16384,
+      max_tokens: useThinking ? 32768 : 16384,
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],
-    });
+    };
 
-    const textBlocks = response.content.filter(b => b.type === 'text');
-    const content = textBlocks.map(b => b.text).join('\n');
+    if (useThinking) {
+      params.thinking = { type: 'enabled', budget_tokens: budgetMap[options!.effort!] };
+    }
+
+    const response = await this.anthropic.messages.create(params);
+
+    const textBlocks = response.content.filter((b) => b.type === 'text');
+    const content = textBlocks.map((b) => 'text' in b ? b.text : '').join('\n');
     core.startGroup('Claude API response');
     core.info(content);
     core.endGroup();

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -386,6 +386,28 @@ describe('runJudgeAgent', () => {
     expect(mockSendMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('passes effort option to sendMessage', async () => {
+    const judgedResponse = JSON.stringify([
+      { title: 'Unused variable', severity: 'suggestion', reasoning: 'Real issue.', confidence: 'high' },
+    ]);
+    mockSendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding()],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+    };
+
+    await runJudgeAgent(mockClient, makeConfig(), input);
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { effort: 'high' },
+    );
+  });
+
   it('returns originals when judge response is empty', async () => {
     mockSendMessage.mockResolvedValue({ content: '' });
 

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -259,7 +259,7 @@ export async function runJudgeAgent(
   const systemPrompt = buildJudgeSystemPrompt(config);
   const userMessage = buildJudgeUserMessage(findings, codeContextMap, memoryContext);
 
-  const response = await client.sendMessage(systemPrompt, userMessage);
+  const response = await client.sendMessage(systemPrompt, userMessage, { effort: 'high' });
   const judged = parseJudgeResponse(response.content);
 
   if (judged.length === 0) {


### PR DESCRIPTION
## Summary

- `fetchFileContents()` fetches file content via GitHub API for changed files
- Per-file size limit (50KB), total budget (100KB), binary file skipping
- `buildReviewerUserMessage()` now includes full file content per changed file before the diff
- Reviewer system prompt updated to reference file context
- Graceful fallback to diff-only if fetch fails

Closes #141