### PR TITLE
chore: add `codecov.yml` — make coverage checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+    patch:
+      default:
+        target: 0%
+        informational: true
+
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

- Add `codecov.yml` with `informational: true` on both project and patch checks
- Codecov will still report coverage but never block PRs