### PR TITLE
fix: skip duplicate approval in `checkAndAutoApprove`

### DIFF
--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -320,10 +320,12 @@ describe('checkAndAutoApprove', () => {
     threads?: ReturnType<typeof makeGraphqlFetchThreadNode>[];
     prHeadSha?: string;
     createReviewFn?: jest.Mock;
+    existingReviews?: Array<{ body?: string; state?: string }>;
   } = {}) {
     const threads = overrides.threads ?? [];
     const prHeadSha = overrides.prHeadSha ?? 'abc123';
     const createReviewFn = overrides.createReviewFn ?? jest.fn().mockResolvedValue({});
+    const existingReviews = overrides.existingReviews ?? [];
 
     return {
       graphql: jest.fn().mockResolvedValue(makeGraphqlFetchResponse(threads)),
@@ -331,6 +333,7 @@ describe('checkAndAutoApprove', () => {
         pulls: {
           get: jest.fn().mockResolvedValue({ data: { head: { sha: prHeadSha } } }),
           createReview: createReviewFn,
+          listReviews: jest.fn().mockResolvedValue({ data: existingReviews }),
         },
       },
     } as unknown as Octokit;
@@ -441,6 +444,62 @@ describe('checkAndAutoApprove', () => {
     const octokit = makeMockOctokit({
       threads: [],
       createReviewFn: createReviewMock,
+    });
+
+    const result = await checkAndAutoApprove(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(true);
+    expect(createReviewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'APPROVE' }),
+    );
+  });
+
+  it('skips duplicate approval when bot already has an active APPROVED review', async () => {
+    const createReviewMock = jest.fn().mockResolvedValue({});
+    const octokit = makeMockOctokit({
+      threads: [],
+      createReviewFn: createReviewMock,
+      existingReviews: [
+        { body: '<!-- manki -->', state: 'APPROVED' },
+      ],
+    });
+
+    const result = await checkAndAutoApprove(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(true);
+    expect(createReviewMock).not.toHaveBeenCalled();
+    expect(dismissPreviousReviews).not.toHaveBeenCalled();
+  });
+
+  it('creates new approval when latest bot review is CHANGES_REQUESTED', async () => {
+    const createReviewMock = jest.fn().mockResolvedValue({});
+    const octokit = makeMockOctokit({
+      threads: [],
+      prHeadSha: 'sha-new',
+      createReviewFn: createReviewMock,
+      existingReviews: [
+        { body: '<!-- manki -->', state: 'APPROVED' },
+        { body: '<!-- manki -->', state: 'CHANGES_REQUESTED' },
+      ],
+    });
+
+    const result = await checkAndAutoApprove(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(true);
+    expect(createReviewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'APPROVE' }),
+    );
+  });
+
+  it('creates new approval when previous bot approval was DISMISSED', async () => {
+    const createReviewMock = jest.fn().mockResolvedValue({});
+    const octokit = makeMockOctokit({
+      threads: [],
+      prHeadSha: 'sha-new',
+      createReviewFn: createReviewMock,
+      existingReviews: [
+        { body: '<!-- manki -->', state: 'DISMISSED' },
+      ],
     });
 
     const result = await checkAndAutoApprove(octokit, 'owner', 'repo', 1);

--- a/src/state.ts
+++ b/src/state.ts
@@ -120,6 +120,21 @@ async function checkAndAutoApprove(
     return false;
   }
 
+  const { data: reviews } = await octokit.rest.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+  const botReviews = reviews.filter(
+    (r: { body?: string | null; state?: string }) =>
+      r.body?.includes('<!-- manki') && r.state !== 'DISMISSED',
+  );
+  const latestBotReview = botReviews[botReviews.length - 1];
+  if (latestBotReview?.state === 'APPROVED') {
+    core.info('Already approved — skipping duplicate approval');
+    return true;
+  }
+
   const { data: pr } = await octokit.rest.pulls.get({
     owner,
     repo,


### PR DESCRIPTION
## Summary

- Check for existing active bot APPROVED review before creating a new one
- Prevents N duplicate approvals when N review comment events trigger `checkAndAutoApprove` in sequence
- Returns `true` (already approved) without dismissing or re-approving

Closes #339