### PR TITLE
fix: prevent bot self-triggering on `pull_request_review` events

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -168,6 +168,40 @@ describe('run', () => {
         'Ignoring event from bot: github-actions[bot]',
       );
     });
+
+    it('ignores pull_request_review events where review author is manki-labs[bot]', async () => {
+      setContext({
+        eventName: 'pull_request_review',
+        payload: {
+          action: 'submitted',
+          review: { user: { login: 'manki-labs[bot]' } },
+          pull_request: { number: 1, base: { ref: 'main' } },
+        },
+      });
+
+      await run();
+
+      expect(jest.mocked(core.info)).toHaveBeenCalledWith(
+        'Ignoring event from bot: manki-labs[bot]',
+      );
+    });
+
+    it('ignores pull_request_review events where review author is github-actions[bot]', async () => {
+      setContext({
+        eventName: 'pull_request_review',
+        payload: {
+          action: 'submitted',
+          review: { user: { login: 'github-actions[bot]' } },
+          pull_request: { number: 1, base: { ref: 'main' } },
+        },
+      });
+
+      await run();
+
+      expect(jest.mocked(core.info)).toHaveBeenCalledWith(
+        'Ignoring event from bot: github-actions[bot]',
+      );
+    });
   });
 
   describe('pull_request event filtering', () => {
@@ -581,6 +615,28 @@ describe('handleReviewStateCheck', () => {
     expect(jest.mocked(core.info)).toHaveBeenCalledWith(
       'No pull request in payload — skipping auto-approve check',
     );
+  });
+
+  it('skips auto-approve when review is for a stale commit', async () => {
+    setContext({
+      eventName: 'pull_request_review',
+      payload: {
+        action: 'submitted',
+        review: { commit_id: 'old-sha-111' },
+        pull_request: {
+          number: 1,
+          head: { sha: 'new-sha-222' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+
+    await handleReviewStateCheck();
+
+    expect(jest.mocked(core.info)).toHaveBeenCalledWith(
+      'Review is for stale commit old-sha-111, HEAD is new-sha-222 — skipping auto-approve',
+    );
+    expect(jest.mocked(stateModule.checkAndAutoApprove)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,10 @@ async function run(): Promise<void> {
 
   // Prevent self-triggering — skip events caused by our own bot
   const actor = github.context.payload.sender?.login ?? '';
-  if (actor === 'manki-labs[bot]' || actor === 'github-actions[bot]') {
-    core.info(`Ignoring event from bot: ${actor}`);
+  const reviewAuthor = github.context.payload.review?.user?.login ?? '';
+  if (actor === 'manki-labs[bot]' || actor === 'github-actions[bot]' ||
+      reviewAuthor === 'manki-labs[bot]' || reviewAuthor === 'github-actions[bot]') {
+    core.info(`Ignoring event from bot: ${actor || reviewAuthor}`);
     return;
   }
 
@@ -552,6 +554,13 @@ async function handleReviewStateCheck(): Promise<void> {
   const pr = github.context.payload.pull_request;
   if (!pr) {
     core.info('No pull request in payload — skipping auto-approve check');
+    return;
+  }
+
+  const reviewSha = github.context.payload.review?.commit_id;
+  const headSha = github.context.payload.pull_request?.head?.sha;
+  if (reviewSha && headSha && reviewSha !== headSha) {
+    core.info(`Review is for stale commit ${reviewSha}, HEAD is ${headSha} — skipping auto-approve`);
     return;
   }
 


### PR DESCRIPTION
## Summary

- Check `review.user.login` for bot actor (not just `sender`) to catch bot's own review submissions
- Add stale commit SHA guard in auto-approve — skip if review targets an outdated commit

Closes #288