### PR TITLE
fix: use comment ID in concurrency group to prevent review comment cancellation

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   review:
     concurrency:
-      group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      group: manki-${{ github.event_name }}-${{ github.event.comment.id || github.event.pull_request.number || github.event.issue.number || github.run_id }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Use `github.event.comment.id` as first fallback in the workflow concurrency group, so each review comment event gets its own group
- Prevents Manki's own inline review comments from cancelling user reply runs via `cancel-in-progress`
- No change for `pull_request` and `pull_request_review` events — they still group by PR number

Closes #273