### PR TITLE
feat: AI-generated review summary, text dashboard, clean output

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1283,19 +1283,19 @@ describe('buildDashboard', () => {
   it('renders the started phase with running review and pending judge', () => {
     const data: DashboardData = { phase: 'started', lineCount: 150, agentCount: 5 };
     const md = buildDashboard(data);
-    expect(md).toContain('**Manki** — Review started');
-    expect(md).toContain('Done (150 lines)');
-    expect(md).toContain('Review (5 agents) | Running...');
-    expect(md).toContain('Judge | Pending');
+    expect(md).toContain('**Manki** — Review in progress');
+    expect(md).toContain('\u2713 Parsed diff — 150 lines');
+    expect(md).toContain('\u23F3 Reviewing with 5 agents...');
+    expect(md).toContain('\u25CB Judge — pending');
   });
 
   it('renders the reviewed phase with finding count and running judge', () => {
     const data: DashboardData = { phase: 'reviewed', lineCount: 300, agentCount: 3, rawFindingCount: 12 };
     const md = buildDashboard(data);
-    expect(md).toContain('**Manki** — Review started');
-    expect(md).toContain('Done (300 lines)');
-    expect(md).toContain('Review (3 agents) | Done — 12 findings');
-    expect(md).toContain('Judge | Running...');
+    expect(md).toContain('**Manki** — Review in progress');
+    expect(md).toContain('\u2713 Parsed diff — 300 lines');
+    expect(md).toContain('\u2713 Review — 3 agents \u00B7 12 findings');
+    expect(md).toContain('\u23F3 Running judge...');
   });
 
   it('renders the complete phase with kept/dropped counts', () => {
@@ -1304,25 +1304,22 @@ describe('buildDashboard', () => {
       rawFindingCount: 20, keptCount: 8, droppedCount: 12,
     };
     const md = buildDashboard(data);
-    expect(md).toContain('**Manki** — Review complete');
-    expect(md).toContain('Done (500 lines)');
-    expect(md).toContain('Review (7 agents) | Done — 20 findings');
-    expect(md).toContain('Judge | Done — 8 kept, 12 dropped');
+    expect(md).toContain('\u2713 Parsed diff — 500 lines');
+    expect(md).toContain('\u2713 Review — 7 agents \u00B7 20 findings');
+    expect(md).toContain('\u2713 Judge — 8 kept \u00B7 12 dropped');
   });
 
   it('defaults rawFindingCount to 0 when not provided in reviewed phase', () => {
     const data: DashboardData = { phase: 'reviewed', lineCount: 100, agentCount: 3 };
     const md = buildDashboard(data);
-    expect(md).toContain('Done — 0 findings');
+    expect(md).toContain('0 findings');
   });
 
-  it('contains a proper markdown table structure', () => {
+  it('uses text status lines instead of a table', () => {
     const data: DashboardData = { phase: 'started', lineCount: 50, agentCount: 2 };
     const md = buildDashboard(data);
-    expect(md).toContain('| | Step | Status |');
-    expect(md).toContain('|---|------|--------|');
-    expect(md).toContain('| 1 |');
-    expect(md).toContain('| 2 |');
-    expect(md).toContain('| 3 |');
+    expect(md).not.toContain('| |');
+    expect(md).not.toContain('|---|');
+    expect(md).toContain('\u2713 Parsed diff');
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -150,39 +150,34 @@ export async function fetchRepoContext(
 }
 
 /**
- * Build a markdown dashboard table showing review progress across phases.
+ * Build text status lines showing review progress across phases.
  */
 export function buildDashboard(data: DashboardData): string {
-  const parseStatus = `Done (${data.lineCount} lines)`;
-
-  let reviewStatus: string;
   if (data.phase === 'started') {
-    reviewStatus = 'Running...';
-  } else {
-    reviewStatus = `Done — ${data.rawFindingCount ?? 0} findings`;
+    return [
+      '**Manki** — Review in progress',
+      '',
+      `\u2713 Parsed diff — ${data.lineCount} lines`,
+      `\u23F3 Reviewing with ${data.agentCount} agents...`,
+      `\u25CB Judge — pending`,
+    ].join('\n');
   }
 
-  let judgeStatus: string;
-  if (data.phase === 'started') {
-    judgeStatus = 'Pending';
-  } else if (data.phase === 'reviewed') {
-    judgeStatus = 'Running...';
-  } else {
-    judgeStatus = `Done — ${data.keptCount ?? 0} kept, ${data.droppedCount ?? 0} dropped`;
+  if (data.phase === 'reviewed') {
+    return [
+      '**Manki** — Review in progress',
+      '',
+      `\u2713 Parsed diff — ${data.lineCount} lines`,
+      `\u2713 Review — ${data.agentCount} agents \u00B7 ${data.rawFindingCount ?? 0} findings`,
+      `\u23F3 Running judge...`,
+    ].join('\n');
   }
 
-  const header = data.phase === 'complete'
-    ? '**Manki** — Review complete'
-    : '**Manki** — Review started';
-
+  // phase === 'complete'
   return [
-    header,
-    '',
-    '| | Step | Status |',
-    '|---|------|--------|',
-    `| 1 | Parse diff | ${parseStatus} |`,
-    `| 2 | Review (${data.agentCount} agents) | ${reviewStatus} |`,
-    `| 3 | Judge | ${judgeStatus} |`,
+    `\u2713 Parsed diff — ${data.lineCount} lines`,
+    `\u2713 Review — ${data.agentCount} agents \u00B7 ${data.rawFindingCount ?? 0} findings`,
+    `\u2713 Judge — ${data.keptCount ?? 0} kept \u00B7 ${data.droppedCount ?? 0} dropped`,
   ].join('\n');
 }
 
@@ -220,25 +215,40 @@ export async function updateProgressComment(
   commentId: number,
   result: ReviewResult,
   dashboard?: DashboardData,
+  stats?: ReviewStats,
 ): Promise<void> {
-  const emoji = result.verdict === 'APPROVE' ? '✅' : result.verdict === 'REQUEST_CHANGES' ? '❌' : '💬';
+  const emoji = result.verdict === 'APPROVE' ? '\u2705' : result.verdict === 'REQUEST_CHANGES' ? '\u274C' : '\u{1F4AC}';
+  const verdictLabel = result.verdict.replace('_', ' ');
   const safeSummary = sanitizeMarkdown(result.summary);
-  const findingsSummary = result.findings.length > 0
-    ? `\n\n| Severity | Count |\n|---|---|\n| Required | ${result.findings.filter(f => f.severity === 'required').length} |\n| Suggestions | ${result.findings.filter(f => f.severity === 'suggestion').length} |\n| Nits | ${result.findings.filter(f => f.severity === 'nit').length} |\n| Ignored | ${result.findings.filter(f => f.severity === 'ignore').length} |`
-    : '';
 
-  const safeHighlights = result.highlights.map(h => sanitizeMarkdown(h));
-  const highlights = safeHighlights.length > 0
-    ? `\n\n**Highlights:**\n${safeHighlights.map(h => `- ${h}`).join('\n')}`
-    : '';
+  const statsLine = stats ? formatStatsOneLiner(stats) : '';
+  const dashboardBlock = dashboard ? buildDashboard(dashboard) : '';
 
-  const dashboardBlock = dashboard ? `${buildDashboard(dashboard)}\n\n---\n\n` : '';
+  const parts: string[] = [
+    BOT_MARKER,
+    `**Manki** — ${emoji} ${verdictLabel}`,
+    '',
+    `> ${safeSummary}`,
+  ];
+
+  if (statsLine || dashboardBlock) {
+    const detailsSummary = statsLine || 'Review details';
+    parts.push('');
+    parts.push(`<details>`);
+    parts.push(`<summary>${detailsSummary}</summary>`);
+    parts.push('');
+    if (dashboardBlock) {
+      parts.push(dashboardBlock);
+    }
+    parts.push('');
+    parts.push(`</details>`);
+  }
 
   await octokit.rest.issues.updateComment({
     owner,
     repo,
     comment_id: commentId,
-    body: truncateBody(`${BOT_MARKER}\n${dashboardBlock}${emoji} **Manki** — ${result.verdict.replace('_', ' ')}\n\n${safeSummary}${findingsSummary}${highlights}`),
+    body: truncateBody(parts.join('\n')),
   });
 }
 
@@ -378,7 +388,7 @@ export async function postReview(
     }
   }
 
-  let body = `${BOT_MARKER}\n${sanitizeMarkdown(result.summary)}`;
+  let body = `${BOT_MARKER}\n> ${sanitizeMarkdown(result.summary)}`;
   if (stats) {
     body += `\n\n${formatStatsOneLiner(stats)}`;
     body += `\n\n${formatStatsJson(stats)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,7 +448,7 @@ async function runFullReview(
       keptCount: result.findings.length,
       droppedCount: droppedCount >= 0 ? droppedCount : 0,
     };
-    await updateProgressComment(octokit, owner, repo, progressCommentId, result, completeDashboard);
+    await updateProgressComment(octokit, owner, repo, progressCommentId, result, completeDashboard, stats);
 
     core.setOutput('review_id', reviewId.toString());
     core.setOutput('verdict', result.verdict);

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -304,25 +304,52 @@ describe('extractCodeContext', () => {
 });
 
 describe('parseJudgeResponse', () => {
-  it('parses valid JSON array with all fields', () => {
+  it('parses object format with summary and findings', () => {
+    const json = JSON.stringify({
+      summary: 'Clean PR with one minor issue.',
+      findings: [
+        { title: 'Bug found', severity: 'required', reasoning: 'This is a real bug.', confidence: 'high' },
+      ],
+    });
+
+    const result = parseJudgeResponse(json);
+    expect(result.summary).toBe('Clean PR with one minor issue.');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toBe('Bug found');
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].reasoning).toBe('This is a real bug.');
+    expect(result.findings[0].confidence).toBe('high');
+  });
+
+  it('falls back to default summary when plain array is returned', () => {
     const json = JSON.stringify([
       { title: 'Bug found', severity: 'required', reasoning: 'This is a real bug.', confidence: 'high' },
     ]);
 
     const result = parseJudgeResponse(json);
-    expect(result).toHaveLength(1);
-    expect(result[0].title).toBe('Bug found');
-    expect(result[0].severity).toBe('required');
-    expect(result[0].reasoning).toBe('This is a real bug.');
-    expect(result[0].confidence).toBe('high');
+    expect(result.summary).toBe('Review complete.');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toBe('Bug found');
+  });
+
+  it('falls back to default summary when summary is missing from object', () => {
+    const json = JSON.stringify({
+      findings: [
+        { title: 'Test', severity: 'suggestion', reasoning: 'Okay.', confidence: 'medium' },
+      ],
+    });
+
+    const result = parseJudgeResponse(json);
+    expect(result.summary).toBe('Review complete.');
+    expect(result.findings).toHaveLength(1);
   });
 
   it('parses JSON wrapped in markdown code fences', () => {
     const json = '```json\n[{"title":"Bug","severity":"required","reasoning":"Real bug.","confidence":"high"}]\n```';
 
     const result = parseJudgeResponse(json);
-    expect(result).toHaveLength(1);
-    expect(result[0].title).toBe('Bug');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toBe('Bug');
   });
 
   it('defaults missing confidence to medium', () => {
@@ -331,7 +358,7 @@ describe('parseJudgeResponse', () => {
     ]);
 
     const result = parseJudgeResponse(json);
-    expect(result[0].confidence).toBe('medium');
+    expect(result.findings[0].confidence).toBe('medium');
   });
 
   it('defaults invalid severity to suggestion', () => {
@@ -340,31 +367,33 @@ describe('parseJudgeResponse', () => {
     ]);
 
     const result = parseJudgeResponse(json);
-    expect(result[0].severity).toBe('suggestion');
+    expect(result.findings[0].severity).toBe('suggestion');
   });
 
-  it('returns empty array for empty response', () => {
+  it('returns empty findings for empty response', () => {
     const result = parseJudgeResponse('');
-    expect(result).toEqual([]);
+    expect(result.findings).toEqual([]);
+    expect(result.summary).toBe('Review complete.');
   });
 
-  it('returns empty array for malformed JSON', () => {
+  it('returns empty findings for malformed JSON', () => {
     const result = parseJudgeResponse('not json {broken');
-    expect(result).toEqual([]);
+    expect(result.findings).toEqual([]);
   });
 
-  it('returns empty array for non-array JSON', () => {
+  it('returns empty findings for unrecognized object', () => {
     const result = parseJudgeResponse('{"not": "an array"}');
-    expect(result).toEqual([]);
+    expect(result.findings).toEqual([]);
+    expect(result.summary).toBe('Review complete.');
   });
 
   it('handles missing title and reasoning gracefully', () => {
     const json = JSON.stringify([{ severity: 'nit' }]);
 
     const result = parseJudgeResponse(json);
-    expect(result).toHaveLength(1);
-    expect(result[0].title).toBe('Untitled');
-    expect(result[0].reasoning).toBe('');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toBe('Untitled');
+    expect(result.findings[0].reasoning).toBe('');
   });
 
   it('parses multiple findings', () => {
@@ -374,9 +403,9 @@ describe('parseJudgeResponse', () => {
     ]);
 
     const result = parseJudgeResponse(json);
-    expect(result).toHaveLength(2);
-    expect(result[0].severity).toBe('required');
-    expect(result[1].severity).toBe('ignore');
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[1].severity).toBe('ignore');
   });
 });
 
@@ -434,7 +463,7 @@ describe('runJudgeAgent', () => {
     mockSendMessage.mockReset();
   });
 
-  it('returns empty array for empty findings', async () => {
+  it('returns empty findings with default summary for empty findings', async () => {
     const input: JudgeInput = {
       findings: [],
       diff: makeDiff(),
@@ -443,14 +472,18 @@ describe('runJudgeAgent', () => {
     };
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
-    expect(result).toEqual([]);
+    expect(result.findings).toEqual([]);
+    expect(result.summary).toBe('Review complete.');
     expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
-  it('calls client and returns updated findings', async () => {
-    const judgedResponse = JSON.stringify([
-      { title: 'Unused variable', severity: 'ignore', reasoning: 'False positive.', confidence: 'high' },
-    ]);
+  it('calls client and returns updated findings with summary', async () => {
+    const judgedResponse = JSON.stringify({
+      summary: 'One false positive found.',
+      findings: [
+        { title: 'Unused variable', severity: 'ignore', reasoning: 'False positive.', confidence: 'high' },
+      ],
+    });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
 
     const input: JudgeInput = {
@@ -461,17 +494,21 @@ describe('runJudgeAgent', () => {
     };
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('ignore');
-    expect(result[0].judgeNotes).toBe('False positive.');
-    expect(result[0].judgeConfidence).toBe('high');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].judgeNotes).toBe('False positive.');
+    expect(result.findings[0].judgeConfidence).toBe('high');
+    expect(result.summary).toBe('One false positive found.');
     expect(mockSendMessage).toHaveBeenCalledTimes(1);
   });
 
   it('passes effort option to sendMessage', async () => {
-    const judgedResponse = JSON.stringify([
-      { title: 'Unused variable', severity: 'suggestion', reasoning: 'Real issue.', confidence: 'high' },
-    ]);
+    const judgedResponse = JSON.stringify({
+      summary: 'Real issue found.',
+      findings: [
+        { title: 'Unused variable', severity: 'suggestion', reasoning: 'Real issue.', confidence: 'high' },
+      ],
+    });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
 
     const input: JudgeInput = {
@@ -502,16 +539,19 @@ describe('runJudgeAgent', () => {
     };
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
-    expect(result[0].judgeNotes).toBeUndefined();
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].judgeNotes).toBeUndefined();
   });
 
   it('matches judge findings by fuzzy title when order differs', async () => {
-    const judgedResponse = JSON.stringify([
-      { title: 'Different title', severity: 'nit', reasoning: 'Minor.', confidence: 'low' },
-      { title: 'Unused variable cleanup', severity: 'ignore', reasoning: 'Not real.', confidence: 'high' },
-    ]);
+    const judgedResponse = JSON.stringify({
+      summary: 'Mixed findings.',
+      findings: [
+        { title: 'Different title', severity: 'nit', reasoning: 'Minor.', confidence: 'low' },
+        { title: 'Unused variable cleanup', severity: 'ignore', reasoning: 'Not real.', confidence: 'high' },
+      ],
+    });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
 
     const input: JudgeInput = {
@@ -528,19 +568,22 @@ describe('runJudgeAgent', () => {
     };
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
-    expect(result).toHaveLength(2);
+    expect(result.findings).toHaveLength(2);
     // "Unused variable" should fuzzy-match "Unused variable cleanup" => severity 'ignore'
-    expect(result[0].severity).toBe('ignore');
-    expect(result[0].judgeNotes).toBe('Not real.');
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].judgeNotes).toBe('Not real.');
     // "Something completely different" matches "Different title" by position => severity 'nit'
-    expect(result[1].severity).toBe('nit');
-    expect(result[1].judgeNotes).toBe('Minor.');
+    expect(result.findings[1].severity).toBe('nit');
+    expect(result.findings[1].judgeNotes).toBe('Minor.');
   });
 
   it('includes memory context when memory is provided', async () => {
-    const judgedResponse = JSON.stringify([
-      { title: 'Unused variable', severity: 'ignore', reasoning: 'Suppressed.', confidence: 'high' },
-    ]);
+    const judgedResponse = JSON.stringify({
+      summary: 'Suppressed finding.',
+      findings: [
+        { title: 'Unused variable', severity: 'ignore', reasoning: 'Suppressed.', confidence: 'high' },
+      ],
+    });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
 
     const input: JudgeInput = {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -31,6 +31,11 @@ export interface JudgedFinding {
   confidence: 'high' | 'medium' | 'low';
 }
 
+export interface JudgeResult {
+  summary: string;
+  findings: JudgedFinding[];
+}
+
 const CONTEXT_LINES = 10;
 
 export function buildJudgeSystemPrompt(config: ReviewConfig): string {
@@ -81,20 +86,23 @@ Multiple specialist reviewers may flag the same issue independently. When you se
 
 ## Output Format
 
-Respond with ONLY a JSON array (no markdown fences, no explanation). Each element:
+Respond with ONLY a JSON object (no markdown fences, no explanation):
 
 \`\`\`
-[
-  {
-    "title": "Short title matching or close to the original finding title",
-    "severity": "required" | "suggestion" | "nit" | "ignore",
-    "reasoning": "1-2 sentences explaining your judgment",
-    "confidence": "high" | "medium" | "low"
-  }
-]
+{
+  "summary": "1-2 sentence review summary. Be conversational but professional. Focus on what matters: what was found, what's good, what needs attention. Never list agent names. Never mention agent count or review level. Never say 'after judge evaluation'. For clean PRs: acknowledge briefly. For PRs with findings: highlight the most important finding(s).",
+  "findings": [
+    {
+      "title": "Short title matching or close to the original finding title",
+      "severity": "required" | "suggestion" | "nit" | "ignore",
+      "reasoning": "1-2 sentences explaining your judgment",
+      "confidence": "high" | "medium" | "low"
+    }
+  ]
+}
 \`\`\`
 
-The output array may be shorter than the input when duplicates are merged. Preserve the order of first appearance.`;
+The findings array may be shorter than the input when duplicates are merged. Preserve the order of first appearance.`;
 
   if (config.instructions) {
     prompt += `\n\n## Project Instructions\n\n${config.instructions}`;
@@ -264,25 +272,39 @@ function filterSuppressionsForFindings(suppressions: Suppression[], findings: Fi
   return result;
 }
 
-export function parseJudgeResponse(responseText: string): JudgedFinding[] {
+export function parseJudgeResponse(responseText: string): JudgeResult {
   const jsonText = extractJSON(responseText);
 
   try {
     const parsed = JSON.parse(jsonText);
-    if (!Array.isArray(parsed)) {
-      core.warning(`Judge did not return an array, got: ${typeof parsed}`);
-      return [];
+
+    const parseFindings = (arr: unknown[]): JudgedFinding[] =>
+      arr.map((item: unknown) => item as Record<string, unknown>).map((f) => ({
+        title: String(f.title || 'Untitled'),
+        severity: validateSeverity(f.severity),
+        reasoning: String(f.reasoning || ''),
+        confidence: validateConfidence(f.confidence),
+      }));
+
+    // New object format with summary + findings
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const findings = Array.isArray(parsed.findings) ? parseFindings(parsed.findings) : [];
+      const summary = typeof parsed.summary === 'string' && parsed.summary
+        ? parsed.summary
+        : 'Review complete.';
+      return { summary, findings };
     }
 
-    return parsed.map((f: Record<string, unknown>) => ({
-      title: String(f.title || 'Untitled'),
-      severity: validateSeverity(f.severity),
-      reasoning: String(f.reasoning || ''),
-      confidence: validateConfidence(f.confidence),
-    }));
+    // Backward compat: plain JSON array
+    if (Array.isArray(parsed)) {
+      return { summary: 'Review complete.', findings: parseFindings(parsed) };
+    }
+
+    core.warning(`Judge returned unexpected format: ${typeof parsed}`);
+    return { summary: 'Review complete.', findings: [] };
   } catch (e) {
     core.warning(`Failed to parse judge response: ${e}`);
-    return [];
+    return { summary: 'Review complete.', findings: [] };
   }
 }
 
@@ -297,10 +319,10 @@ export async function runJudgeAgent(
   client: ClaudeClient,
   config: ReviewConfig,
   input: JudgeInput,
-): Promise<Finding[]> {
+): Promise<{ findings: Finding[]; summary: string }> {
   const { findings, diff, memory, prContext, linkedIssues } = input;
 
-  if (findings.length === 0) return [];
+  if (findings.length === 0) return { findings, summary: 'Review complete.' };
 
   const codeContextMap = new Map<string, string>();
   for (const f of findings) {
@@ -320,15 +342,17 @@ export async function runJudgeAgent(
   const userMessage = buildJudgeUserMessage(findings, codeContextMap, memoryContext, prContext, linkedIssues, changedFiles);
 
   const response = await client.sendMessage(systemPrompt, userMessage, { effort: 'high' });
-  const judged = parseJudgeResponse(response.content);
+  const judgeResult = parseJudgeResponse(response.content);
 
-  if (judged.length === 0) {
+  if (judgeResult.findings.length === 0) {
     core.warning('Judge returned no findings — returning originals unchanged');
-    return findings;
+    return { findings, summary: judgeResult.summary };
   }
 
-  const mapped = mapJudgedToFindings(findings, judged);
-  return deduplicateFindings(mapped);
+  return {
+    findings: deduplicateFindings(mapJudgedToFindings(findings, judgeResult.findings)),
+    summary: judgeResult.summary,
+  };
 }
 
 export function mapJudgedToFindings(original: Finding[], judged: JudgedFinding[]): Finding[] {

--- a/src/review.ts
+++ b/src/review.ts
@@ -278,6 +278,7 @@ export async function runReview(
   }
 
   let finalFindings: Finding[];
+  let judgeSummary = 'Review complete.';
   if (findingsForJudge.length === 0) {
     finalFindings = [];
   } else {
@@ -292,9 +293,10 @@ export async function runReview(
         prContext,
         linkedIssues,
       };
-      const judged = await runJudgeAgent(clients.judge, config, judgeInput);
-      finalFindings = judged.filter(f => f.severity !== 'ignore');
-      core.info(`Judge complete: ${finalFindings.length} findings survived (${judged.length - finalFindings.length} ignored)`);
+      const judgeResult = await runJudgeAgent(clients.judge, config, judgeInput);
+      judgeSummary = judgeResult.summary;
+      finalFindings = judgeResult.findings.filter(f => f.severity !== 'ignore');
+      core.info(`Judge complete: ${finalFindings.length} findings survived (${judgeResult.findings.length - finalFindings.length} ignored)`);
     } catch (error) {
       core.warning(`Judge failed: ${error}. Returning reviewer findings without judge evaluation.`);
       finalFindings = allFindings;
@@ -303,11 +305,10 @@ export async function runReview(
 
   const verdict = determineVerdict(finalFindings);
 
-  const teamNames = team.agents.map(a => a.name).join(', ');
-  const summary = `Reviewed by ${team.agents.length} agents: ${teamNames}. ${finalFindings.length} findings after judge evaluation.`;
+  const summary = judgeSummary;
 
   core.startGroup('Review Summary');
-  core.info(`Team: ${teamNames}`);
+  core.info(`Team: ${team.agents.map(a => a.name).join(', ')}`);
   core.info(`Level: ${team.level} (${team.lineCount} lines changed)`);
   core.info(`Verdict: ${verdict}`);
   core.info(`Findings: ${finalFindings.length}`);


### PR DESCRIPTION
## Summary

- Judge now generates a 1-2 sentence AI summary instead of the hardcoded `Reviewed by N agents: ...` template
- Dashboard uses text status lines (✓/⏳/○) instead of markdown tables
- Final progress comment shows verdict + AI summary blockquote + collapsed stats/pipeline details
- Review event body uses AI summary in blockquote format
- Removed duplicated severity count table and highlights from progress comment

Closes #232