### PR TITLE
chore: raise Codecov project coverage target to 95%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 88%
+        target: 95%
         threshold: 2%
         informational: false
     patch:


### PR DESCRIPTION
## Summary

- Raise project coverage target from 88% to 95% (current: 96%)
- Threshold stays at 2% (effective minimum: 93%)

Part of #277