### PR TITLE
feat: pass memory context (learnings, suppressions) to reviewer agents

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -342,6 +342,7 @@ describe('buildReviewerUserMessage', () => {
     expect(memIdx).toBeLessThan(filesIdx);
     expect(filesIdx).toBeLessThan(diffIdx);
   });
+
 });
 
 describe('parseFindings with extractJSON', () => {


### PR DESCRIPTION
## Summary

- `buildReviewerUserMessage()` now includes memory context as a `## Review Memory` section
- Memory context built inside `runReview()` and passed to each reviewer agent
- Reviewer system prompt updated to instruct respecting learnings and suppressions
- Memory no longer mixed into generic repo context — passed directly to reviewers

Closes #148