### PR TITLE
fix: judge merges duplicate findings from different reviewer agents

### DIFF
--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -4,8 +4,10 @@ import {
   extractCodeContext,
   parseJudgeResponse,
   filterMemoryForFindings,
+  mapJudgedToFindings,
   runJudgeAgent,
   JudgeInput,
+  JudgedFinding,
 } from './judge';
 import { ClaudeClient } from './claude';
 import { RepoMemory, Learning, Suppression } from './memory';
@@ -116,6 +118,12 @@ describe('buildJudgeSystemPrompt', () => {
   it('defines the judge role', () => {
     const prompt = buildJudgeSystemPrompt(makeConfig());
     expect(prompt).toContain('code review judge');
+  });
+
+  it('includes duplicate detection instructions', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('Duplicate Detection');
+    expect(prompt).toContain('ONE entry for the merged finding');
   });
 
   it('includes severity examples for each level', () => {
@@ -511,6 +519,80 @@ describe('runJudgeAgent', () => {
 
     const [, userMessage] = mockSendMessage.mock.calls[0];
     expect(userMessage).toContain('Relevant Suppressions');
+  });
+});
+
+describe('mapJudgedToFindings', () => {
+  it('handles 1:1 mapping when judge returns same count', () => {
+    const originals = [
+      makeFinding({ title: 'Bug A', severity: 'suggestion', reviewers: ['R1'] }),
+      makeFinding({ title: 'Bug B', severity: 'suggestion', reviewers: ['R2'], file: 'b.ts' }),
+    ];
+    const judged: JudgedFinding[] = [
+      { title: 'Bug A', severity: 'required', reasoning: 'Real bug.', confidence: 'high' },
+      { title: 'Bug B', severity: 'nit', reasoning: 'Minor.', confidence: 'low' },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result).toHaveLength(2);
+    expect(result[0].severity).toBe('required');
+    expect(result[1].severity).toBe('nit');
+  });
+
+  it('handles fewer judge results by merging duplicates', () => {
+    const originals = [
+      makeFinding({ title: 'Null check missing', severity: 'suggestion', reviewers: ['SecurityReviewer'] }),
+      makeFinding({ title: 'Missing null check', severity: 'required', reviewers: ['BugReviewer'] }),
+      makeFinding({ title: 'Unused import', severity: 'nit', reviewers: ['StyleReviewer'] }),
+    ];
+    const judged: JudgedFinding[] = [
+      { title: 'Null check missing', severity: 'required', reasoning: 'Merged findings 1 and 2 — same issue.', confidence: 'high' },
+      { title: 'Unused import', severity: 'nit', reasoning: 'Minor style issue.', confidence: 'medium' },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result).toHaveLength(2);
+
+    // First result should have merged reviewers from both null-check findings
+    expect(result[0].severity).toBe('required');
+    expect(result[0].reviewers).toContain('SecurityReviewer');
+    expect(result[0].reviewers).toContain('BugReviewer');
+    expect(result[0].judgeNotes).toContain('Merged findings 1 and 2');
+
+    // Second result maps normally
+    expect(result[1].severity).toBe('nit');
+    expect(result[1].reviewers).toEqual(['StyleReviewer']);
+  });
+
+  it('deduplicates reviewers when merging', () => {
+    const originals = [
+      makeFinding({ title: 'Error handling', reviewers: ['R1', 'R2'] }),
+      makeFinding({ title: 'Error handling missing', reviewers: ['R2', 'R3'] }),
+    ];
+    const judged: JudgedFinding[] = [
+      { title: 'Error handling', severity: 'suggestion', reasoning: 'Merged.', confidence: 'medium' },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result).toHaveLength(1);
+    expect(result[0].reviewers).toHaveLength(3);
+    expect(result[0].reviewers).toContain('R1');
+    expect(result[0].reviewers).toContain('R2');
+    expect(result[0].reviewers).toContain('R3');
+  });
+
+  it('uses the longest description when merging', () => {
+    const originals = [
+      makeFinding({ title: 'Null check', description: 'Short.' }),
+      makeFinding({ title: 'Null check missing', description: 'This is a much more detailed description of the null check issue.' }),
+    ];
+    const judged: JudgedFinding[] = [
+      { title: 'Null check', severity: 'required', reasoning: 'Merged.', confidence: 'high' },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('This is a much more detailed description of the null check issue.');
   });
 });
 

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -70,6 +70,15 @@ For each finding, evaluate:
 - If a reviewer flags something that looks intentional or is a matter of preference, mark it \`ignore\`.
 - If a finding is correct but overstated in severity, downgrade it.
 
+## Duplicate Detection
+
+Multiple specialist reviewers may flag the same issue independently. When you see findings that describe the same underlying problem (even with different wording, slightly different line numbers, or different titles):
+
+- Return only ONE entry for the merged finding
+- Use the best/clearest title from the duplicates
+- Use the most detailed description
+- In your reasoning, note which findings you merged (e.g., "Merged findings 1 and 4 — same issue")
+
 ## Output Format
 
 Respond with ONLY a JSON array (no markdown fences, no explanation). Each element:
@@ -85,7 +94,7 @@ Respond with ONLY a JSON array (no markdown fences, no explanation). Each elemen
 ]
 \`\`\`
 
-Return one element per finding, in the same order as presented.`;
+The output array may be shorter than the input when duplicates are merged. Preserve the order of first appearance.`;
 
   if (config.instructions) {
     prompt += `\n\n## Project Instructions\n\n${config.instructions}`;
@@ -304,19 +313,23 @@ export async function runJudgeAgent(
   return mapJudgedToFindings(findings, judged);
 }
 
-function mapJudgedToFindings(original: Finding[], judged: JudgedFinding[]): Finding[] {
+export function mapJudgedToFindings(original: Finding[], judged: JudgedFinding[]): Finding[] {
+  // When judge returns fewer results (due to merging duplicates), use fuzzy matching only
+  if (judged.length < original.length) {
+    return mapMergedFindings(original, judged);
+  }
+
+  // 1:1 mapping: match by position, fall back to fuzzy title match
   const result: Finding[] = [];
 
   for (let i = 0; i < original.length; i++) {
     const finding = { ...original[i] };
 
-    // Match by position first (judge returns findings in same order)
     let match: JudgedFinding | undefined;
     if (i < judged.length) {
       match = judged[i];
     }
 
-    // Fall back to fuzzy title match if position doesn't seem right
     if (match && !titlesRelated(finding.title, match.title)) {
       const titleMatch = judged.find(j => titlesRelated(finding.title, j.title));
       if (titleMatch) {
@@ -331,6 +344,46 @@ function mapJudgedToFindings(original: Finding[], judged: JudgedFinding[]): Find
     }
 
     result.push(finding);
+  }
+
+  return result;
+}
+
+function mapMergedFindings(original: Finding[], judged: JudgedFinding[]): Finding[] {
+  const result: Finding[] = [];
+
+  for (const j of judged) {
+    // Find all original findings that match this judge result
+    const matches = original.filter(o => titlesRelated(o.title, j.title));
+
+    if (matches.length === 0) {
+      // No match found — skip this judge result (should not happen in practice)
+      continue;
+    }
+
+    // Use the first match as the base finding
+    const merged: Finding = { ...matches[0] };
+    merged.severity = j.severity;
+    merged.judgeNotes = j.reasoning;
+    merged.judgeConfidence = j.confidence;
+
+    // Combine reviewers from all matched originals
+    const allReviewers = new Set<string>();
+    for (const m of matches) {
+      for (const r of m.reviewers) {
+        allReviewers.add(r);
+      }
+    }
+    merged.reviewers = [...allReviewers];
+
+    // Use the longest description among matches
+    for (const m of matches) {
+      if (m.description.length > merged.description.length) {
+        merged.description = m.description;
+      }
+    }
+
+    result.push(merged);
   }
 
   return result;


### PR DESCRIPTION
## Summary

- Judge prompt now instructs merging of duplicate findings from different reviewers
- `mapJudgedToFindings()` handles fewer judge results than input (merges happened)
- Merged findings combine reviewer attribution and keep the best description
- Fixes duplicate inline comments when multiple agents flag the same issue

Closes #186