### PR TITLE
chore: raise patch coverage target from 80% to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
         informational: false
     patch:
       default:
-        target: 80%
+        target: 90%
         informational: false
 
 comment:


### PR DESCRIPTION
## Summary
- Raises the codecov patch coverage target from 80% to 90% to prevent gradual coverage erosion
- Project coverage has declined from ~95.75% to ~95.43% over recent PRs that all passed the 80% patch threshold