### PR TITLE
feat: improve triage-created issues with prefix, clean body, structured format

### DIFF
--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -1,4 +1,4 @@
-import { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, isBotComment, hasBotMention, isReviewRequest, isBotMentionNonReview, handlePRComment, handleReviewCommentReply } from './interaction';
+import { parseCommand, buildReplyContext, parseTriageBody, extractFindingContent, triageTitlePrefix, extractPrNumber, ParsedCommand, isBotComment, hasBotMention, isReviewRequest, isBotMentionNonReview, handlePRComment, handleReviewCommentReply } from './interaction';
 import { ReviewConfig } from './types';
 import * as github from '@actions/github';
 import * as core from '@actions/core';
@@ -179,8 +179,13 @@ describe('parseTriageBody', () => {
       '- [ ] ❓ **Unused import** — `src/utils.ts:10`',
     ].join('\n');
     const result = parseTriageBody(body);
-    expect(result.accepted).toEqual([{ title: 'Null check missing', ref: 'src/index.ts:42' }]);
-    expect(result.rejected).toEqual([{ title: 'Unused import', ref: 'src/utils.ts:10' }]);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].title).toBe('Null check missing');
+    expect(result.accepted[0].ref).toBe('src/index.ts:42');
+    expect(result.accepted[0].section).toContain('Null check missing');
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].title).toBe('Unused import');
+    expect(result.rejected[0].ref).toBe('src/utils.ts:10');
   });
 
   it('parses new details/summary format with code tags', () => {
@@ -195,14 +200,21 @@ describe('parseTriageBody', () => {
       '</details>',
     ].join('\n');
     const result = parseTriageBody(body);
-    expect(result.accepted).toEqual([{ title: 'Style nit', ref: 'src/app.ts:7' }]);
-    expect(result.rejected).toEqual([{ title: 'Rename variable', ref: 'src/app.ts:15' }]);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].title).toBe('Style nit');
+    expect(result.accepted[0].ref).toBe('src/app.ts:7');
+    expect(result.accepted[0].section).toContain('Consider using const');
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].title).toBe('Rename variable');
+    expect(result.rejected[0].ref).toBe('src/app.ts:15');
   });
 
   it('parses blocker emoji in new format', () => {
     const body = '- [x] <details><summary>🚫 **Security flaw** — <code>src/auth.ts:99</code></summary>\n</details>';
     const result = parseTriageBody(body);
-    expect(result.accepted).toEqual([{ title: 'Security flaw', ref: 'src/auth.ts:99' }]);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].title).toBe('Security flaw');
+    expect(result.accepted[0].ref).toBe('src/auth.ts:99');
   });
 
   it('handles mix of old and new formats', () => {
@@ -227,6 +239,83 @@ describe('parseTriageBody', () => {
     const result = parseTriageBody('No findings here.');
     expect(result.accepted).toEqual([]);
     expect(result.rejected).toEqual([]);
+  });
+});
+
+describe('extractFindingContent', () => {
+  it('extracts description from a details/summary section', () => {
+    const section = [
+      '- [x] <details><summary>📝 **Style nit** — <code>src/app.ts:7</code></summary>',
+      '',
+      'Consider using const instead of let.',
+      '</details>',
+    ].join('\n');
+    const result = extractFindingContent(section);
+    expect(result.description).toBe('Consider using const instead of let.');
+    expect(result.permalink).toBeNull();
+    expect(result.suggestedFix).toBeNull();
+  });
+
+  it('extracts permalink from section', () => {
+    const section = [
+      '- [x] <details><summary>📝 **Bug** — <code>src/a.ts:1</code></summary>',
+      '',
+      'Description here.',
+      'https://github.com/owner/repo/blob/abc123/src/a.ts#L1',
+      '</details>',
+    ].join('\n');
+    const result = extractFindingContent(section);
+    expect(result.description).toBe('Description here.');
+    expect(result.permalink).toBe('https://github.com/owner/repo/blob/abc123/src/a.ts#L1');
+  });
+
+  it('extracts suggested fix from section', () => {
+    const section = [
+      '- [x] <details><summary>📝 **Fix me** — <code>src/b.ts:5</code></summary>',
+      '',
+      'This needs fixing.',
+      '**Suggested fix:**',
+      '```',
+      'const x = 1;',
+      '```',
+      '</details>',
+    ].join('\n');
+    const result = extractFindingContent(section);
+    expect(result.description).toBe('This needs fixing.');
+    expect(result.suggestedFix).toBe('const x = 1;');
+  });
+
+  it('returns empty description for minimal sections', () => {
+    const section = '- [x] 💡 **Simple** — `src/a.ts:1`';
+    const result = extractFindingContent(section);
+    expect(result.description).toBe('');
+    expect(result.permalink).toBeNull();
+    expect(result.suggestedFix).toBeNull();
+  });
+});
+
+describe('triageTitlePrefix', () => {
+  it('returns test for missing test titles', () => {
+    expect(triageTitlePrefix('Missing test for edge case')).toBe('test');
+  });
+
+  it('returns test for no test titles', () => {
+    expect(triageTitlePrefix('No test coverage for parser')).toBe('test');
+  });
+
+  it('returns fix for other titles', () => {
+    expect(triageTitlePrefix('Null check missing')).toBe('fix');
+    expect(triageTitlePrefix('Unused import')).toBe('fix');
+  });
+});
+
+describe('extractPrNumber', () => {
+  it('extracts PR number from triage issue title', () => {
+    expect(extractPrNumber('triage: findings from PR #42')).toBe(42);
+  });
+
+  it('returns null for non-matching titles', () => {
+    expect(extractPrNumber('some other issue')).toBeNull();
   });
 });
 
