### PR TITLE
fix: serialize concurrent `ensureCLI` calls with shared install promise

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -71,12 +71,21 @@ export class ClaudeClient {
           await execFileAsync('npm', ['install', '-g', '@anthropic-ai/claude-code'], {
             timeout: 120000,
           });
-          const { stdout } = await execFileAsync('which', ['claude']);
-          return stdout.trim();
+          try {
+            const { stdout } = await execFileAsync('which', ['claude']);
+            return stdout.trim();
+          } catch {
+            throw new Error('Failed to install Claude CLI');
+          }
         })();
       }
-      this.cachedCLIPath = await cliInstallPromise;
-      return this.cachedCLIPath;
+      try {
+        this.cachedCLIPath = await cliInstallPromise;
+        return this.cachedCLIPath;
+      } catch (error) {
+        cliInstallPromise = null;
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Add module-level `cliInstallPromise` to serialize concurrent CLI install attempts
- When multiple reviewer agents call `ensureCLI()` in parallel, only the first one runs `npm install` — the rest await the same promise
- Fixes `ENOTEMPTY` and `ETXTBSY` errors seen when the CLI is not pre-installed

Closes #246