### PR TITLE
chore: bump `max_diff_lines` default from 10k to 50k

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   review_language: 'en',
   include_paths: ['**/*'],
   exclude_paths: ['*.lock', 'dist/**', '*.generated.*'],
-  max_diff_lines: 10000,
+  max_diff_lines: 50000,
   reviewers: DEFAULT_REVIEWERS,
   instructions: '',
   review_level: 'auto',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -21,7 +21,7 @@ const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
   review_language: 'en',
   include_paths: ['**/*'],
   exclude_paths: [],
-  max_diff_lines: 10000,
+  max_diff_lines: 50000,
   reviewers: [],
   review_level: 'auto',
   review_thresholds: { small: 200, medium: 1000 },

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -23,7 +23,7 @@ const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
   review_language: 'en',
   include_paths: ['**/*'],
   exclude_paths: [],
-  max_diff_lines: 10000,
+  max_diff_lines: 50000,
   reviewers: [],
   instructions: '',
   review_level: 'auto',


### PR DESCRIPTION
## Summary

- Bumps `max_diff_lines` default from 10,000 to 50,000

Closes #208