### PR TITLE
feat: fetch subdirectory CLAUDE.md files for changed file paths

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,4 +1,4 @@
-import { formatFindingComment, mapVerdictToEvent, BOT_MARKER, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues } from './github';
+import { formatFindingComment, mapVerdictToEvent, BOT_MARKER, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd } from './github';
 import { Finding, ReviewResult } from './types';
 
 describe('formatFindingComment', () => {
@@ -998,5 +998,149 @@ describe('fetchLinkedIssues', () => {
     const result = await fetchLinkedIssues(octokit, 'owner', 'repo', 'Closes #1');
     expect(result[0].title).not.toContain('<!--');
     expect(result[0].body).not.toContain('<script>');
+  });
+});
+
+describe('fetchSubdirClaudeMd', () => {
+  function mockOctokit(
+    treeEntries: Array<{ path: string; type: string }>,
+    fileContents: Record<string, string>,
+  ) {
+    return {
+      rest: {
+        git: {
+          getTree: jest.fn(async () => ({
+            data: { tree: treeEntries },
+          })),
+        },
+        repos: {
+          getContent: jest.fn(async ({ path }: { path: string }) => {
+            const content = fileContents[path];
+            if (content === undefined) throw new Error(`Not found: ${path}`);
+            return {
+              data: {
+                content: Buffer.from(content).toString('base64'),
+                encoding: 'base64',
+              },
+            };
+          }),
+        },
+      },
+    } as unknown as Parameters<typeof fetchSubdirClaudeMd>[0];
+  }
+
+  const baseTree = [
+    { path: 'CLAUDE.md', type: 'blob' },
+    { path: '.claude/CLAUDE.md', type: 'blob' },
+    { path: 'src/CLAUDE.md', type: 'blob' },
+    { path: 'src/auth/CLAUDE.md', type: 'blob' },
+    { path: 'lib/CLAUDE.md', type: 'blob' },
+  ];
+
+  it('finds CLAUDE.md in subdirectories for changed files', async () => {
+    const octokit = mockOctokit(baseTree, {
+      'src/CLAUDE.md': 'Source rules',
+    });
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['src/index.ts']);
+    expect(result).toContain('## src/CLAUDE.md');
+    expect(result).toContain('Source rules');
+  });
+
+  it('walks up directory tree to find nearest CLAUDE.md', async () => {
+    const octokit = mockOctokit(baseTree, {
+      'src/auth/CLAUDE.md': 'Auth rules',
+    });
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['src/auth/handlers.ts']);
+    expect(result).toContain('## src/auth/CLAUDE.md');
+    expect(result).toContain('Auth rules');
+  });
+
+  it('deduplicates when two changed files share the same nearest CLAUDE.md', async () => {
+    const octokit = mockOctokit(baseTree, {
+      'src/CLAUDE.md': 'Source rules',
+    });
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', [
+      'src/foo.ts',
+      'src/bar.ts',
+    ]);
+    const matches = result.match(/## src\/CLAUDE\.md/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('excludes root CLAUDE.md and .claude/CLAUDE.md', async () => {
+    const octokit = mockOctokit(
+      [{ path: 'CLAUDE.md', type: 'blob' }, { path: '.claude/CLAUDE.md', type: 'blob' }],
+      {},
+    );
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['README.md']);
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when no subdirectory CLAUDE.md files exist', async () => {
+    const octokit = mockOctokit(
+      [{ path: 'CLAUDE.md', type: 'blob' }],
+      {},
+    );
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['src/index.ts']);
+    expect(result).toBe('');
+  });
+
+  it('returns empty string for empty changedPaths', async () => {
+    const octokit = mockOctokit(baseTree, {});
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', []);
+    expect(result).toBe('');
+  });
+
+  it('fetches multiple CLAUDE.md files for changes in different directories', async () => {
+    const octokit = mockOctokit(baseTree, {
+      'src/CLAUDE.md': 'Source rules',
+      'lib/CLAUDE.md': 'Lib rules',
+    });
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', [
+      'src/index.ts',
+      'lib/utils.ts',
+    ]);
+    expect(result).toContain('## src/CLAUDE.md');
+    expect(result).toContain('Source rules');
+    expect(result).toContain('## lib/CLAUDE.md');
+    expect(result).toContain('Lib rules');
+  });
+
+  it('resolves @references in subdirectory CLAUDE.md files', async () => {
+    const octokit = mockOctokit(baseTree, {
+      'src/CLAUDE.md': '@rules/style.md',
+      'src/rules/style.md': 'Style guidelines',
+    });
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['src/index.ts']);
+    expect(result).toContain('Style guidelines');
+  });
+
+  it('skips CLAUDE.md files that fail to fetch', async () => {
+    const octokit = mockOctokit(baseTree, {
+      'src/CLAUDE.md': 'Source rules',
+      // lib/CLAUDE.md is missing — will throw
+    });
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', [
+      'src/index.ts',
+      'lib/utils.ts',
+    ]);
+    expect(result).toContain('## src/CLAUDE.md');
+    expect(result).not.toContain('lib/CLAUDE.md');
+  });
+
+  it('ignores root-level changed files with no subdirectory CLAUDE.md', async () => {
+    const octokit = mockOctokit(baseTree, {});
+
+    const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['package.json']);
+    expect(result).toBe('');
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -788,4 +788,70 @@ export async function fetchLinkedIssues(
   return results;
 }
 
+/**
+ * Discover and fetch CLAUDE.md files in subdirectories relevant to changed file paths.
+ * Walks up the directory tree from each changed file to find the nearest CLAUDE.md,
+ * excluding root-level files already fetched by `fetchRepoContext`.
+ */
+export async function fetchSubdirClaudeMd(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  changedPaths: string[],
+): Promise<string> {
+  if (changedPaths.length === 0) return '';
+
+  let treeEntries: Array<{ path?: string; type?: string }>;
+  try {
+    const { data } = await octokit.rest.git.getTree({ owner, repo, tree_sha: ref, recursive: 'true' });
+    treeEntries = data.tree;
+  } catch {
+    core.debug('Could not fetch repo tree for subdirectory CLAUDE.md discovery');
+    return '';
+  }
+
+  const claudeMdPaths = new Set(
+    treeEntries
+      .filter(e => e.type === 'blob' && e.path?.endsWith('/CLAUDE.md'))
+      .map(e => e.path!)
+      .filter(p => p !== 'CLAUDE.md' && p !== '.claude/CLAUDE.md'),
+  );
+
+  if (claudeMdPaths.size === 0) return '';
+
+  // For each changed file, walk up the directory tree and find the nearest CLAUDE.md
+  const toFetch = new Set<string>();
+  for (const changedPath of changedPaths) {
+    let dir = changedPath.includes('/') ? changedPath.substring(0, changedPath.lastIndexOf('/')) : '';
+    while (dir) {
+      const candidate = `${dir}/CLAUDE.md`;
+      if (claudeMdPaths.has(candidate)) {
+        toFetch.add(candidate);
+        break;
+      }
+      dir = dir.includes('/') ? dir.substring(0, dir.lastIndexOf('/')) : '';
+    }
+  }
+
+  if (toFetch.size === 0) return '';
+
+  const parts: string[] = [];
+  for (const path of toFetch) {
+    try {
+      const { data } = await octokit.rest.repos.getContent({ owner, repo, path, ref });
+      if ('content' in data && data.encoding === 'base64') {
+        let content = Buffer.from(data.content, 'base64').toString('utf-8');
+        const dir = path.substring(0, path.lastIndexOf('/'));
+        content = await resolveReferences(octokit, owner, repo, ref, content, dir);
+        parts.push(`## ${path}\n\n${content}`);
+      }
+    } catch {
+      core.debug(`Could not fetch subdirectory CLAUDE.md: ${path}`);
+    }
+  }
+
+  return parts.join('\n\n---\n\n');
+}
+
 export { dynamicFence, formatFindingComment, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_MARKER };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   fetchPRDiff,
   fetchConfigFile,
   fetchRepoContext,
+  fetchSubdirClaudeMd,
   fetchFileContents,
   postProgressComment,
   updateProgressComment,
@@ -241,7 +242,17 @@ async function runFullReview(
       return;
     }
 
-    const repoContext = await fetchRepoContext(octokit, owner, repo, baseRef);
+    let repoContext = await fetchRepoContext(octokit, owner, repo, baseRef);
+
+    const changedPaths = filteredFiles.map(f => f.path);
+    try {
+      const subdirContext = await fetchSubdirClaudeMd(octokit, owner, repo, baseRef, changedPaths);
+      if (subdirContext) {
+        repoContext = repoContext ? `${repoContext}\n\n---\n\n${subdirContext}` : subdirContext;
+      }
+    } catch (error) {
+      core.warning(`Failed to fetch subdirectory CLAUDE.md files: ${error}`);
+    }
 
     let memory: RepoMemory | null = null;
     if (config.memory?.enabled) {


### PR DESCRIPTION
## Summary

- `fetchSubdirClaudeMd()` discovers CLAUDE.md files in subdirectories of changed files
- Uses single API call to fetch repo tree, walks up directory tree to find nearest CLAUDE.md
- Deduplicates, excludes root CLAUDE.md (already fetched), resolves @references
- 10 new tests

Closes #151