### PR TITLE
feat: implement `@manki forget` command for removing learnings and suppressions

### DIFF
--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -63,6 +63,16 @@ describe('parseCommand', () => {
     expect(result).toEqual<ParsedCommand>({ type: 'forget', args: 'something' });
   });
 
+  it('parses @manki forget suppression with pattern', () => {
+    const result = parseCommand('@manki forget suppression unused variable');
+    expect(result).toEqual<ParsedCommand>({ type: 'forget', args: 'suppression unused variable' });
+  });
+
+  it('parses @manki forget without args', () => {
+    const result = parseCommand('@manki forget');
+    expect(result).toEqual<ParsedCommand>({ type: 'forget', args: '' });
+  });
+
   it('parses @manki check with args', () => {
     const result = parseCommand('@manki check memory');
     expect(result).toEqual<ParsedCommand>({ type: 'check', args: 'memory' });

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { ClaudeClient } from './claude';
-import { writeSuppression, writeLearning, batchUpdatePatternDecisions, sanitizeMemoryField } from './memory';
+import { writeSuppression, writeLearning, removeLearning, removeSuppression, batchUpdatePatternDecisions, sanitizeMemoryField } from './memory';
 import { reactToIssueComment, reactToReviewComment } from './github';
 import { checkAndAutoApprove, fetchBotReviewThreads } from './state';
 import { ReviewConfig } from './types';
@@ -175,11 +175,8 @@ export async function handlePRComment(
       await handleRemember(octokit, owner, repo, issueNumber, command.args, memoryConfig, memoryToken);
       break;
     case 'forget':
-      await octokit.rest.issues.createComment({
-        owner, repo,
-        issue_number: issueNumber,
-        body: `${BOT_MARKER}\nThe \`forget\` command is not yet implemented. You can manually remove learnings from the memory repo.`,
-      });
+      await reactToIssueComment(octokit, owner, repo, commentId, 'eyes');
+      await handleForget(octokit, owner, repo, issueNumber, command.args, memoryConfig, memoryToken);
       break;
     case 'check':
       await reactToIssueComment(octokit, owner, repo, commentId, 'eyes');
@@ -310,7 +307,9 @@ async function handleHelp(
     owner,
     repo,
     issue_number: prNumber,
-    body: `${BOT_MARKER}\n**Manki Commands:**\n\n| Command | Description |\n|---------|-------------|\n| \`@manki review\` | Run a full multi-agent review |\n| \`@manki explain [topic]\` | Explain something about this PR |\n| \`@manki dismiss [finding]\` | Dismiss a review finding |\n| \`@manki remember <instruction>\` | Teach the reviewer something for future reviews |\n| \`@manki remember global: <instruction>\` | Teach globally (all repos) |\n| \`@manki check\` | Check if all required issues are resolved and auto-approve |\n| \`@manki triage\` | Process nit issue checkboxes — create issues for ticked items, suppress unticked |\n| \`@manki help\` | Show this help message |\n\nYou can also reply to any review comment to start a conversation.`,
+    body: `${BOT_MARKER}\n**Manki Commands:**\n\n| Command | Description |\n|---------|-------------|\n| \`@manki review\` | Run a full multi-agent review |\n| \`@manki explain [topic]\` | Explain something about this PR |\n| \`@manki dismiss [finding]\` | Dismiss a review finding |\n| \`@manki remember <instruction>\` | Teach the reviewer something for future reviews |\n| \`@manki remember global: <instruction>\` | Teach globally (all repos) |\n| \`@manki forget <text>\` | Remove a learning matching the text |
+| \`@manki forget suppression <pattern>\` | Remove a suppression matching the pattern |
+| \`@manki check\` | Check if all required issues are resolved and auto-approve |\n| \`@manki triage\` | Process nit issue checkboxes — create issues for ticked items, suppress unticked |\n| \`@manki help\` | Show this help message |\n\nYou can also reply to any review comment to start a conversation.`,
   });
 }
 
@@ -388,6 +387,105 @@ async function handleRemember(
       owner, repo,
       issue_number: prNumber,
       body: `${BOT_MARKER}\nFailed to store learning. Check that the memory repo token has write access.`,
+    });
+  }
+}
+
+async function handleForget(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  args: string,
+  memoryConfig?: MemoryConfig,
+  memoryToken?: string,
+): Promise<void> {
+  const authorAssociation = github.context.payload.comment?.author_association;
+  const isTrusted = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(authorAssociation ?? '');
+
+  if (!isTrusted) {
+    await octokit.rest.issues.createComment({
+      owner, repo,
+      issue_number: issueNumber,
+      body: `${BOT_MARKER}\nOnly collaborators can remove memories.`,
+    });
+    return;
+  }
+
+  if (!args || args.trim().length < 3) {
+    await octokit.rest.issues.createComment({
+      owner, repo,
+      issue_number: issueNumber,
+      body: `${BOT_MARKER}\nPlease provide a search term (at least 3 characters).\n\nUsage:\n- \`@manki forget <text>\` — remove a learning matching the text\n- \`@manki forget suppression <pattern>\` — remove a suppression matching the pattern`,
+    });
+    return;
+  }
+
+  if (!memoryConfig?.enabled || !memoryToken) {
+    await octokit.rest.issues.createComment({
+      owner, repo,
+      issue_number: issueNumber,
+      body: `${BOT_MARKER}\nMemory is not enabled for this repo. Add \`memory.enabled: true\` to \`.manki.yml\` to use this feature.`,
+    });
+    return;
+  }
+
+  const memoryOctokit = github.getOctokit(memoryToken);
+  const memoryRepo = memoryConfig.repo || `${owner}/review-memory`;
+  const trimmed = args.trim();
+
+  try {
+    if (trimmed.toLowerCase().startsWith('suppression ')) {
+      const searchPattern = trimmed.slice('suppression '.length).trim();
+      if (searchPattern.length < 3) {
+        await octokit.rest.issues.createComment({
+          owner, repo,
+          issue_number: issueNumber,
+          body: `${BOT_MARKER}\nPlease provide a search pattern (at least 3 characters) after \`suppression\`.`,
+        });
+        return;
+      }
+
+      const { removed, remaining } = await removeSuppression(memoryOctokit, memoryRepo, repo, searchPattern);
+
+      if (removed) {
+        await octokit.rest.issues.createComment({
+          owner, repo,
+          issue_number: issueNumber,
+          body: `${BOT_MARKER}\nRemoved suppression: "${removed.pattern}" (${remaining} remaining)`,
+        });
+        core.info(`Removed suppression: "${removed.pattern}"`);
+      } else {
+        await octokit.rest.issues.createComment({
+          owner, repo,
+          issue_number: issueNumber,
+          body: `${BOT_MARKER}\nNo matching suppression found for: "${searchPattern}"`,
+        });
+      }
+    } else {
+      const { removed, remaining } = await removeLearning(memoryOctokit, memoryRepo, repo, trimmed);
+
+      if (removed) {
+        await octokit.rest.issues.createComment({
+          owner, repo,
+          issue_number: issueNumber,
+          body: `${BOT_MARKER}\nRemoved learning: "${removed.content}" (${remaining} remaining)`,
+        });
+        core.info(`Removed learning: "${removed.content}"`);
+      } else {
+        await octokit.rest.issues.createComment({
+          owner, repo,
+          issue_number: issueNumber,
+          body: `${BOT_MARKER}\nNo matching learning found for: "${trimmed}"`,
+        });
+      }
+    }
+  } catch (error) {
+    core.warning(`Failed to remove memory: ${error}`);
+    await octokit.rest.issues.createComment({
+      owner, repo,
+      issue_number: issueNumber,
+      body: `${BOT_MARKER}\nFailed to remove memory. Check that the memory repo token has write access.`,
     });
   }
 }

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -6,6 +6,8 @@ import {
   sanitizeMemoryField,
   filterLearningsForFinding,
   filterSuppressionsForFinding,
+  removeLearning,
+  removeSuppression,
   Suppression,
   Pattern,
   Learning,
@@ -429,5 +431,114 @@ describe('filterSuppressionsForFinding', () => {
 
     const result = filterSuppressionsForFinding(suppressions, finding);
     expect(result).toHaveLength(0);
+  });
+});
+
+type MockOctokit = Parameters<typeof removeLearning>[0];
+
+function mockMemoryOctokit(yamlFiles: Record<string, unknown[]>): MockOctokit {
+  const store = new Map<string, unknown[]>();
+  for (const [path, data] of Object.entries(yamlFiles)) {
+    store.set(path, [...data]);
+  }
+
+  return {
+    rest: {
+      repos: {
+        getContent: jest.fn(async ({ path }: { path: string }) => {
+          const data = store.get(path);
+          if (!data) throw new Error(`Not found: ${path}`);
+          const { stringify } = await import('yaml');
+          return {
+            data: {
+              content: Buffer.from(stringify(data)).toString('base64'),
+              encoding: 'base64',
+              sha: 'abc123',
+            },
+          };
+        }),
+        createOrUpdateFileContents: jest.fn(async ({ path, content }: { path: string; content: string }) => {
+          const { parse } = await import('yaml');
+          const decoded = Buffer.from(content, 'base64').toString('utf-8');
+          store.set(path, parse(decoded));
+        }),
+      },
+    },
+  } as unknown as MockOctokit;
+}
+
+describe('removeLearning', () => {
+  it('removes matching learning by case-insensitive substring', async () => {
+    const learnings: Learning[] = [
+      makeLearning({ id: 'l1', content: 'Always use strict mode' }),
+      makeLearning({ id: 'l2', content: 'Check for null before access' }),
+    ];
+    const octokit = mockMemoryOctokit({ 'test-repo/learnings.yml': learnings });
+
+    const { removed, remaining } = await removeLearning(octokit, 'owner/memory', 'test-repo', 'strict mode');
+
+    expect(removed).not.toBeNull();
+    expect(removed!.id).toBe('l1');
+    expect(removed!.content).toBe('Always use strict mode');
+    expect(remaining).toBe(1);
+  });
+
+  it('returns null when no learning matches', async () => {
+    const learnings: Learning[] = [
+      makeLearning({ id: 'l1', content: 'Always use strict mode' }),
+    ];
+    const octokit = mockMemoryOctokit({ 'test-repo/learnings.yml': learnings });
+
+    const { removed, remaining } = await removeLearning(octokit, 'owner/memory', 'test-repo', 'nonexistent');
+
+    expect(removed).toBeNull();
+    expect(remaining).toBe(1);
+  });
+
+  it('returns null when no learnings file exists', async () => {
+    const octokit = mockMemoryOctokit({});
+
+    const { removed, remaining } = await removeLearning(octokit, 'owner/memory', 'test-repo', 'anything');
+
+    expect(removed).toBeNull();
+    expect(remaining).toBe(0);
+  });
+});
+
+describe('removeSuppression', () => {
+  it('removes matching suppression by case-insensitive substring', async () => {
+    const suppressions: Suppression[] = [
+      makeSuppression({ id: 'sup-1', pattern: 'unused variable' }),
+      makeSuppression({ id: 'sup-2', pattern: 'todo comment' }),
+    ];
+    const octokit = mockMemoryOctokit({ 'test-repo/suppressions.yml': suppressions });
+
+    const { removed, remaining } = await removeSuppression(octokit, 'owner/memory', 'test-repo', 'TODO');
+
+    expect(removed).not.toBeNull();
+    expect(removed!.id).toBe('sup-2');
+    expect(removed!.pattern).toBe('todo comment');
+    expect(remaining).toBe(1);
+  });
+
+  it('returns null when no suppression matches', async () => {
+    const suppressions: Suppression[] = [
+      makeSuppression({ id: 'sup-1', pattern: 'unused variable' }),
+    ];
+    const octokit = mockMemoryOctokit({ 'test-repo/suppressions.yml': suppressions });
+
+    const { removed, remaining } = await removeSuppression(octokit, 'owner/memory', 'test-repo', 'nonexistent');
+
+    expect(removed).toBeNull();
+    expect(remaining).toBe(1);
+  });
+
+  it('returns null when no suppressions file exists', async () => {
+    const octokit = mockMemoryOctokit({});
+
+    const { removed, remaining } = await removeSuppression(octokit, 'owner/memory', 'test-repo', 'anything');
+
+    expect(removed).toBeNull();
+    expect(remaining).toBe(0);
   });
 });

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -282,6 +282,60 @@ export async function writeLearning(
 }
 
 /**
+ * Remove a learning from the memory repo by case-insensitive substring match on content.
+ */
+export async function removeLearning(
+  octokit: Octokit,
+  memoryRepo: string,
+  targetRepo: string,
+  searchText: string,
+): Promise<{ removed: Learning | null; remaining: number }> {
+  const [owner, repo] = memoryRepo.split('/');
+  const path = `${targetRepo}/learnings.yml`;
+
+  const existing = await fetchYamlFile<Learning[]>(octokit, owner, repo, path) || [];
+  const searchLower = searchText.toLowerCase();
+  const index = existing.findIndex(l => l.content.toLowerCase().includes(searchLower));
+
+  if (index === -1) {
+    return { removed: null, remaining: existing.length };
+  }
+
+  const [removed] = existing.splice(index, 1);
+  const content = stringifyYaml(existing);
+  await writeFile(octokit, owner, repo, path, content, `Remove learning: ${removed.content.slice(0, 50)}`);
+
+  return { removed, remaining: existing.length };
+}
+
+/**
+ * Remove a suppression from the memory repo by case-insensitive substring match on pattern.
+ */
+export async function removeSuppression(
+  octokit: Octokit,
+  memoryRepo: string,
+  targetRepo: string,
+  searchPattern: string,
+): Promise<{ removed: Suppression | null; remaining: number }> {
+  const [owner, repo] = memoryRepo.split('/');
+  const path = `${targetRepo}/suppressions.yml`;
+
+  const existing = await fetchYamlFile<Suppression[]>(octokit, owner, repo, path) || [];
+  const searchLower = searchPattern.toLowerCase();
+  const index = existing.findIndex(s => s.pattern.toLowerCase().includes(searchLower));
+
+  if (index === -1) {
+    return { removed: null, remaining: existing.length };
+  }
+
+  const [removed] = existing.splice(index, 1);
+  const content = stringifyYaml(existing);
+  await writeFile(octokit, owner, repo, path, content, `Remove suppression: ${removed.pattern.slice(0, 50)}`);
+
+  return { removed, remaining: existing.length };
+}
+
+/**
  * Update a pattern tracker in the memory repo.
  */
 export async function updatePattern(


### PR DESCRIPTION
## Summary

- `@manki forget <text>` removes a learning matching the text
- `@manki forget suppression <pattern>` removes a suppression matching the pattern
- `removeLearning()` and `removeSuppression()` added to memory module
- Collaborator trust check, confirmation comments, help text updated

Closes #154