### PR TITLE
fix: remove blockquote from review summary, separate recap text

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -228,7 +228,7 @@ export async function updateProgressComment(
     BOT_MARKER,
     `**Manki** — ${emoji} ${verdictLabel}`,
     '',
-    `> ${safeSummary}`,
+    safeSummary,
   ];
 
   if (statsLine || dashboardBlock) {
@@ -331,6 +331,7 @@ export async function postReview(
   result: ReviewResult,
   diff?: ParsedDiff,
   stats?: ReviewStats,
+  recapSummary?: string,
 ): Promise<number> {
   const event = mapVerdictToEvent(result.verdict);
 
@@ -388,7 +389,10 @@ export async function postReview(
     }
   }
 
-  let body = `${BOT_MARKER}\n> ${sanitizeMarkdown(result.summary)}`;
+  let body = `${BOT_MARKER}\n${sanitizeMarkdown(result.summary)}`;
+  if (recapSummary) {
+    body += `\n\n${recapSummary}`;
+  }
   if (stats) {
     body += `\n\n${formatStatsOneLiner(stats)}`;
     body += `\n\n${formatStatsJson(stats)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,7 +356,6 @@ async function runFullReview(
     const resolved = recap.previousFindings.filter(f => f.status === 'resolved').length;
     const open = recap.previousFindings.filter(f => f.status === 'open').length;
     const recapSummary = buildRecapSummary(result.findings.length, duplicates.length, resolved, open);
-    result.summary = `${result.summary}\n\n${recapSummary}`;
 
     // Enrich findings with code context from the diff for nit issues
     for (const finding of result.findings) {
@@ -410,7 +409,7 @@ async function runFullReview(
     };
 
     const reviewResult = { ...result, findings: inlineFindings };
-    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, stats);
+    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, stats, recapSummary);
 
     if (nitHandling === 'issues' && nitFindings.length > 0) {
       try {


### PR DESCRIPTION
## Summary

- Remove `> ` blockquote prefix from AI summary in both review body and progress comment
- Stop appending recap text ("Findings: N new") to `result.summary` — pass as separate parameter to `postReview`
- Recap info now appears as its own line between summary and stats

Closes #240