### PR TITLE
refactor: make `resolvedToken` dependency explicit in `auth.ts`

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { createAppAuth } from '@octokit/auth-app';
 
-import { createAuthenticatedOctokit, getMemoryToken, resolveGitHubToken, setResolvedToken, TokenResult } from './auth';
+import { createAuthenticatedOctokit, getMemoryToken, resolveGitHubToken, TokenResult } from './auth';
 
 jest.mock('@actions/core');
 jest.mock('@actions/github');
@@ -12,8 +12,6 @@ const mockGetInput = core.getInput as jest.MockedFunction<typeof core.getInput>;
 describe('getMemoryToken', () => {
   beforeEach(() => {
     mockGetInput.mockReset();
-    // Reset the resolved token between tests
-    setResolvedToken('');
   });
 
   it('returns memory_repo_token when set', () => {
@@ -23,7 +21,7 @@ describe('getMemoryToken', () => {
       return '';
     });
 
-    expect(getMemoryToken()).toBe('memory-token-123');
+    expect(getMemoryToken(null)).toBe('memory-token-123');
   });
 
   it('falls back to github_token when memory_repo_token is empty', () => {
@@ -33,13 +31,13 @@ describe('getMemoryToken', () => {
       return '';
     });
 
-    expect(getMemoryToken()).toBe('github-token-456');
+    expect(getMemoryToken(null)).toBe('github-token-456');
   });
 
   it('returns null when both tokens are empty', () => {
     mockGetInput.mockImplementation(() => '');
 
-    expect(getMemoryToken()).toBeNull();
+    expect(getMemoryToken(null)).toBeNull();
   });
 
   it('prefers memory_repo_token over github_token', () => {
@@ -49,7 +47,7 @@ describe('getMemoryToken', () => {
       return '';
     });
 
-    expect(getMemoryToken()).toBe('memory-token');
+    expect(getMemoryToken(null)).toBe('memory-token');
   });
 
   it('prefers resolved app token over raw github_token', () => {
@@ -58,8 +56,7 @@ describe('getMemoryToken', () => {
       return '';
     });
 
-    setResolvedToken('app-token-resolved');
-    expect(getMemoryToken()).toBe('app-token-resolved');
+    expect(getMemoryToken('app-token-resolved')).toBe('app-token-resolved');
   });
 
   it('prefers memory_repo_token over resolved app token', () => {
@@ -69,8 +66,7 @@ describe('getMemoryToken', () => {
       return '';
     });
 
-    setResolvedToken('app-token-resolved');
-    expect(getMemoryToken()).toBe('explicit-memory-token');
+    expect(getMemoryToken('app-token-resolved')).toBe('explicit-memory-token');
   });
 
   it('falls back to github_token when resolved token is not set', () => {
@@ -79,7 +75,7 @@ describe('getMemoryToken', () => {
       return '';
     });
 
-    expect(getMemoryToken()).toBe('github-token');
+    expect(getMemoryToken(null)).toBe('github-token');
   });
 });
 
