### PR TITLE
feat: live-updating dashboard progress comment

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,5 +1,5 @@
-import { formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_MARKER, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd } from './github';
-import { Finding, ReviewResult, ReviewStats } from './types';
+import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_MARKER, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd } from './github';
+import { DashboardData, Finding, ReviewResult, ReviewStats } from './types';
 
 describe('formatFindingComment', () => {
   const baseFinding: Finding = {
@@ -1276,5 +1276,53 @@ describe('fetchSubdirClaudeMd', () => {
 
     const result = await fetchSubdirClaudeMd(octokit, 'owner', 'repo', 'abc123', ['package.json']);
     expect(result).toBe('');
+  });
+});
+
+describe('buildDashboard', () => {
+  it('renders the started phase with running review and pending judge', () => {
+    const data: DashboardData = { phase: 'started', lineCount: 150, agentCount: 5 };
+    const md = buildDashboard(data);
+    expect(md).toContain('**Manki** — Review started');
+    expect(md).toContain('Done (150 lines)');
+    expect(md).toContain('Review (5 agents) | Running...');
+    expect(md).toContain('Judge | Pending');
+  });
+
+  it('renders the reviewed phase with finding count and running judge', () => {
+    const data: DashboardData = { phase: 'reviewed', lineCount: 300, agentCount: 3, rawFindingCount: 12 };
+    const md = buildDashboard(data);
+    expect(md).toContain('**Manki** — Review started');
+    expect(md).toContain('Done (300 lines)');
+    expect(md).toContain('Review (3 agents) | Done — 12 findings');
+    expect(md).toContain('Judge | Running...');
+  });
+
+  it('renders the complete phase with kept/dropped counts', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 500, agentCount: 7,
+      rawFindingCount: 20, keptCount: 8, droppedCount: 12,
+    };
+    const md = buildDashboard(data);
+    expect(md).toContain('**Manki** — Review complete');
+    expect(md).toContain('Done (500 lines)');
+    expect(md).toContain('Review (7 agents) | Done — 20 findings');
+    expect(md).toContain('Judge | Done — 8 kept, 12 dropped');
+  });
+
+  it('defaults rawFindingCount to 0 when not provided in reviewed phase', () => {
+    const data: DashboardData = { phase: 'reviewed', lineCount: 100, agentCount: 3 };
+    const md = buildDashboard(data);
+    expect(md).toContain('Done — 0 findings');
+  });
+
+  it('contains a proper markdown table structure', () => {
+    const data: DashboardData = { phase: 'started', lineCount: 50, agentCount: 2 };
+    const md = buildDashboard(data);
+    expect(md).toContain('| | Step | Status |');
+    expect(md).toContain('|---|------|--------|');
+    expect(md).toContain('| 1 |');
+    expect(md).toContain('| 2 |');
+    expect(md).toContain('| 3 |');
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { Finding, FindingSeverity, ParsedDiff, ReviewResult, ReviewStats, ReviewVerdict } from './types';
+import { DashboardData, Finding, FindingSeverity, ParsedDiff, ReviewResult, ReviewStats, ReviewVerdict } from './types';
 import { isLineInDiff, findClosestDiffLine } from './diff';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
@@ -150,6 +150,43 @@ export async function fetchRepoContext(
 }
 
 /**
+ * Build a markdown dashboard table showing review progress across phases.
+ */
+export function buildDashboard(data: DashboardData): string {
+  const parseStatus = `Done (${data.lineCount} lines)`;
+
+  let reviewStatus: string;
+  if (data.phase === 'started') {
+    reviewStatus = 'Running...';
+  } else {
+    reviewStatus = `Done — ${data.rawFindingCount ?? 0} findings`;
+  }
+
+  let judgeStatus: string;
+  if (data.phase === 'started') {
+    judgeStatus = 'Pending';
+  } else if (data.phase === 'reviewed') {
+    judgeStatus = 'Running...';
+  } else {
+    judgeStatus = `Done — ${data.keptCount ?? 0} kept, ${data.droppedCount ?? 0} dropped`;
+  }
+
+  const header = data.phase === 'complete'
+    ? '**Manki** — Review complete'
+    : '**Manki** — Review started';
+
+  return [
+    header,
+    '',
+    '| | Step | Status |',
+    '|---|------|--------|',
+    `| 1 | Parse diff | ${parseStatus} |`,
+    `| 2 | Review (${data.agentCount} agents) | ${reviewStatus} |`,
+    `| 3 | Judge | ${judgeStatus} |`,
+  ].join('\n');
+}
+
+/**
  * Post a "review in progress" comment on the PR.
  * Returns the comment ID so we can update/delete it later.
  */
@@ -158,18 +195,23 @@ export async function postProgressComment(
   owner: string,
   repo: string,
   prNumber: number,
+  dashboard?: DashboardData,
 ): Promise<number> {
+  const body = dashboard
+    ? `${BOT_MARKER}\n${buildDashboard(dashboard)}`
+    : `${BOT_MARKER}\n**Manki** — Review started`;
+
   const { data } = await octokit.rest.issues.createComment({
     owner,
     repo,
     issue_number: prNumber,
-    body: `${BOT_MARKER}\n🔍 **Manki** review in progress...\n\nRunning specialist reviewer agents. This typically takes 1-3 minutes.`,
+    body,
   });
   return data.id;
 }
 
 /**
- * Update the progress comment with the final summary.
+ * Update the progress comment with dashboard state or the final summary.
  */
 export async function updateProgressComment(
   octokit: Octokit,
@@ -177,6 +219,7 @@ export async function updateProgressComment(
   repo: string,
   commentId: number,
   result: ReviewResult,
+  dashboard?: DashboardData,
 ): Promise<void> {
   const emoji = result.verdict === 'APPROVE' ? '✅' : result.verdict === 'REQUEST_CHANGES' ? '❌' : '💬';
   const safeSummary = sanitizeMarkdown(result.summary);
@@ -189,11 +232,31 @@ export async function updateProgressComment(
     ? `\n\n**Highlights:**\n${safeHighlights.map(h => `- ${h}`).join('\n')}`
     : '';
 
+  const dashboardBlock = dashboard ? `${buildDashboard(dashboard)}\n\n---\n\n` : '';
+
   await octokit.rest.issues.updateComment({
     owner,
     repo,
     comment_id: commentId,
-    body: truncateBody(`${BOT_MARKER}\n${emoji} **Manki** — ${result.verdict.replace('_', ' ')}\n\n${safeSummary}${findingsSummary}${highlights}`),
+    body: truncateBody(`${BOT_MARKER}\n${dashboardBlock}${emoji} **Manki** — ${result.verdict.replace('_', ' ')}\n\n${safeSummary}${findingsSummary}${highlights}`),
+  });
+}
+
+/**
+ * Update the progress comment with just a dashboard (no final result yet).
+ */
+export async function updateProgressDashboard(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commentId: number,
+  dashboard: DashboardData,
+): Promise<void> {
+  await octokit.rest.issues.updateComment({
+    owner,
+    repo,
+    comment_id: commentId,
+    body: `${BOT_MARKER}\n${buildDashboard(dashboard)}`,
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handlePRComment } from './interaction';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { fetchRecapState, deduplicateFindings, buildRecapSummary, resolveAddressedThreads } from './recap';
-import { runReview, determineVerdict } from './review';
-import { PrContext, ReviewStats } from './types';
+import { runReview, determineVerdict, selectTeam } from './review';
+import { DashboardData, PrContext, ReviewStats } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -18,6 +18,7 @@ import {
   fetchFileContents,
   postProgressComment,
   updateProgressComment,
+  updateProgressDashboard,
   dismissPreviousReviews,
   postReview,
   createNitIssue,
@@ -208,6 +209,15 @@ async function runFullReview(
 
     const rawDiff = await fetchPRDiff(octokit, owner, repo, prNumber);
     const diff = parsePRDiff(rawDiff);
+    const team = selectTeam(diff, config, config.reviewers);
+    const lineCount = diff.totalAdditions + diff.totalDeletions;
+
+    const dashboard: DashboardData = {
+      phase: 'started',
+      lineCount,
+      agentCount: team.agents.length,
+    };
+    await updateProgressDashboard(octokit, owner, repo, progressCommentId, dashboard);
 
     if (isDiffTooLarge(diff, config.max_diff_lines)) {
       core.warning(`Diff too large (${diff.totalAdditions + diff.totalDeletions} lines > ${config.max_diff_lines} max)`);
@@ -314,7 +324,18 @@ async function runFullReview(
 
     await dismissPreviousReviews(octokit, owner, repo, prNumber);
 
-    const result = await runReview({ reviewer: reviewerClient, judge: judgeClient }, config, diff, rawDiff, fullContext, memory, fileContents, prContext, linkedIssues);
+    let rawFindingCount = 0;
+    const result = await runReview(
+      { reviewer: reviewerClient, judge: judgeClient }, config, diff, rawDiff, fullContext,
+      memory, fileContents, prContext, linkedIssues,
+      (progress) => {
+        rawFindingCount = progress.rawFindingCount;
+        dashboard.phase = 'reviewed';
+        dashboard.rawFindingCount = progress.rawFindingCount;
+        updateProgressDashboard(octokit, owner, repo, progressCommentId, dashboard)
+          .catch(err => core.warning(`Failed to update dashboard: ${err}`));
+      },
+    );
 
     if (!result.reviewComplete && result.verdict === 'APPROVE') {
       result.verdict = 'COMMENT';
@@ -418,7 +439,16 @@ async function runFullReview(
       }
     }
 
-    await updateProgressComment(octokit, owner, repo, progressCommentId, result);
+    const droppedCount = rawFindingCount - result.findings.length;
+    const completeDashboard: DashboardData = {
+      phase: 'complete',
+      lineCount,
+      agentCount: team.agents.length,
+      rawFindingCount,
+      keptCount: result.findings.length,
+      droppedCount: droppedCount >= 0 ? droppedCount : 0,
+    };
+    await updateProgressComment(octokit, owner, repo, progressCommentId, result, completeDashboard);
 
     core.setOutput('review_id', reviewId.toString());
     core.setOutput('verdict', result.verdict);

--- a/src/review.ts
+++ b/src/review.ts
@@ -175,6 +175,11 @@ export interface ReviewClients {
   judge: ClaudeClient;
 }
 
+export interface ReviewProgress {
+  phase: 'reviewed';
+  rawFindingCount: number;
+}
+
 export async function runReview(
   clients: ReviewClients,
   config: ReviewConfig,
@@ -185,6 +190,7 @@ export async function runReview(
   fileContents?: Map<string, string>,
   prContext?: PrContext,
   linkedIssues?: LinkedIssue[],
+  onProgress?: (progress: ReviewProgress) => void,
 ): Promise<ReviewResult> {
   const team = selectTeam(diff, config, config.reviewers);
   core.info(`Review team (${team.level}): ${team.agents.map(a => a.name).join(', ')}`);
@@ -256,6 +262,10 @@ export async function runReview(
       highlights: [],
       reviewComplete: false,
     };
+  }
+
+  if (onProgress) {
+    onProgress({ phase: 'reviewed', rawFindingCount: allFindings.length });
   }
 
   let findingsForJudge = allFindings;

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export interface PrContext {
   baseBranch: string;
 }
 
+
 export interface ReviewStats {
   model: string;
   reviewTimeMs: number;
@@ -109,4 +110,13 @@ export interface ReviewStats {
   verdict: string;
   prNumber: number;
   commitSha: string;
+}
+
+export interface DashboardData {
+  phase: 'started' | 'reviewed' | 'complete';
+  lineCount: number;
+  agentCount: number;
+  rawFindingCount?: number;
+  keptCount?: number;
+  droppedCount?: number;
 }


### PR DESCRIPTION
## Summary

- Add `DashboardData` type and `buildDashboard` function that renders a markdown table tracking review phases
- Progress comment now updates at each phase: parse diff → review agents → judge
- Added `onProgress` callback to `runReview` for intermediate dashboard updates

Closes #203