### PR TITLE
fix: lower high-confidence suggestion threshold to 1

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -186,20 +186,15 @@ describe('determineVerdict', () => {
     expect(determineVerdict([])).toBe('APPROVE');
   });
 
-  it('should REQUEST_CHANGES when 3+ high-confidence suggestions exist', () => {
+  it('should REQUEST_CHANGES when 1+ high-confidence suggestions exist', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'a', file: 'f', line: 1, description: '', reviewers: ['r'], judgeConfidence: 'high' },
-      { severity: 'suggestion', title: 'b', file: 'f', line: 2, description: '', reviewers: ['r'], judgeConfidence: 'high' },
-      { severity: 'suggestion', title: 'c', file: 'f', line: 3, description: '', reviewers: ['r'], judgeConfidence: 'high' },
     ];
     expect(determineVerdict(findings)).toBe('REQUEST_CHANGES');
   });
 
-  it('should APPROVE when fewer than 3 high-confidence suggestions exist', () => {
-    const findings: Finding[] = [
-      { severity: 'suggestion', title: 'a', file: 'f', line: 1, description: '', reviewers: ['r'], judgeConfidence: 'high' },
-      { severity: 'suggestion', title: 'b', file: 'f', line: 2, description: '', reviewers: ['r'], judgeConfidence: 'high' },
-    ];
+  it('should APPROVE when no high-confidence suggestions exist', () => {
+    const findings: Finding[] = [];
     expect(determineVerdict(findings)).toBe('APPROVE');
   });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -7,7 +7,7 @@ import { LinkedIssue } from './github';
 import { ReviewConfig, ReviewerAgent, Finding, ReviewResult, ReviewVerdict, ParsedDiff, DiffFile, TeamRoster, PrContext } from './types';
 import { extractJSON } from './json';
 
-export const HIGH_CONF_SUGGESTION_THRESHOLD = 3;
+export const HIGH_CONF_SUGGESTION_THRESHOLD = 1;
 
 export const AGENT_POOL: readonly ReviewerAgent[] = Object.freeze([
   {


### PR DESCRIPTION
## Summary

- Lower `HIGH_CONF_SUGGESTION_THRESHOLD` from 3 to 1 — a single high-confidence suggestion now triggers REQUEST_CHANGES
- Even one finding the judge is confident about represents a real issue that shouldn't auto-approve

Closes #350