### PR TITLE
feat: review event body with summary and collapsed stats

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,5 +1,5 @@
-import { formatFindingComment, mapVerdictToEvent, BOT_MARKER, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd } from './github';
-import { Finding, ReviewResult } from './types';
+import { formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_MARKER, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd } from './github';
+import { Finding, ReviewResult, ReviewStats } from './types';
 
 describe('formatFindingComment', () => {
   const baseFinding: Finding = {
@@ -479,6 +479,142 @@ describe('postReview generalFindings', () => {
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
     const body = mockCreateReview.mock.calls[0][0].body as string;
     expect(body).toContain('`src/utils.ts`');
+  });
+});
+
+describe('formatStatsOneLiner', () => {
+  const baseStats: ReviewStats = {
+    model: 'claude-sonnet-4-20250514',
+    reviewTimeMs: 45000,
+    diffLines: 120,
+    diffAdditions: 80,
+    diffDeletions: 40,
+    filesReviewed: 5,
+    agents: ['Security & Safety', 'Correctness'],
+    findingsRaw: 10,
+    findingsKept: 4,
+    findingsDropped: 6,
+    severity: { required: 1, suggestion: 2, nit: 1 },
+    verdict: 'REQUEST_CHANGES',
+    prNumber: 42,
+    commitSha: 'abc123',
+  };
+
+  it('formats a one-liner with severity breakdown', () => {
+    const result = formatStatsOneLiner(baseStats);
+    expect(result).toBe('\u{1F4CA} 4 findings (1 required, 2 suggestion, 1 nit) \u00B7 120 lines \u00B7 45s');
+  });
+
+  it('omits zero-count severities', () => {
+    const stats = { ...baseStats, severity: { required: 0, suggestion: 3, nit: 0 }, findingsKept: 3 };
+    const result = formatStatsOneLiner(stats);
+    expect(result).toContain('(3 suggestion)');
+    expect(result).not.toContain('required');
+    expect(result).not.toContain('nit');
+  });
+
+  it('shows none when all severities are zero', () => {
+    const stats = { ...baseStats, severity: { required: 0, suggestion: 0, nit: 0 }, findingsKept: 0 };
+    const result = formatStatsOneLiner(stats);
+    expect(result).toContain('(none)');
+  });
+
+  it('rounds review time to nearest second', () => {
+    const stats = { ...baseStats, reviewTimeMs: 1500 };
+    const result = formatStatsOneLiner(stats);
+    expect(result).toContain('2s');
+  });
+});
+
+describe('formatStatsJson', () => {
+  it('wraps stats in a collapsed details block with JSON', () => {
+    const stats: ReviewStats = {
+      model: 'claude-sonnet-4-20250514',
+      reviewTimeMs: 30000,
+      diffLines: 50,
+      diffAdditions: 30,
+      diffDeletions: 20,
+      filesReviewed: 3,
+      agents: ['Security'],
+      findingsRaw: 5,
+      findingsKept: 2,
+      findingsDropped: 3,
+      severity: { required: 1, suggestion: 1, nit: 0 },
+      verdict: 'APPROVE',
+      prNumber: 10,
+      commitSha: 'def456',
+    };
+    const result = formatStatsJson(stats);
+    expect(result).toContain('<details>');
+    expect(result).toContain('<summary>Review stats</summary>');
+    expect(result).toContain('```json');
+    expect(result).toContain('"model": "claude-sonnet-4-20250514"');
+    expect(result).toContain('"findingsKept": 2');
+    expect(result).toContain('</details>');
+  });
+});
+
+describe('postReview with stats', () => {
+  const mockCreateReview = jest.fn().mockResolvedValue({ data: { id: 1 } });
+  const mockOctokit = {
+    rest: {
+      pulls: {
+        createReview: mockCreateReview,
+      },
+    },
+  } as unknown as Parameters<typeof postReview>[0];
+
+  beforeEach(() => {
+    mockCreateReview.mockClear();
+  });
+
+  it('includes stats one-liner and collapsed JSON in review body', async () => {
+    const result: ReviewResult = {
+      verdict: 'APPROVE',
+      summary: 'All good.',
+      findings: [],
+      highlights: [],
+      reviewComplete: true,
+    };
+    const stats: ReviewStats = {
+      model: 'claude-sonnet-4-20250514',
+      reviewTimeMs: 60000,
+      diffLines: 200,
+      diffAdditions: 150,
+      diffDeletions: 50,
+      filesReviewed: 8,
+      agents: ['Security', 'Correctness'],
+      findingsRaw: 6,
+      findingsKept: 3,
+      findingsDropped: 3,
+      severity: { required: 0, suggestion: 2, nit: 1 },
+      verdict: 'APPROVE',
+      prNumber: 99,
+      commitSha: 'abc',
+    };
+
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, stats);
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    expect(body).toContain('\u{1F4CA} 3 findings');
+    expect(body).toContain('200 lines');
+    expect(body).toContain('60s');
+    expect(body).toContain('<details>');
+    expect(body).toContain('"model": "claude-sonnet-4-20250514"');
+  });
+
+  it('omits stats section when stats not provided', async () => {
+    const result: ReviewResult = {
+      verdict: 'APPROVE',
+      summary: 'All good.',
+      findings: [],
+      highlights: [],
+      reviewComplete: true,
+    };
+
+    await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    expect(body).not.toContain('\u{1F4CA}');
+    expect(body).not.toContain('Review stats');
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { Finding, FindingSeverity, ParsedDiff, ReviewResult, ReviewVerdict } from './types';
+import { Finding, FindingSeverity, ParsedDiff, ReviewResult, ReviewStats, ReviewVerdict } from './types';
 import { isLineInDiff, findClosestDiffLine } from './diff';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
@@ -230,6 +230,22 @@ export async function dismissPreviousReviews(
   }
 }
 
+function formatStatsOneLiner(stats: ReviewStats): string {
+  const parts: string[] = [];
+  if (stats.severity.required) parts.push(`${stats.severity.required} required`);
+  if (stats.severity.suggestion) parts.push(`${stats.severity.suggestion} suggestion`);
+  if (stats.severity.nit) parts.push(`${stats.severity.nit} nit`);
+  const breakdown = parts.length > 0 ? parts.join(', ') : 'none';
+  const total = stats.findingsKept;
+  const time = Math.round(stats.reviewTimeMs / 1000);
+  return `\u{1F4CA} ${total} findings (${breakdown}) \u00B7 ${stats.diffLines} lines \u00B7 ${time}s`;
+}
+
+function formatStatsJson(stats: ReviewStats): string {
+  const json = JSON.stringify(stats, null, 2);
+  return `<details>\n<summary>Review stats</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
+}
+
 /**
  * Post the review with inline comments.
  */
@@ -241,6 +257,7 @@ export async function postReview(
   commitSha: string,
   result: ReviewResult,
   diff?: ParsedDiff,
+  stats?: ReviewStats,
 ): Promise<number> {
   const event = mapVerdictToEvent(result.verdict);
 
@@ -299,6 +316,10 @@ export async function postReview(
   }
 
   let body = `${BOT_MARKER}\n${sanitizeMarkdown(result.summary)}`;
+  if (stats) {
+    body += `\n\n${formatStatsOneLiner(stats)}`;
+    body += `\n\n${formatStatsJson(stats)}`;
+  }
   if (generalFindings.length > 0) {
     body += `\n\n**General findings:**\n${generalFindings.map(c => `- ${c}`).join('\n')}`;
   }
@@ -854,4 +875,4 @@ export async function fetchSubdirClaudeMd(
   return parts.join('\n\n---\n\n');
 }
 
-export { dynamicFence, formatFindingComment, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_MARKER };
+export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_MARKER };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleReviewCommentReply, handlePRComment } from './interaction';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { fetchRecapState, deduplicateFindings, buildRecapSummary, resolveAddressedThreads } from './recap';
 import { runReview, determineVerdict } from './review';
-import { PrContext } from './types';
+import { PrContext, ReviewStats } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -155,6 +155,7 @@ async function runFullReview(
   prContext?: PrContext,
 ): Promise<void> {
   core.info(`Starting review for ${owner}/${repo}#${prNumber}`);
+  const startTime = Date.now();
 
   const oauthToken = core.getInput('claude_code_oauth_token');
   const apiKey = core.getInput('anthropic_api_key');
@@ -364,8 +365,31 @@ async function runFullReview(
       ? result.findings
       : result.findings.filter(f => f.severity !== 'nit');
 
+    const reviewTimeMs = Date.now() - startTime;
+    const severityMap: Record<string, number> = { required: 0, suggestion: 0, nit: 0 };
+    for (const f of result.findings) {
+      if (f.severity in severityMap) severityMap[f.severity]++;
+    }
+
+    const stats: ReviewStats = {
+      model: reviewerModel,
+      reviewTimeMs,
+      diffLines: diff.totalAdditions + diff.totalDeletions,
+      diffAdditions: diff.totalAdditions,
+      diffDeletions: diff.totalDeletions,
+      filesReviewed: filteredFiles.length,
+      agents: result.agentNames ?? [],
+      findingsRaw: result.rawFindingCount ?? result.findings.length,
+      findingsKept: result.findings.length,
+      findingsDropped: (result.rawFindingCount ?? result.findings.length) - result.findings.length,
+      severity: severityMap,
+      verdict: result.verdict,
+      prNumber,
+      commitSha,
+    };
+
     const reviewResult = { ...result, findings: inlineFindings };
-    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff);
+    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, stats);
 
     if (nitHandling === 'issues' && nitFindings.length > 0) {
       try {

--- a/src/review.ts
+++ b/src/review.ts
@@ -314,6 +314,8 @@ export async function runReview(
     findings: finalFindings,
     highlights: [],
     reviewComplete: true,
+    rawFindingCount: allFindings.length,
+    agentNames: team.agents.map(a => a.name),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface ReviewResult {
   findings: Finding[];
   highlights: string[];
   reviewComplete: boolean;
+  rawFindingCount?: number;
+  agentNames?: string[];
 }
 
 export interface ReviewerAgent {
@@ -90,4 +92,21 @@ export interface PrContext {
   title: string;
   body: string;
   baseBranch: string;
+}
+
+export interface ReviewStats {
+  model: string;
+  reviewTimeMs: number;
+  diffLines: number;
+  diffAdditions: number;
+  diffDeletions: number;
+  filesReviewed: number;
+  agents: string[];
+  findingsRaw: number;
+  findingsKept: number;
+  findingsDropped: number;
+  severity: Record<string, number>;
+  verdict: string;
+  prNumber: number;
+  commitSha: string;
 }


### PR DESCRIPTION
## Summary

- Add `ReviewStats` type with comprehensive metrics for future AI training
- Review event body now includes: summary + stats one-liner + collapsed JSON stats
- Track `rawFindingCount` and `agentNames` through the review pipeline
- `formatStatsOneLiner` shows severity breakdown, line count, and time
- `formatStatsJson` renders collapsed `<details>` with full machine-parseable stats

Closes #204