### PR TITLE
fix: `isReviewRequest` and `hasBotMention` support all command prefixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { createAuthenticatedOctokit, getMemoryToken } from './auth';
 import { ClaudeClient } from './claude';
 import { loadConfig, resolveModel } from './config';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
-import { handleReviewCommentReply, handlePRComment, BOT_MENTION_PATTERN } from './interaction';
+import { handleReviewCommentReply, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention } from './interaction';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { fetchRecapState, deduplicateFindings, buildRecapSummary, resolveAddressedThreads } from './recap';
 import { runReview, determineVerdict, selectTeam } from './review';
@@ -54,11 +54,12 @@ async function run(): Promise<void> {
 
       case 'issue_comment':
         if (action === 'created') {
-          if (isReviewRequest() && github.context.payload.issue?.pull_request) {
+          const commentBody = github.context.payload.comment?.body ?? '';
+          if (isReviewRequest(commentBody) && github.context.payload.issue?.pull_request) {
             await handleCommentTrigger();
-          } else if (hasBotMention() && github.context.payload.issue?.pull_request) {
+          } else if (isBotMentionNonReview(commentBody) && github.context.payload.issue?.pull_request) {
             await handleInteraction();
-          } else if (hasBotMention() && !github.context.payload.issue?.pull_request) {
+          } else if (isBotMentionNonReview(commentBody) && !github.context.payload.issue?.pull_request) {
             await handleIssueInteraction();
           }
         }
@@ -547,21 +548,6 @@ async function handleReviewStateCheck(): Promise<void> {
   }
 }
 
-function isReviewRequest(): boolean {
-  const comment = github.context.payload.comment;
-  if (!comment) return false;
-
-  const body = comment.body?.toLowerCase() ?? '';
-  return BOT_MENTION_PATTERN.test(body) && body.includes('review');
-}
-
-function hasBotMention(): boolean {
-  const comment = github.context.payload.comment;
-  if (!comment) return false;
-
-  const body = comment.body?.toLowerCase() ?? '';
-  return BOT_MENTION_PATTERN.test(body) && !body.includes('review');
-}
 
 async function handleInteraction(): Promise<void> {
   const oauthToken = core.getInput('claude_code_oauth_token');
@@ -640,9 +626,9 @@ async function handleReviewCommentInteraction(): Promise<void> {
   }
 
   // Only respond if this is a reply to a bot comment or mentions @manki
-  const body = comment.body?.toLowerCase() ?? '';
+  const body = comment.body ?? '';
   const isReplyToBot = !!comment.in_reply_to_id; // handleReviewCommentReply will verify it's actually our comment
-  const mentionsBot = body.includes('@manki');
+  const mentionsBot = hasBotMention(body);
 
   if (!isReplyToBot && !mentionsBot) {
     core.info('Review comment is not a reply to bot or @manki mention — skipping');

--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -1,4 +1,4 @@
-import { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, isBotComment, hasBotMention } from './interaction';
+import { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, isBotComment, hasBotMention, isReviewRequest, isBotMentionNonReview } from './interaction';
 
 describe('parseCommand', () => {
   it('parses @manki explain with args', () => {
@@ -295,5 +295,56 @@ describe('hasBotMention', () => {
 
   it('is case-insensitive for @manki-labs', () => {
     expect(hasBotMention('@MANKI-LABS help')).toBe(true);
+  });
+});
+
+describe('isReviewRequest', () => {
+  it('detects @manki review', () => {
+    expect(isReviewRequest('@manki review')).toBe(true);
+  });
+
+  it('detects /manki review', () => {
+    expect(isReviewRequest('/manki review')).toBe(true);
+  });
+
+  it('detects @manki-labs review', () => {
+    expect(isReviewRequest('@manki-labs review')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isReviewRequest('@Manki Review')).toBe(true);
+  });
+
+  it('returns false for non-review commands', () => {
+    expect(isReviewRequest('@manki explain')).toBe(false);
+    expect(isReviewRequest('/manki help')).toBe(false);
+  });
+
+  it('returns false for text without bot mention', () => {
+    expect(isReviewRequest('please review this')).toBe(false);
+  });
+});
+
+describe('isBotMentionNonReview', () => {
+  it('detects @manki explain', () => {
+    expect(isBotMentionNonReview('@manki explain')).toBe(true);
+  });
+
+  it('detects /manki help', () => {
+    expect(isBotMentionNonReview('/manki help')).toBe(true);
+  });
+
+  it('detects @manki-labs dismiss', () => {
+    expect(isBotMentionNonReview('@manki-labs dismiss')).toBe(true);
+  });
+
+  it('returns false for review commands', () => {
+    expect(isBotMentionNonReview('@manki review')).toBe(false);
+    expect(isBotMentionNonReview('/manki review')).toBe(false);
+    expect(isBotMentionNonReview('@manki-labs review')).toBe(false);
+  });
+
+  it('returns false for text without bot mention', () => {
+    expect(isBotMentionNonReview('just a comment')).toBe(false);
   });
 });

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -749,4 +749,12 @@ function parseTriageBody(body: string): TriageResult {
   return { accepted, rejected };
 }
 
-export { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, TriageFinding, TriageResult, BOT_MARKER, BOT_MENTION_PATTERN, isBotComment, hasBotMention };
+function isReviewRequest(body: string): boolean {
+  return BOT_MENTION_PATTERN.test(body.toLowerCase()) && /\breview\b/i.test(body);
+}
+
+function isBotMentionNonReview(body: string): boolean {
+  return BOT_MENTION_PATTERN.test(body.toLowerCase()) && !/\breview\b/i.test(body);
+}
+
+export { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, TriageFinding, TriageResult, BOT_MARKER, BOT_MENTION_PATTERN, isBotComment, hasBotMention, isReviewRequest, isBotMentionNonReview };


### PR DESCRIPTION
## Summary

- Import `BOT_MENTION_PATTERN` from `interaction.ts` into `index.ts`
- Replace hardcoded `@manki` checks in `isReviewRequest()` and `hasBotMention()` with shared pattern
- Fixes `/manki review` and `@manki-labs review` not triggering reviews

Closes #263