### PR TITLE
feat: judge improvements — consensus weighting, acceptance criteria, impact x likelihood

### DIFF
--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -139,17 +139,41 @@ describe('buildJudgeSystemPrompt', () => {
     expect(prompt).toContain('Null/undefined dereference');
     expect(prompt).toContain('Missing error handling');
     // suggestion examples
-    expect(prompt).toContain('logging "failed"');
+    expect(prompt).toContain('Error message lacks context');
     expect(prompt).toContain('const');
-    expect(prompt).toContain('reusable helper');
+    expect(prompt).toContain('extracting a helper');
     // nit examples
-    expect(prompt).toContain('connectionCount');
+    expect(prompt).toContain('Variable name could be more descriptive');
     expect(prompt).toContain('import ordering');
     expect(prompt).toContain('JSDoc');
     // ignore examples (judge only)
     expect(prompt).toContain('TODO with a tracking issue');
     expect(prompt).toContain('workaround documented');
-    expect(prompt).toContain('ternary vs if/else');
+    expect(prompt).toContain('Style preference that does not affect correctness');
+  });
+
+  it('contains Reviewer Consensus section', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('## Reviewer Consensus');
+    expect(prompt).toContain('3+ reviewers flagged it');
+    expect(prompt).toContain('2 reviewers flagged it');
+    expect(prompt).toContain('1 reviewer flagged it');
+  });
+
+  it('contains Acceptance Criteria section', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('## Acceptance Criteria');
+    expect(prompt).toContain('unmet acceptance criterion');
+    expect(prompt).toContain('partially met criterion');
+  });
+
+  it('contains Impact and Likelihood severity framework', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig());
+    expect(prompt).toContain('## Severity Assessment');
+    expect(prompt).toContain('**Impact**');
+    expect(prompt).toContain('**Likelihood**');
+    expect(prompt).toContain('**Severity mapping:**');
+    expect(prompt).toContain('Critical/High impact + Certain/Probable likelihood');
   });
 });
 

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -41,26 +41,51 @@ const CONTEXT_LINES = 10;
 export function buildJudgeSystemPrompt(config: ReviewConfig): string {
   let prompt = `You are a code review judge. You evaluate findings from multiple specialist reviewers for accuracy, actionability, and severity.
 
-## Severity Scale
+## Severity Assessment
 
-- **required**: Issues that should be fixed before merge. This includes bugs, security vulnerabilities, data corruption, crashes, incorrect behavior, missing error handling that causes silent failures, logic errors that produce wrong results, and patterns the project has flagged as important in its review memory.
+Evaluate each finding on two dimensions:
+
+**Impact** — How bad is it if this issue manifests?
+- Critical: data loss, security breach, crash, broken core functionality
+- High: incorrect behavior, silent failures, missing error handling that loses information
+- Medium: degraded experience, confusing behavior, inconsistency, tech debt
+- Low: cosmetic, style, naming, minor readability
+
+**Likelihood** — How likely is this issue to actually occur?
+- Certain: will happen on every execution of the affected code path
+- Probable: will happen under common conditions or normal usage
+- Possible: could happen under specific edge cases or unusual input
+- Unlikely: requires unusual circumstances or rare conditions
+
+**Severity mapping:**
+- **required**: Critical/High impact + Certain/Probable likelihood, OR any Critical impact, OR patterns flagged as important in project memory
+- **suggestion**: High impact + Possible likelihood, Medium impact + Certain/Probable likelihood, or any finding worth addressing but not blocking
+- **nit**: Low impact regardless of likelihood, or Medium impact + Unlikely likelihood
+- **ignore**: False positives, intentional patterns, style preferences, reviewer misunderstandings
+
+Include your impact and likelihood assessment in the reasoning field (e.g., "Impact: High (silent data loss), Likelihood: Probable (happens on every error path) → required").
+
+Examples of **required** (high impact, certain/probable):
   - SQL injection or unsanitized user input passed to any external system
   - Null/undefined dereference that will crash at runtime
   - Missing error handling that silently swallows failures
-  - Logic error that produces incorrect results under certain conditions
+  - Logic error that produces incorrect results under common conditions
   - Breaking API change without migration path
-- **suggestion**: Code clarity, readability, minor optimizations, design improvements. Worth doing but not blocking.
-  - Error message lacks context (e.g., logging "failed" without the error reason)
-  - Variable could be \`const\` instead of \`let\` since it is never reassigned
-  - Function could be simplified by extracting a reusable helper
-- **nit**: Typos, naming nitpicks, minor style issues. Entirely optional.
-  - Variable name could be more descriptive (e.g., \`x\` → \`connectionCount\`)
-  - Inconsistent import ordering compared to rest of file
+
+Examples of **suggestion** (medium impact or lower likelihood):
+  - Error message lacks context (impact: medium, likelihood: certain)
+  - Variable could be \`const\` instead of \`let\` (impact: low, likelihood: certain → actually a nit)
+  - Function could be simplified by extracting a helper (impact: medium, likelihood: N/A)
+
+Examples of **nit**:
+  - Variable name could be more descriptive
+  - Inconsistent import ordering
   - Missing JSDoc on an exported function
-- **ignore**: False positives, intentional patterns, reviewer misunderstandings. Will be dropped.
+
+Examples of **ignore**:
   - Intentional TODO with a tracking issue number
   - Known workaround documented in comments
-  - Style preference that does not affect correctness (e.g., ternary vs if/else)
+  - Style preference that does not affect correctness
 
 ## Evaluation Criteria
 
@@ -72,10 +97,29 @@ For each finding, evaluate:
 
 ## Guidelines
 
-- Respect the project's review memory when calibrating severity. If the project has learned that certain patterns matter (e.g., error handling, type safety), keep findings about those patterns at higher severity.
-- Trust reviewer severity unless you have clear evidence it's overstated. The reviewers see the full code context — don't downgrade just because a finding isn't a crash-level bug.
+- Respect the project's review memory when calibrating severity. If the project has learned that certain patterns matter, keep findings about those patterns at higher severity.
+- Trust reviewer severity unless you have clear evidence it's overstated. The reviewers see the full code context.
+- When multiple reviewers agree, give their consensus significant weight.
 - Be liberal with \`ignore\` — actively filter noise and false positives.
 - If a reviewer flags something that looks intentional or is a matter of preference, mark it \`ignore\`.
+- When downgrading a finding that multiple reviewers flagged, explicitly explain why in your reasoning.
+
+## Reviewer Consensus
+
+When evaluating severity, consider how many reviewers independently flagged each finding (visible in the reviewers list):
+- **3+ reviewers flagged it** — strong signal. Default to keeping the reviewer's severity. Only downgrade if you're certain it's a false positive.
+- **2 reviewers flagged it** — moderate signal. Trust the severity unless you have specific evidence to downgrade.
+- **1 reviewer flagged it** — use your independent judgment. May downgrade or ignore if not convincing.
+
+Multiple independent reviewers reaching the same conclusion is strong evidence that the finding is real. Downgrading a consensus finding requires explicit justification in your reasoning.
+
+## Acceptance Criteria
+
+If the PR description or linked issues contain acceptance criteria (checkbox items like "- [ ] criterion"):
+- Check if each criterion is addressed by the changes in this PR
+- An unmet acceptance criterion that the PR claims to implement should be flagged as \`required\`
+- A partially met criterion should be flagged as \`suggestion\` with details on what's missing
+- Acceptance criteria from the issue that are clearly out of scope for this specific PR can be ignored
 
 ## Duplicate Detection
 


### PR DESCRIPTION
## Summary

- Add consensus weighting: 3+ reviewers = strong signal, 1 reviewer = use judgment
- Add acceptance criteria enforcement: unmet criteria from linked issues = required
- Replace flat severity scale with Impact x Likelihood matrix (inspired by SonarQube)
- Updated guidelines to respect consensus and explain downgrades

Closes #305