### PR TITLE
feat: pre-filter suppressed findings before judge evaluation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { ClaudeClient } from './claude';
 import { loadConfig, resolveModel } from './config';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handlePRComment } from './interaction';
-import { loadMemory, applySuppressions, applyEscalations, updatePattern, RepoMemory } from './memory';
+import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { fetchRecapState, deduplicateFindings, buildRecapSummary, resolveAddressedThreads } from './recap';
 import { runReview, determineVerdict } from './review';
 import { PrContext } from './types';
@@ -286,15 +286,6 @@ async function runFullReview(
 
     if (!result.reviewComplete && result.verdict === 'APPROVE') {
       result.verdict = 'COMMENT';
-    }
-
-    if (memory && memory.suppressions.length > 0) {
-      const { kept, suppressed } = applySuppressions(result.findings, memory.suppressions);
-      if (suppressed.length > 0) {
-        core.info(`Suppressed ${suppressed.length} findings based on memory`);
-        result.findings = kept;
-        result.verdict = determineVerdict(result.findings);
-      }
     }
 
     const { unique, duplicates } = deduplicateFindings(result.findings, recap.previousFindings);

--- a/src/review.ts
+++ b/src/review.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 
 import { ClaudeClient } from './claude';
 import { runJudgeAgent, JudgeInput } from './judge';
-import { RepoMemory, buildMemoryContext } from './memory';
+import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
 import { ReviewConfig, ReviewerAgent, Finding, ReviewResult, ReviewVerdict, ParsedDiff, TeamRoster, PrContext } from './types';
 import { extractJSON } from './json';
 
@@ -146,7 +146,7 @@ export async function runReview(
     )
   );
 
-  const allFindings: Finding[] = [];
+  let allFindings: Finding[] = [];
   for (let i = 0; i < agentResults.length; i++) {
     const result = agentResults[i];
     if (result.status === 'fulfilled') {
@@ -165,6 +165,14 @@ export async function runReview(
       highlights: [],
       reviewComplete: false,
     };
+  }
+
+  if (memory?.suppressions && memory.suppressions.length > 0) {
+    const { kept, suppressed } = applySuppressions(allFindings, memory.suppressions);
+    if (suppressed.length > 0) {
+      core.info(`Suppressed ${suppressed.length} findings before judge evaluation`);
+    }
+    allFindings = kept;
   }
 
   let finalFindings: Finding[];


### PR DESCRIPTION
## Summary

- `applySuppressions()` moved from post-review (index.ts) to pre-judge (review.ts)
- Judge no longer wastes tokens evaluating findings that match suppression patterns
- Suppressed count logged for debugging

Closes #152