### PR TITLE
fix: code fences in nit issues render at column 0 for GitHub compat

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -625,7 +625,7 @@ export function buildNitIssueBody(
 
     if (f.suggestedFix) {
       const fence = dynamicFence(f.suggestedFix);
-      item += `\n  **Suggested fix:**\n  ${fence}\n  ${f.suggestedFix}\n  ${fence}\n`;
+      item += `\n  **Suggested fix:**\n${fence}\n${f.suggestedFix}\n${fence}\n`;
     }
 
     item += `\n  </details>`;


### PR DESCRIPTION
## Summary

- Remove 2-space indentation from code fence markers in `buildNitIssueBody`
- GitHub's markdown parser doesn't recognize indented fences inside `<details>` blocks, causing the closing `</details>` and footer to be swallowed into the code block

Closes #227