### PR TITLE
fix: show full description in collapsed duplicate findings

### DIFF
--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -530,13 +530,14 @@ describe('buildRecapSummary', () => {
 
   it('appends collapsed dedup details with per-finding collapsible sections', () => {
     const matches = [
-      { finding: makeFinding({ title: 'Unused import', file: 'src/index.ts', line: 10, severity: 'suggestion' }), matchedTitle: 'Remove unused import' },
+      { finding: makeFinding({ title: 'Unused import', file: 'src/index.ts', line: 10, severity: 'suggestion', description: 'The import is not used anywhere' }), matchedTitle: 'Remove unused import' },
     ];
     const summary = buildRecapSummary(1, 1, 0, 0, matches);
     expect(summary).toContain('Findings: 1 new, 1 skipped (already flagged)');
     expect(summary).toContain('1 finding skipped (previously flagged)');
-    expect(summary).toContain('<summary>"Unused import" (src/index.ts:10, suggestion)</summary>');
-    expect(summary).toContain('Matches previously flagged: "Remove unused import"');
+    expect(summary).toContain('💡 "Unused import" (src/index.ts:10, suggestion)</summary>');
+    expect(summary).toContain('**Description:** The import is not used anywhere');
+    expect(summary).toContain('*Matches previously flagged: "Remove unused import"*');
   });
 
   it('sanitizes HTML in finding titles within dedup details', () => {

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { ClaudeClient } from './claude';
 import { matchesSuppression, Suppression } from './memory';
+import { getSeverityEmoji } from './github';
 import { Finding, FindingSeverity, ParsedDiff } from './types';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
@@ -294,9 +295,11 @@ function buildRecapSummary(
     const title = sanitizeHtml(d.finding.title);
     const file = sanitizeHtml(d.finding.file);
     const line = d.finding.line;
-    const severity = sanitizeHtml(d.finding.severity);
+    const severity = d.finding.severity as FindingSeverity;
+    const emoji = getSeverityEmoji(severity);
+    const description = sanitizeHtml(d.finding.description);
     const matched = sanitizeHtml(d.matchedTitle);
-    return `<details>\n<summary>"${title}" (${file}:${line}, ${severity})</summary>\n\nMatches previously flagged: "${matched}"\n</details>`;
+    return `<details>\n<summary>${emoji} "${title}" (${file}:${line}, ${sanitizeHtml(severity)})</summary>\n\n**Description:** ${description}\n\n*Matches previously flagged: "${matched}"*\n</details>`;
   });
   const count = duplicateMatches.length;
   return summary + `\n\n<details><summary>🔁 ${count} finding${count === 1 ? '' : 's'} skipped (previously flagged)</summary>\n\n${lines.join('\n\n')}\n\n</details>`;


### PR DESCRIPTION
## Summary
- Collapsed duplicate finding sections now show the full finding description when expanded
- Summary line shows severity emoji, title, file, and severity for quick scanning
- Matched previous finding title shown as italic context

Closes #396