### PR TITLE
test: verify token fetch uses POST method

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -116,6 +116,7 @@ describe('resolveGitHubToken', () => {
     const call = (global.fetch as jest.Mock).mock.calls[0];
     expect(call[0]).toBe(TOKEN_URL);
     expect(call[1].headers['Authorization']).toBe('Bearer fake-oidc-token');
+    expect(call[1].method).toBe('POST');
     expect(JSON.parse(call[1].body)).toEqual({ owner: OWNER, repo: REPO });
   });
 


### PR DESCRIPTION
## Summary
- Add assertion that the OIDC token exchange request uses POST method
- Ensures the fetch call method is explicitly verified alongside URL and body

Closes #269