### PR TITLE
fix: team size label shows actual agent count

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -294,7 +294,7 @@ export async function runReview(
   const verdict = determineVerdict(finalFindings);
 
   const teamNames = team.agents.map(a => a.name).join(', ');
-  const summary = `Reviewed by ${team.agents.length} agents (${team.level}): ${teamNames}. ${finalFindings.length} findings after judge evaluation.`;
+  const summary = `Reviewed by ${team.agents.length} agents: ${teamNames}. ${finalFindings.length} findings after judge evaluation.`;
 
   core.startGroup('Review Summary');
   core.info(`Team: ${teamNames}`);


### PR DESCRIPTION
## Summary

- Remove the `(small)` / `(medium)` / `(large)` level suffix from the review summary
- Label now shows actual agent count: "Reviewed by 6 agents" instead of "Reviewed by 6 agents (small)"

Closes #198