### PR TITLE
fix: filter all bot events by `sender.type` instead of hardcoded names

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -146,38 +146,25 @@ describe('run', () => {
   });
 
   describe('bot self-triggering prevention', () => {
-    it('ignores events from manki-labs[bot]', async () => {
+    it('ignores events from any bot sender', async () => {
       setContext({
         eventName: 'pull_request',
-        payload: { action: 'opened', sender: { login: 'manki-labs[bot]' } },
+        payload: { action: 'opened', sender: { login: 'dependabot[bot]', type: 'Bot' } },
       });
 
       await run();
 
       expect(jest.mocked(core.info)).toHaveBeenCalledWith(
-        'Ignoring event from bot: manki-labs[bot]',
+        'Ignoring event from bot: dependabot[bot]',
       );
     });
 
-    it('ignores events from github-actions[bot]', async () => {
-      setContext({
-        eventName: 'pull_request',
-        payload: { action: 'opened', sender: { login: 'github-actions[bot]' } },
-      });
-
-      await run();
-
-      expect(jest.mocked(core.info)).toHaveBeenCalledWith(
-        'Ignoring event from bot: github-actions[bot]',
-      );
-    });
-
-    it('ignores pull_request_review events where review author is manki-labs[bot]', async () => {
+    it('ignores pull_request_review events where review author is a bot', async () => {
       setContext({
         eventName: 'pull_request_review',
         payload: {
           action: 'submitted',
-          review: { user: { login: 'manki-labs[bot]' } },
+          review: { user: { login: 'manki-labs[bot]', type: 'Bot' } },
           pull_request: { number: 1, base: { ref: 'main' } },
         },
       });
@@ -189,20 +176,20 @@ describe('run', () => {
       );
     });
 
-    it('ignores pull_request_review events where review author is github-actions[bot]', async () => {
+    it('does not ignore events from human users', async () => {
       setContext({
-        eventName: 'pull_request_review',
+        eventName: 'pull_request',
         payload: {
-          action: 'submitted',
-          review: { user: { login: 'github-actions[bot]' } },
-          pull_request: { number: 1, base: { ref: 'main' } },
+          action: 'opened',
+          sender: { login: 'some-user', type: 'User' },
+          pull_request: { number: 1, head: { sha: 'abc' }, base: { ref: 'main' }, title: 'Test', body: '', draft: false },
         },
       });
 
       await run();
 
-      expect(jest.mocked(core.info)).toHaveBeenCalledWith(
-        'Ignoring event from bot: github-actions[bot]',
+      expect(jest.mocked(core.info)).not.toHaveBeenCalledWith(
+        expect.stringContaining('Ignoring event from bot'),
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,12 +44,12 @@ async function run(): Promise<void> {
 
   core.info(`Event: ${eventName}, Action: ${action}`);
 
-  // Prevent self-triggering — skip events caused by our own bot
-  const actor = github.context.payload.sender?.login ?? '';
-  const reviewAuthor = github.context.payload.review?.user?.login ?? '';
-  if (actor === 'manki-labs[bot]' || actor === 'github-actions[bot]' ||
-      reviewAuthor === 'manki-labs[bot]' || reviewAuthor === 'github-actions[bot]') {
-    core.info(`Ignoring event from bot: ${actor || reviewAuthor}`);
+  // Prevent self-triggering — skip events caused by any bot
+  const senderType = github.context.payload.sender?.type ?? '';
+  const reviewAuthorType = github.context.payload.review?.user?.type ?? '';
+  if (senderType === 'Bot' || reviewAuthorType === 'Bot') {
+    const actor = github.context.payload.sender?.login ?? github.context.payload.review?.user?.login ?? 'unknown bot';
+    core.info(`Ignoring event from bot: ${actor}`);
     return;
   }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `manki-labs[bot]` / `github-actions[bot]` checks with universal `sender.type === 'Bot'`
- Catches all bots (codecov, dependabot, renovate, etc.) without maintaining a list
- Also checks `review.user.type` for `pull_request_review` events

Closes #312