### PR TITLE
chore: enforce 88% project coverage and 80% patch coverage via Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,13 +2,13 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 5%
-        informational: true
+        target: 88%
+        threshold: 2%
+        informational: false
     patch:
       default:
-        target: 0%
-        informational: true
+        target: 80%
+        informational: false
 
 comment:
   layout: "diff, files"


### PR DESCRIPTION
## Summary

- Set `informational: false` on both project and patch Codecov checks — they now block PRs
- Project target: 88% with 2% threshold (allows minor fluctuation from current 90%)
- Patch target: 80% (new code must be well-tested)

Part of #277