@@ -964,6 +1053,7 @@ describe('handleTriage (via handlePRComment)', () => {
     const octokit = createMockOctokit();
     octokit.rest.issues.get.mockResolvedValue({
       data: {
+        title: 'triage: findings from PR #10',
         body: '- [x] 💡 **Fix null check** — `src/a.ts:1`\n- [ ] 📝 **Rename var** — `src/b.ts:2`',
       },
     });
@@ -971,7 +1061,27 @@ describe('handleTriage (via handlePRComment)', () => {
     await handlePRComment(octokit, null, 'test-owner', 'test-repo', 5);
 
     expect(octokit.rest.issues.create).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Fix null check' }),
+      expect.objectContaining({
+        title: 'fix: Fix null check',
+        body: expect.stringContaining('## Context'),
+      }),
+    );
+    // Body should reference triage issue and PR
+    expect(octokit.rest.issues.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('PR #10'),
+      }),
+    );
+    // Body should have structured sections
+    expect(octokit.rest.issues.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('## File'),
+      }),
+    );
+    expect(octokit.rest.issues.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('`src/a.ts:1`'),
+      }),
     );
     expect(octokit.rest.issues.update).toHaveBeenCalledWith(
       expect.objectContaining({ state: 'closed', issue_number: 5 }),

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -563,6 +563,7 @@ async function handleTriage(
 
   const { data: issue } = await octokit.rest.issues.get({ owner, repo, issue_number: issueNumber });
   const body = issue.body ?? '';
+  const issueTitle = issue.title ?? '';
 
   const { accepted, rejected } = parseTriageBody(body);
 
@@ -575,20 +576,42 @@ async function handleTriage(
     return;
   }
 
+  const prNumber = extractPrNumber(issueTitle);
+
   const createdIssues: number[] = [];
   for (const item of accepted) {
-    const sectionRegex = new RegExp(
-      `- \\[x\\] (?:<details><summary>)?[📝💡❓🚫] \\*\\*${escapeRegex(item.title)}\\*\\*[\\s\\S]*?(?=\\n- \\[|\\n---|$)`,
-      'iu',
-    );
-    const sectionMatch = body.match(sectionRegex);
-    const context = sectionMatch ? sectionMatch[0] : item.title;
+    const cleanTitle = `${triageTitlePrefix(item.title)}: ${item.title}`;
+    const { description, permalink, suggestedFix } = extractFindingContent(item.section);
+
+    const bodyParts: string[] = [
+      `## Context`,
+      ``,
+      `From review triage (#${issueNumber}${prNumber ? `, PR #${prNumber}` : ''}).`,
+      ``,
+      `## Description`,
+      ``,
+      description || item.title,
+      ``,
+      `## File`,
+      ``,
+      `\`${item.ref}\``,
+    ];
+
+    if (permalink) {
+      bodyParts.push('', permalink);
+    }
+
+    if (suggestedFix) {
+      bodyParts.push('', '## Suggested Fix', '', '```', suggestedFix, '```');
+    }
+
+    const issueBody = bodyParts.join('\n');
 
     try {
       const { data: newIssue } = await octokit.rest.issues.create({
         owner, repo,
-        title: item.title,
-        body: `**From review triage** — Source: #${issueNumber}\n\n${context}`,
+        title: cleanTitle,
+        body: issueBody,
       });
       createdIssues.push(newIssue.number);
       core.info(`Created issue #${newIssue.number} for "${item.title}"`);
@@ -669,10 +692,6 @@ async function handleTriage(
   core.info(`Triage complete: ${accepted.length} accepted, ${rejected.length} rejected`);
 }
 
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 async function handleGenericQuestion(
   octokit: Octokit,
   client: ClaudeClient,
@@ -724,6 +743,7 @@ function hasBotMention(body: string): boolean {
 interface TriageFinding {
   title: string;
   ref: string;
+  section: string;
 }
 
 interface TriageResult {
@@ -731,22 +751,90 @@ interface TriageResult {
   rejected: TriageFinding[];
 }
 
+interface FindingContent {
+  description: string;
+  permalink: string | null;
+  suggestedFix: string | null;
+}
+
 function parseTriageBody(body: string): TriageResult {
-  const checkedRegex = /^- \[x\] (?:<details><summary>)?[📝💡❓🚫] \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmiu;
-  const uncheckedRegex = /^- \[ \] (?:<details><summary>)?[📝💡❓🚫] \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmu;
+  const headerRegex = /^- \[([ x])\] (?:<details><summary>)?[📝💡❓🚫] \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmiu;
 
   const accepted: TriageFinding[] = [];
   const rejected: TriageFinding[] = [];
 
+  // Collect all match positions first
+  const matches: { checked: boolean; title: string; ref: string; start: number }[] = [];
   let match;
-  while ((match = checkedRegex.exec(body)) !== null) {
-    accepted.push({ title: match[1], ref: match[2] });
+  while ((match = headerRegex.exec(body)) !== null) {
+    matches.push({
+      checked: match[1] === 'x',
+      title: match[2],
+      ref: match[3],
+      start: match.index,
+    });
   }
-  while ((match = uncheckedRegex.exec(body)) !== null) {
-    rejected.push({ title: match[1], ref: match[2] });
+
+  // Extract full sections using positions of subsequent findings
+  for (let i = 0; i < matches.length; i++) {
+    const end = i + 1 < matches.length ? matches[i + 1].start : body.length;
+    const section = body.slice(matches[i].start, end).trim();
+    const finding: TriageFinding = {
+      title: matches[i].title,
+      ref: matches[i].ref,
+      section,
+    };
+    if (matches[i].checked) {
+      accepted.push(finding);
+    } else {
+      rejected.push(finding);
+    }
   }
 
   return { accepted, rejected };
+}
+
+function extractFindingContent(section: string): FindingContent {
+  // Strip HTML tags (details/summary/code)
+  const stripped = section
+    .replace(/<\/?details>/g, '')
+    .replace(/<\/?summary>/g, '')
+    .replace(/<\/?code>/g, '`');
+
+  // Extract permalink (GitHub URL)
+  const permalinkMatch = stripped.match(/(https:\/\/github\.com\/[^\s)]+)/);
+  const permalink = permalinkMatch ? permalinkMatch[1] : null;
+
+  // Extract suggested fix (content after "**Suggested fix:**")
+  const suggestedFixMatch = stripped.match(/\*\*Suggested fix:\*\*\s*\n```[\s\S]*?\n([\s\S]*?)\n```/);
+  const suggestedFix = suggestedFixMatch ? suggestedFixMatch[1].trim() : null;
+
+  // Extract description: content between the header line and the permalink or suggested fix
+  const lines = stripped.split('\n');
+  // Skip the first line (checkbox + title line)
+  const descriptionLines: string[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    if (line.startsWith('https://github.com/')) break;
+    if (line.startsWith('**Suggested fix:**')) break;
+    if (line === '```') break;
+    descriptionLines.push(line);
+  }
+  const description = descriptionLines.join('\n').trim();
+
+  return { description, permalink, suggestedFix };
+}
+
+function triageTitlePrefix(title: string): string {
+  const lower = title.toLowerCase();
+  if (lower.startsWith('missing test') || lower.includes('no test')) return 'test';
+  return 'fix';
+}
+
+function extractPrNumber(issueTitle: string): number | null {
+  const match = issueTitle.match(/findings from PR #(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
 }
 
 function isReviewRequest(body: string): boolean {
@@ -757,4 +845,4 @@ function isBotMentionNonReview(body: string): boolean {
   return BOT_MENTION_PATTERN.test(body.toLowerCase()) && !/\breview\b/i.test(body);
 }
 
-export { parseCommand, buildReplyContext, parseTriageBody, ParsedCommand, TriageFinding, TriageResult, BOT_MARKER, BOT_MENTION_PATTERN, isBotComment, hasBotMention, isReviewRequest, isBotMentionNonReview };
+export { parseCommand, buildReplyContext, parseTriageBody, extractFindingContent, triageTitlePrefix, extractPrNumber, ParsedCommand, TriageFinding, TriageResult, FindingContent, BOT_MARKER, BOT_MENTION_PATTERN, isBotComment, hasBotMention, isReviewRequest, isBotMentionNonReview };


### PR DESCRIPTION
## Summary

- Add conventional commit prefix to triage issue titles (`fix:`, `test:`, `chore:`)
- Restructure issue body with Context/Description/File/Suggested Fix sections
- Strip HTML artifacts (`<details>`, `<summary>`, `<code>`) from content
- Extract PR number from triage issue title for context

Closes #318