### PR TITLE
fix: log correct actor when `reviewAuthorType` triggers bot skip

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -163,6 +163,7 @@ describe('run', () => {
         eventName: 'pull_request_review',
         payload: {
           action: 'submitted',
+          sender: { login: 'some-human', type: 'User' },
           review: { user: { login: 'manki-labs[bot]', type: 'Bot' } },
           pull_request: { number: 1, base: { ref: 'main' } },
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,9 @@ async function run(): Promise<void> {
   const senderType = github.context.payload.sender?.type ?? '';
   const reviewAuthorType = github.context.payload.review?.user?.type ?? '';
   if (senderType === 'Bot' || reviewAuthorType === 'Bot') {
-    const actor = github.context.payload.sender?.login ?? github.context.payload.review?.user?.login ?? 'unknown bot';
+    const actor = senderType === 'Bot'
+      ? (github.context.payload.sender?.login ?? 'unknown bot')
+      : (github.context.payload.review?.user?.login ?? 'unknown bot');
     core.info(`Ignoring event from bot: ${actor}`);
     return;
   }


### PR DESCRIPTION
## Summary
- When `reviewAuthorType === 'Bot'` triggers the bot skip (but sender is human), log the review author's login instead of the sender's login
- Added realistic `sender` to the review author bot test case

Closes #316