### PR TITLE
fix: remove @manki-labs backwards-compat from mention patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For the full setup guide (permissions, memory system, GitHub App identity, troub
 | `/manki forget suppression <pattern>` | Remove a suppression matching the pattern |
 | `/manki help` | Show all commands |
 
-You can also use `@manki` or `@manki-labs` as the command prefix, or reply to any of her review comments to start a conversation. Tip: You can edit a comment to add `/manki` if you forgot to include it.
+You can also use `@manki` as the command prefix, or reply to any of her review comments to start a conversation. Tip: You can edit a comment to add `/manki` if you forgot to include it.
 
 ## Configure
 
@@ -120,7 +120,7 @@ nit_handling: issues
 memory:
   enabled: true
   repo: "your-org/review-memory"
-# memory_repo_token is optional if the manki-labs GitHub App
+# memory_repo_token is optional if the manki-review GitHub App
 # is installed on your memory repo. Otherwise, add it as a
 # workflow secret: memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}
 ```

--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -125,21 +125,6 @@ describe('parseCommand', () => {
     expect(result).toEqual<ParsedCommand>({ type: 'help', args: '' });
   });
 
-  it('parses @manki-labs prefix (backwards compat)', () => {
-    const result = parseCommand('@manki-labs explain the error handling');
-    expect(result).toEqual<ParsedCommand>({ type: 'explain', args: 'the error handling' });
-  });
-
-  it('parses @manki-labs dismiss (backwards compat)', () => {
-    const result = parseCommand('@manki-labs dismiss null-check-warning');
-    expect(result).toEqual<ParsedCommand>({ type: 'dismiss', args: 'null-check-warning' });
-  });
-
-  it('parses @manki-labs help (backwards compat)', () => {
-    const result = parseCommand('@manki-labs help');
-    expect(result).toEqual<ParsedCommand>({ type: 'help', args: '' });
-  });
-
   it('is case-insensitive for /manki prefix', () => {
     const result = parseCommand('/Manki EXPLAIN the changes');
     expect(result).toEqual<ParsedCommand>({ type: 'explain', args: 'the changes' });

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -215,8 +215,8 @@ interface ParsedCommand {
   args: string;
 }
 
-const BOT_MENTION_PATTERN = /(?:@manki-review|@manki-labs|@manki|\/manki)\b/;
-const BOT_PREFIX_PATTERN = /(?:@manki-review|@manki-labs|@manki|\/manki)\s+(explain|dismiss|help|remember|forget|check|triage)(?:\s+(.*))?/;
+const BOT_MENTION_PATTERN = /(?:@manki-review|@manki|\/manki)\b/;
+const BOT_PREFIX_PATTERN = /(?:@manki-review|@manki|\/manki)\s+(explain|dismiss|help|remember|forget|check|triage)(?:\s+(.*))?/;
 
 function parseCommand(body: string): ParsedCommand {
   const lower = body.toLowerCase();


### PR DESCRIPTION
## Summary
- Removed `@manki-labs` from `BOT_MENTION_PATTERN` and `BOT_PREFIX_PATTERN`
- Removed backwards-compat test cases
- Updated README references from `manki-labs` to `manki-review`

Closes #402