### PR TITLE
refactor: remove unused config fields `review_language`, `include_paths`, `model`

### DIFF
--- a/.manki.yml.example
+++ b/.manki.yml.example
@@ -1,9 +1,6 @@
 # Manki configuration
 # Place this file as .manki.yml in your repository root
 
-# Claude model for reviews (default: claude-opus-4-6)
-# model: claude-opus-4-6
-
 # Automatically review PRs on open/update (default: true)
 # When false, reviews only run via @manki review
 # auto_review: true
@@ -12,12 +9,7 @@
 # Triggers on thread resolution and via @manki check
 # auto_approve: true
 
-# Review language (default: en)
-# review_language: en
-
 # File filtering
-# include_paths:
-#   - "**/*"
 # exclude_paths:
 #   - "*.lock"
 #   - "dist/**"
@@ -44,7 +36,7 @@
 # instructions: |
 #   This is a Rust project. Focus on ownership and error handling.
 
-# Per-stage model selection (optional — falls back to `model` if not set)
+# Per-stage model selection
 # models:
 #   reviewer: claude-sonnet-4-6    # fast, parallel reviewers
 #   judge: claude-opus-4-6         # precise, single judge

--- a/SETUP.md
+++ b/SETUP.md
@@ -209,12 +209,7 @@ auto_review: true
 # Auto-approve when all blocking issues are resolved (default: true)
 auto_approve: true
 
-# Review language (default: en)
-review_language: en
-
 # File filtering
-include_paths:
-  - "**/*"
 exclude_paths:
   - "*.lock"
 
@@ -367,7 +362,7 @@ You can also trigger a review manually by commenting `@manki review` on any PR.
 |---------|----------|
 | "spawn claude ENOENT" | Add the "Install Claude Code CLI" step before the action |
 | "Failed to post APPROVE review" | Enable "Allow GitHub Actions to create and approve pull requests" in repo settings |