@@ -219,7 +215,6 @@ describe('createAuthenticatedOctokit', () => {
     mockGetInput.mockReset();
     mockGetOctokit.mockReset();
     mockCreateAppAuth.mockReset();
-    setResolvedToken('');
     jest.restoreAllMocks();
 
     // Default context.repo
@@ -260,7 +255,8 @@ describe('createAuthenticatedOctokit', () => {
     expect(mockAuth).toHaveBeenCalledWith({ type: 'installation', installationId: 999 });
     expect(core.setSecret).toHaveBeenCalledWith('app-jwt-token');
     expect(core.setSecret).toHaveBeenCalledWith('installation-token-abc');
-    expect(result).toBeDefined();
+    expect(result.octokit).toBeDefined();
+    expect(result.resolvedToken).toBe('installation-token-abc');
   });
 
   it('throws when github_app_id is not a number', async () => {
@@ -295,14 +291,12 @@ describe('createAuthenticatedOctokit', () => {
 
     const result = await createAuthenticatedOctokit();
 
-    expect(result).toBeDefined();
+    expect(result.octokit).toBeDefined();
+    expect(result.resolvedToken).toBe('ghp_fallback');
     expect(mockGetOctokit).toHaveBeenCalledWith('ghp_fallback');
-
-    // Resolved token is cached for getMemoryToken
-    expect(getMemoryToken()).toBe('ghp_fallback');
   });
 
-  it('caches app token for getMemoryToken after resolution', async () => {
+  it('returns resolved app token for use with getMemoryToken', async () => {
     mockGetInput.mockImplementation((name: string) => {
       if (name === 'github_app_id') return '';
       if (name === 'github_app_private_key') return '';
@@ -318,9 +312,10 @@ describe('createAuthenticatedOctokit', () => {
     ));
     mockGetOctokit.mockReturnValue({} as ReturnType<typeof github.getOctokit>);
 
-    await createAuthenticatedOctokit();
+    const result = await createAuthenticatedOctokit();
 
-    expect(getMemoryToken()).toBe('resolved-app-token');
+    expect(result.resolvedToken).toBe('resolved-app-token');
+    expect(getMemoryToken(result.resolvedToken)).toBe('resolved-app-token');
   });
 
   it('uses custom manki_token_url when provided', async () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,10 +4,9 @@ import { createAppAuth } from '@octokit/auth-app';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
-let resolvedToken: string | null = null;
-
-export function setResolvedToken(token: string): void {
-  resolvedToken = token;
+export interface AuthResult {
+  octokit: Octokit;
+  resolvedToken: string;
 }
 
 export interface TokenResult {
@@ -74,7 +73,7 @@ export async function resolveGitHubToken(
  * Create an authenticated Octokit client.
  * Priority: explicit App credentials > auto-detect manki-labs app > github_token.
  */
-export async function createAuthenticatedOctokit(): Promise<Octokit> {
+export async function createAuthenticatedOctokit(): Promise<AuthResult> {
   const appId = core.getInput('github_app_id');
   const privateKey = core.getInput('github_app_private_key');
   const githubToken = core.getInput('github_token');
@@ -82,8 +81,7 @@ export async function createAuthenticatedOctokit(): Promise<Octokit> {
   if (appId && privateKey) {
     core.info('Using GitHub App authentication for custom bot identity');
     const token = await getInstallationToken(appId, privateKey);
-    setResolvedToken(token);
-    return github.getOctokit(token);
+    return { octokit: github.getOctokit(token), resolvedToken: token };
   }
 
   if (!githubToken) {
@@ -93,16 +91,15 @@ export async function createAuthenticatedOctokit(): Promise<Octokit> {
   const tokenUrl = core.getInput('manki_token_url') || 'https://manki.dustinface.me/token';
   const { owner, repo: repoName } = github.context.repo;
   const { token } = await resolveGitHubToken(githubToken, tokenUrl, owner, repoName);
-  setResolvedToken(token);
 
-  return github.getOctokit(token);
+  return { octokit: github.getOctokit(token), resolvedToken: token };
 }
 
 /**
  * Returns a token suitable for memory repo operations.
  * Prefers memory_repo_token, falls back to github_token, returns null if neither is set.
  */
-export function getMemoryToken(): string | null {
+export function getMemoryToken(resolvedToken: string | null): string | null {
   // Explicit memory_repo_token takes priority
   const memoryToken = core.getInput('memory_repo_token');
   if (memoryToken) return memoryToken;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,7 +38,7 @@ const mockOctokitInstance = {
 };
 
 jest.mock('./auth', () => ({
-  createAuthenticatedOctokit: jest.fn().mockResolvedValue(mockOctokitInstance),
+  createAuthenticatedOctokit: jest.fn().mockResolvedValue({ octokit: mockOctokitInstance, resolvedToken: 'mock-resolved-token' }),
   getMemoryToken: jest.fn().mockReturnValue(null),
 }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,13 @@ import { checkAndAutoApprove, resolveStaleThreads } from './state';
 type Octokit = ReturnType<typeof github.getOctokit>;
 
 let cachedOctokit: Octokit | null = null;
+let cachedResolvedToken: string | null = null;
 
 async function getOctokit(): Promise<Octokit> {
   if (!cachedOctokit) {
-    cachedOctokit = await createAuthenticatedOctokit();
+    const { octokit, resolvedToken } = await createAuthenticatedOctokit();
+    cachedOctokit = octokit;
+    cachedResolvedToken = resolvedToken;
   }
   return cachedOctokit;
 }
@@ -329,7 +332,7 @@ async function runFullReview(
 
     let memory: RepoMemory | null = null;
     if (config.memory?.enabled) {
-      const memoryToken = getMemoryToken();
+      const memoryToken = getMemoryToken(cachedResolvedToken);
       if (!memoryToken) {
         core.warning('No memory token available — skipping memory load. Set memory_repo_token or github_token.');
       } else {
@@ -481,7 +484,7 @@ async function runFullReview(
     }
 
     if (memory && config.memory?.enabled) {
-      const memoryToken = getMemoryToken();
+      const memoryToken = getMemoryToken(cachedResolvedToken);
       if (!memoryToken) {
         core.warning('No memory token available — skipping memory update. Set memory_repo_token or github_token.');
       } else {
@@ -644,7 +647,7 @@ async function handleInteraction(): Promise<void> {
   });
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
-  const memoryToken = config.memory?.enabled ? getMemoryToken() ?? undefined : undefined;
+  const memoryToken = config.memory?.enabled ? getMemoryToken(cachedResolvedToken) ?? undefined : undefined;
 
   await handlePRComment(octokit, claude, owner, repo, prNumber, memoryConfig, memoryToken, config);
 }
@@ -672,7 +675,7 @@ async function handleIssueInteraction(): Promise<void> {
   const config = loadConfig(configContent ?? undefined);
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
-  const memoryToken = config.memory?.enabled ? getMemoryToken() ?? undefined : undefined;
+  const memoryToken = config.memory?.enabled ? getMemoryToken(cachedResolvedToken) ?? undefined : undefined;
 
   await handlePRComment(octokit, null, owner, repo, issueNumber, memoryConfig, memoryToken, config);
 }
@@ -721,7 +724,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
   });
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
-  const memoryToken = config.memory?.enabled ? getMemoryToken() ?? undefined : undefined;
+  const memoryToken = config.memory?.enabled ? getMemoryToken(cachedResolvedToken) ?? undefined : undefined;
 
   await handleReviewCommentReply(octokit, claude, memoryConfig, memoryToken);
 
@@ -760,6 +763,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 function _resetOctokitCache(): void {
   cachedOctokit = null;
+  cachedResolvedToken = null;
 }
 
 export { run, handlePullRequest, handleCommentTrigger, handleInteraction, handleIssueInteraction, handleReviewCommentInteraction, handleReviewStateCheck, runFullReview, main, _resetOctokitCache };


### PR DESCRIPTION
## Summary
- Remove module-level mutable `resolvedToken` state and `setResolvedToken` from `auth.ts`
- `createAuthenticatedOctokit` now returns `{ octokit, resolvedToken }` instead of just `Octokit`
- `getMemoryToken` is now a pure function accepting `resolvedToken` as a parameter
- Token caching moved to `index.ts` alongside `cachedOctokit`

Closes #328