### PR TITLE
fix: triage parser matches new `<details>` nit issue format

### DIFF
--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -1,4 +1,4 @@
-import { parseCommand, buildReplyContext, ParsedCommand, isBotComment, hasBotMention } from './interaction';
+import { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, isBotComment, hasBotMention } from './interaction';
 
 describe('parseCommand', () => {
   it('parses @manki explain with args', () => {
@@ -128,6 +128,64 @@ describe('parseCommand', () => {
     expect(result).toEqual<ParsedCommand>({ type: 'triage', args: '' });
   });
 
+});
+
+describe('parseTriageBody', () => {
+  it('parses old backtick format with suggestion and question emojis', () => {
+    const body = [
+      '- [x] 💡 **Null check missing** — `src/index.ts:42`',
+      '- [ ] ❓ **Unused import** — `src/utils.ts:10`',
+    ].join('\n');
+    const result = parseTriageBody(body);
+    expect(result.accepted).toEqual([{ title: 'Null check missing', ref: 'src/index.ts:42' }]);
+    expect(result.rejected).toEqual([{ title: 'Unused import', ref: 'src/utils.ts:10' }]);
+  });
+
+  it('parses new details/summary format with code tags', () => {
+    const body = [
+      '- [x] <details><summary>📝 **Style nit** — <code>src/app.ts:7</code></summary>',
+      '',
+      'Consider using const instead of let.',
+      '</details>',
+      '- [ ] <details><summary>📝 **Rename variable** — <code>src/app.ts:15</code></summary>',
+      '',
+      'Use a more descriptive name.',
+      '</details>',
+    ].join('\n');
+    const result = parseTriageBody(body);
+    expect(result.accepted).toEqual([{ title: 'Style nit', ref: 'src/app.ts:7' }]);
+    expect(result.rejected).toEqual([{ title: 'Rename variable', ref: 'src/app.ts:15' }]);
+  });
+
+  it('parses blocker emoji in new format', () => {
+    const body = '- [x] <details><summary>🚫 **Security flaw** — <code>src/auth.ts:99</code></summary>\n</details>';
+    const result = parseTriageBody(body);
+    expect(result.accepted).toEqual([{ title: 'Security flaw', ref: 'src/auth.ts:99' }]);
+  });
+
+  it('handles mix of old and new formats', () => {
+    const body = [
+      '- [x] 💡 **Old finding** — `src/old.ts:1`',
+      '- [x] <details><summary>📝 **New finding** — <code>src/new.ts:2</code></summary>',
+      '</details>',
+      '- [ ] ❓ **Old rejected** — `src/old.ts:5`',
+      '- [ ] <details><summary>🚫 **New rejected** — <code>src/new.ts:8</code></summary>',
+      '</details>',
+    ].join('\n');
+    const result = parseTriageBody(body);
+    expect(result.accepted).toHaveLength(2);
+    expect(result.rejected).toHaveLength(2);
+    expect(result.accepted[0].title).toBe('Old finding');
+    expect(result.accepted[1].title).toBe('New finding');
+    expect(result.rejected[0].title).toBe('Old rejected');
+    expect(result.rejected[1].title).toBe('New rejected');
+  });
+
+  it('returns empty arrays when no findings match', () => {
+    const result = parseTriageBody('No findings here.');
+    expect(result.accepted).toEqual([]);
+    expect(result.rejected).toEqual([]);
+  });
 });
 
 describe('buildReplyContext', () => {

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -564,19 +564,7 @@ async function handleTriage(
   const { data: issue } = await octokit.rest.issues.get({ owner, repo, issue_number: issueNumber });
   const body = issue.body ?? '';
 
-  const checkedRegex = /^- \[x\] [💡❓] \*\*(.+?)\*\* — `(.+?)`/gmiu;
-  const uncheckedRegex = /^- \[ \] [💡❓] \*\*(.+?)\*\* — `(.+?)`/gmu;
-
-  const accepted: Array<{ title: string; ref: string }> = [];
-  const rejected: Array<{ title: string; ref: string }> = [];
-
-  let match;
-  while ((match = checkedRegex.exec(body)) !== null) {
-    accepted.push({ title: match[1], ref: match[2] });
-  }
-  while ((match = uncheckedRegex.exec(body)) !== null) {
-    rejected.push({ title: match[1], ref: match[2] });
-  }
+  const { accepted, rejected } = parseTriageBody(body);
 
   if (accepted.length === 0 && rejected.length === 0) {
     await octokit.rest.issues.createComment({
@@ -590,7 +578,7 @@ async function handleTriage(
   const createdIssues: number[] = [];
   for (const item of accepted) {
     const sectionRegex = new RegExp(
-      `- \\[x\\] [💡❓] \\*\\*${escapeRegex(item.title)}\\*\\*[\\s\\S]*?(?=\\n- \\[|\\n---|$)`,
+      `- \\[x\\] (?:<details><summary>)?[📝💡❓🚫] \\*\\*${escapeRegex(item.title)}\\*\\*[\\s\\S]*?(?=\\n- \\[|\\n---|$)`,
       'iu',
     );
     const sectionMatch = body.match(sectionRegex);
@@ -733,4 +721,32 @@ function hasBotMention(body: string): boolean {
   return BOT_MENTION_PATTERN.test(body.toLowerCase());
 }
 
-export { parseCommand, buildReplyContext, ParsedCommand, BOT_MARKER, isBotComment, hasBotMention };
+interface TriageFinding {
+  title: string;
+  ref: string;
+}
+
+interface TriageResult {
+  accepted: TriageFinding[];
+  rejected: TriageFinding[];
+}
+
+function parseTriageBody(body: string): TriageResult {
+  const checkedRegex = /^- \[x\] (?:<details><summary>)?[📝💡❓🚫] \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmiu;
+  const uncheckedRegex = /^- \[ \] (?:<details><summary>)?[📝💡❓🚫] \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmu;
+
+  const accepted: TriageFinding[] = [];
+  const rejected: TriageFinding[] = [];
+
+  let match;
+  while ((match = checkedRegex.exec(body)) !== null) {
+    accepted.push({ title: match[1], ref: match[2] });
+  }
+  while ((match = uncheckedRegex.exec(body)) !== null) {
+    rejected.push({ title: match[1], ref: match[2] });
+  }
+
+  return { accepted, rejected };
+}
+
+export { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, TriageFinding, TriageResult, BOT_MARKER, isBotComment, hasBotMention };


### PR DESCRIPTION
## Summary

- Update triage regex to match new `<details><summary>` nit issue format alongside old backtick format
- Support all four severity emojis (📝💡❓🚫)
- Match both `<code>` tags and backticks for file references
- Extract `parseTriageBody()` for testability

Closes #260