-| Review says "No reviewable files" | Check `include_paths`/`exclude_paths` in config -- dotfiles are included by default |
+| Review says "No reviewable files" | Check `exclude_paths` in config -- dotfiles are included by default |
 | Memory not loading | Verify `REVIEW_MEMORY_TOKEN` secret is set and the PAT has Contents read/write on the memory repo |
 | Review doesn't trigger on `@manki review` | The workflow file must exist on the default branch (main) |
 | "Diff too large" | Increase `max_diff_lines` in config or split the PR |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -17,11 +17,8 @@ describe('config', () => {
 
   describe('DEFAULT_CONFIG', () => {
     it('has all required fields with valid types', () => {
-      expect(typeof DEFAULT_CONFIG.model).toBe('string');
       expect(typeof DEFAULT_CONFIG.auto_review).toBe('boolean');
       expect(typeof DEFAULT_CONFIG.auto_approve).toBe('boolean');
-      expect(typeof DEFAULT_CONFIG.review_language).toBe('string');
-      expect(Array.isArray(DEFAULT_CONFIG.include_paths)).toBe(true);
       expect(Array.isArray(DEFAULT_CONFIG.exclude_paths)).toBe(true);
       expect(typeof DEFAULT_CONFIG.max_diff_lines).toBe('number');
       expect(DEFAULT_CONFIG.max_diff_lines).toBeGreaterThan(0);
@@ -72,11 +69,9 @@ describe('config', () => {
 
     it('merges partial config over defaults', () => {
       const yaml = `
-model: claude-sonnet-4-20250514
 max_diff_lines: 5000
 `;
       const config = loadConfigFromContent(yaml);
-      expect(config.model).toBe('claude-sonnet-4-20250514');
       expect(config.max_diff_lines).toBe(5000);
       // Other fields remain default
       expect(config.auto_review).toBe(DEFAULT_CONFIG.auto_review);
@@ -94,16 +89,6 @@ reviewers:
       expect(config.reviewers).toHaveLength(1);
       expect(config.reviewers[0].name).toBe('Custom Reviewer');
       expect(config.reviewers[0].focus).toBe('custom focus area');
-    });
-
-    it('replaces include_paths array entirely', () => {
-      const yaml = `
-include_paths:
-  - "src/**"
-  - "lib/**"
-`;
-      const config = loadConfigFromContent(yaml);
-      expect(config.include_paths).toEqual(['src/**', 'lib/**']);
     });
 
     it('replaces exclude_paths array entirely', () => {
@@ -127,20 +112,14 @@ memory:
 
     it('warns on unknown keys but does not fail', () => {
       const yaml = `
-model: claude-sonnet-4-6
+auto_review: true
 unknown_key: some_value
 another_unknown: 123
 `;
       const config = loadConfigFromContent(yaml);
-      expect(config.model).toBe('claude-sonnet-4-6');
+      expect(config.auto_review).toBe(true);
       expect(core.warning).toHaveBeenCalledWith('Unknown config key: "unknown_key"');
       expect(core.warning).toHaveBeenCalledWith('Unknown config key: "another_unknown"');
-    });
-
-    it('throws on invalid model type', () => {
-      const yaml = 'model: 123';
-      expect(() => loadConfigFromContent(yaml)).toThrow('Invalid config');
-      expect(core.error).toHaveBeenCalledWith('`model` must be a string');
     });
 
     it('throws on invalid max_diff_lines', () => {
@@ -252,11 +231,11 @@ review_thresholds:
 
     it('ignores unknown keys during merge', () => {
       const yaml = `
-model: claude-sonnet-4-20250514
+auto_review: false
 unknown_thing: true
 `;
       const config = loadConfigFromContent(yaml);
-      expect(config.model).toBe('claude-sonnet-4-20250514');
+      expect(config.auto_review).toBe(false);
       expect((config as unknown as Record<string, unknown>)['unknown_thing']).toBeUndefined();
     });
 
@@ -335,7 +314,7 @@ models:
     });
 
     it('defaults review_passes to 1', () => {
-      const config = loadConfigFromContent('model: claude-sonnet-4-6');
+      const config = loadConfigFromContent('auto_review: true');
       expect(config.review_passes).toBe(1);
     });
 
@@ -376,36 +355,25 @@ models:
       expect(resolveModel(config, 'judge')).toBe('claude-sonnet-4-6');
     });
 
-    it('falls back to config.model when models is undefined', () => {
-      const config: ReviewConfig = { ...baseConfig, model: 'custom-model', models: undefined };
-      expect(resolveModel(config, 'reviewer')).toBe('custom-model');
-      expect(resolveModel(config, 'judge')).toBe('custom-model');
+    it('falls back to default models when models is undefined', () => {
+      const config: ReviewConfig = { ...baseConfig, models: undefined };
+      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
     });
 
-    it('models.stage takes precedence over top-level model', () => {
+    it('falls back to default model when stage key is missing', () => {
       const config: ReviewConfig = {
         ...baseConfig,
-        model: 'custom-model',
-        models: { reviewer: 'claude-sonnet-4-6', judge: 'claude-opus-4-6' },
+        models: { reviewer: 'claude-sonnet-4-6' },
       };
       expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
       expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
     });
 
-    it('falls back to config.model when stage key is missing', () => {
-      const config: ReviewConfig = {
-        ...baseConfig,
-        model: 'custom-model',
-        models: { reviewer: 'claude-sonnet-4-6' },
-      };
+    it('falls back to default models when models is empty object', () => {
+      const config: ReviewConfig = { ...baseConfig, models: {} };
       expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
-      expect(resolveModel(config, 'judge')).toBe('custom-model');
-    });
-
-    it('falls back to config.model when models is empty object', () => {
-      const config: ReviewConfig = { ...baseConfig, model: 'custom-model', models: {} };
-      expect(resolveModel(config, 'reviewer')).toBe('custom-model');
-      expect(resolveModel(config, 'judge')).toBe('custom-model');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-6');
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,11 +5,8 @@ import { parse as parseYaml } from 'yaml';
 import { ReviewConfig } from './types';
 
 export const DEFAULT_CONFIG: ReviewConfig = {
-  model: 'claude-sonnet-4-6',
   auto_review: true,
   auto_approve: true,
-  review_language: 'en',
-  include_paths: ['**/*'],
   exclude_paths: ['*.lock', 'dist/**', '*.generated.*'],
   max_diff_lines: 50000,
   reviewers: [],
@@ -29,11 +26,8 @@ export const DEFAULT_CONFIG: ReviewConfig = {
 };
 
 const KNOWN_KEYS = new Set([
-  'model',
   'auto_review',
   'auto_approve',
-  'review_language',
-  'include_paths',
   'exclude_paths',
   'max_diff_lines',
   'reviewers',
@@ -64,10 +58,6 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
     }
   }
 
-  if ('model' in config && typeof config.model !== 'string') {
-    errors.push('`model` must be a string');
-  }
-
   if ('max_diff_lines' in config) {
     if (typeof config.max_diff_lines !== 'number' || config.max_diff_lines <= 0) {
       errors.push('`max_diff_lines` must be a positive number');
@@ -82,18 +72,8 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
     errors.push('`auto_approve` must be a boolean');
   }
 
-  if ('review_language' in config && typeof config.review_language !== 'string') {
-    errors.push('`review_language` must be a string');
-  }
-
   if ('instructions' in config && typeof config.instructions !== 'string') {
     errors.push('`instructions` must be a string');
-  }
-
-  if ('include_paths' in config) {
-    if (!Array.isArray(config.include_paths)) {
-      errors.push('`include_paths` must be an array of strings');
-    }
   }
 
   if ('exclude_paths' in config) {
@@ -272,7 +252,7 @@ export function loadConfigFromFile(filePath: string): ReviewConfig {
 }
 
 export function resolveModel(config: ReviewConfig, stage: 'reviewer' | 'judge'): string {
-  return config.models?.[stage] || config.model;
+  return config.models?.[stage] || DEFAULT_CONFIG.models![stage]!;
 }
 
 export function loadConfig(yamlContent: string | undefined): ReviewConfig {

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -210,42 +210,28 @@ describe('filterFiles', () => {
     { path: 'dist/index.js', changeType: 'modified', hunks: [] },
   ];
 
-  it('returns all files when no patterns specified', () => {
-    const result = filterFiles(files, [], []);
+  it('returns all files when no exclude patterns specified', () => {
+    const result = filterFiles(files, []);
     expect(result).toHaveLength(6);
   });
 
-  it('filters by include patterns', () => {
-    const result = filterFiles(files, ['src/**/*.ts'], []);
-    expect(result).toHaveLength(2);
-    expect(result.map((f) => f.path)).toEqual(['src/main.ts', 'src/utils.ts']);
-  });
-
   it('filters by exclude patterns', () => {
-    const result = filterFiles(files, [], ['dist/**']);
+    const result = filterFiles(files, ['dist/**']);
     expect(result).toHaveLength(5);
     expect(result.map((f) => f.path)).not.toContain('dist/index.js');
   });
 
-  it('applies both include and exclude patterns', () => {
-    const result = filterFiles(files, ['**/*.ts'], ['tests/**']);
-    expect(result).toHaveLength(2);
-    expect(result.map((f) => f.path)).toEqual(['src/main.ts', 'src/utils.ts']);
+  it('applies multiple exclude patterns', () => {
+    const result = filterFiles(files, ['tests/**', 'dist/**']);
+    expect(result).toHaveLength(4);
+    expect(result.map((f) => f.path)).not.toContain('tests/main.test.ts');
+    expect(result.map((f) => f.path)).not.toContain('dist/index.js');
   });
 
   it('supports matchBase for patterns without slashes', () => {
-    const result = filterFiles(files, ['*.ts'], []);
-    expect(result).toHaveLength(3);
-  });
-
-  it('handles multiple include patterns with OR semantics', () => {
-    const result = filterFiles(files, ['*.ts', '*.md'], []);
-    expect(result).toHaveLength(4);
-  });
-
-  it('returns empty array when nothing matches include', () => {
-    const result = filterFiles(files, ['*.py'], []);
-    expect(result).toHaveLength(0);
+    const result = filterFiles(files, ['*.json']);
+    expect(result).toHaveLength(5);
+    expect(result.map((f) => f.path)).not.toContain('package.json');
   });
 
   it('excludes dotfiles when pattern targets them', () => {
@@ -254,18 +240,18 @@ describe('filterFiles', () => {
       { path: '.gitignore', changeType: 'modified', hunks: [] },
       { path: 'src/main.ts', changeType: 'modified', hunks: [] },
     ];
-    const result = filterFiles(dotfiles, ['**/*'], ['.*']);
+    const result = filterFiles(dotfiles, ['.*']);
     expect(result.map((f) => f.path)).toEqual(['src/main.ts']);
   });
 
-  it('includes dotfiles with default include pattern', () => {
+  it('includes dotfiles when no exclude pattern targets them', () => {
     const dotfiles: DiffFile[] = [
       { path: '.manki.yml', changeType: 'modified', hunks: [] },
       { path: '.github/workflows/ci.yml', changeType: 'modified', hunks: [] },
       { path: '.gitignore', changeType: 'modified', hunks: [] },
       { path: 'src/main.ts', changeType: 'modified', hunks: [] },
     ];
-    const result = filterFiles(dotfiles, ['**/*'], []);
+    const result = filterFiles(dotfiles, []);
     expect(result).toHaveLength(4);
     expect(result.map((f) => f.path)).toContain('.manki.yml');
     expect(result.map((f) => f.path)).toContain('.github/workflows/ci.yml');

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -49,23 +49,15 @@ export function parsePRDiff(rawDiff: string): ParsedDiff {
 }
 
 /**
- * Filter diff files based on include/exclude glob patterns.
- * A file is included if it matches ANY include pattern (or include is empty)
- * AND doesn't match ANY exclude pattern.
+ * Filter diff files based on exclude glob patterns.
+ * A file is included unless it matches ANY exclude pattern.
  */
 export function filterFiles(
   files: DiffFile[],
-  includePaths: string[],
   excludePaths: string[],
 ): DiffFile[] {
   return files.filter((file) => {
     const matchOpts = { matchBase: true, dot: true };
-
-    const included =
-      includePaths.length === 0 ||
-      includePaths.some((pattern) => minimatch(file.path, pattern, matchOpts));
-
-    if (!included) return false;
 
     const excluded = excludePaths.some((pattern) =>
       minimatch(file.path, pattern, matchOpts),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,6 @@ jest.mock('./config', () => ({
   loadConfig: jest.fn().mockReturnValue({
     auto_review: true,
     max_diff_lines: 5000,
-    include_paths: [],
     exclude_paths: [],
     nit_handling: 'issues',
     reviewers: [],
@@ -744,8 +743,8 @@ describe('runFullReview orchestration', () => {
     // Reset to default config for each test
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -875,12 +874,9 @@ describe('runFullReview orchestration', () => {
       auto_review: false,
       auto_approve: false,
       max_diff_lines: 5000,
-      include_paths: [],
       exclude_paths: [],
       nit_handling: 'issues',
       reviewers: [],
-      model: 'claude-sonnet-4-20250514',
-      review_language: 'en',
       instructions: '',
       review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
@@ -947,8 +943,8 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -987,8 +983,8 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'comments',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'comments',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -1107,8 +1103,8 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: true, repo: 'owner/memory' },
@@ -1197,8 +1193,8 @@ describe('handleInteraction', () => {
     _resetOctokitCache();
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -1249,8 +1245,8 @@ describe('handleIssueInteraction', () => {
     _resetOctokitCache();
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -1349,8 +1345,8 @@ describe('handleReviewStateCheck', () => {
     });
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -1374,8 +1370,8 @@ describe('handleReviewStateCheck', () => {
     });
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: true, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },
@@ -1403,8 +1399,8 @@ describe('handleReviewCommentInteraction auto-approve', () => {
     jest.mocked(interaction.hasBotMention).mockReturnValue(true);
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: true, max_diff_lines: 5000,
-      include_paths: [], exclude_paths: [], nit_handling: 'issues',
-      reviewers: [], model: 'claude-sonnet-4-20250514', review_language: 'en',
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [],
       instructions: '', review_level: 'auto',
       review_thresholds: { small: 200, medium: 800 },
       memory: { enabled: false, repo: '' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,6 @@ async function runFullReview(
     const config = loadConfig(configContent ?? undefined);
 
     if (modelOverride) {
-      config.model = modelOverride;
       config.models = { reviewer: modelOverride, judge: modelOverride };
     }
 
@@ -296,7 +295,7 @@ async function runFullReview(
       return;
     }
 
-    const filteredFiles = filterFiles(diff.files, config.include_paths, config.exclude_paths);
+    const filteredFiles = filterFiles(diff.files, config.exclude_paths);
     core.info(`Reviewing ${filteredFiles.length} files (${diff.files.length} total, ${diff.files.length - filteredFiles.length} filtered out)`);
 
     if (filteredFiles.length === 0) {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -16,11 +16,8 @@ import { LinkedIssue } from './github';
 import { Finding, ReviewConfig, ParsedDiff, DiffFile, DiffHunk } from './types';
 
 const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
-  model: 'claude-opus-4-6',
   auto_review: true,
   auto_approve: true,
-  review_language: 'en',
-  include_paths: ['**/*'],
   exclude_paths: [],
   max_diff_lines: 50000,
   reviewers: [],

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -21,11 +21,8 @@ import { runJudgeAgent } from './judge';
 import { applySuppressions } from './memory';
 
 const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
-  model: 'claude-opus-4-6',
   auto_review: true,
   auto_approve: true,
-  review_language: 'en',
-  include_paths: ['**/*'],
   exclude_paths: [],
   max_diff_lines: 50000,
   reviewers: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,11 +45,8 @@ export interface TeamRoster {
 }
 
 export interface ReviewConfig {
-  model: string;
   auto_review: boolean;
   auto_approve: boolean;
-  review_language: string;
-  include_paths: string[];
   exclude_paths: string[];
   max_diff_lines: number;
   reviewers: ReviewerAgent[];


### PR DESCRIPTION
## Summary

- Remove `review_language` — completely unused, dead code
- Remove `include_paths` — default `['**/*']` was redundant, `exclude_paths` is sufficient
- Remove top-level `model` — superseded by `models.reviewer`/`models.judge`, `resolveModel()` updated to use `models` defaults directly