### PR TITLE
fix: use fuzzy word-overlap matching in recap dedup to catch rephrased findings

### DIFF
--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -190,6 +190,23 @@ describe('deduplicateFindings', () => {
     expect(result.duplicates).toHaveLength(1);
   });
 
+  it('does not match when line delta exceeds relaxed threshold', () => {
+    const findings = [makeFinding({
+      title: 'Missing null check before dereference',
+      file: 'src/foo.ts',
+      line: 70,
+    })];
+    const previous = [makePrevious({
+      title: 'Missing null check before dereference',
+      file: 'src/foo.ts',
+      line: 45,
+    })];
+
+    const result = deduplicateFindings(findings, previous);
+    expect(result.unique).toHaveLength(1);
+    expect(result.duplicates).toHaveLength(0);
+  });
+
   it('does not match different file even with matching title', () => {
     const findings = [makeFinding({
       title: 'Missing null check before dereference',
@@ -249,6 +266,13 @@ describe('titlesOverlap', () => {
 
   it('returns false when all words are too short and strings differ', () => {
     expect(titlesOverlap('a b c', 'x y z')).toBe(false);
+  });
+
+  it('matches titles with punctuation-laden words', () => {
+    expect(titlesOverlap(
+      'regression: `is_ours` removed, error handling missing',
+      'regression is_ours removed error handling missing',
+    )).toBe(true);
   });
 });
 

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -220,8 +220,8 @@ function titlesOverlap(a: string, b: string): boolean {
 }
 
 function wordOverlapRatio(a: string, b: string): number {
-  const aWords = new Set(a.toLowerCase().split(/\s+/).filter(w => w.length >= 3));
-  const bWords = new Set(b.toLowerCase().split(/\s+/).filter(w => w.length >= 3));
+  const aWords = new Set(a.toLowerCase().split(/\s+/).map(w => w.replace(/^[^a-z0-9]+|[^a-z0-9]+$/gi, '')).filter(w => w.length >= 3));
+  const bWords = new Set(b.toLowerCase().split(/\s+/).map(w => w.replace(/^[^a-z0-9]+|[^a-z0-9]+$/gi, '')).filter(w => w.length >= 3));
   if (aWords.size === 0 || bWords.size === 0) return 0;
 
   let overlap = 0;


### PR DESCRIPTION
## Summary

- Replace strict substring matching in `matchesPrevious` with word-overlap matching (50% threshold)
- Relax line proximity from 5 to 20 lines when word overlap is >= 70% (findings that shifted position)
- Fixes dismissed/resolved findings being re-flagged on subsequent reviews when the LLM rephrases the title slightly

Closes #359