### PR TITLE
fix: skip redundant review after recent approval

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2206,7 +2206,7 @@ describe('isReviewInProgress', () => {
 describe('isRecentlyApproved', () => {
   type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
 
-  function makeMockOctokit(reviews: Array<{ user: { login: string; type?: string }; state: string; submitted_at: string }>) {
+  function makeMockOctokit(reviews: Array<{ user: { login: string; type?: string }; state: string; submitted_at: string; commit_id?: string }>) {
     return {
       rest: {
         pulls: {
@@ -2280,5 +2280,52 @@ describe('isRecentlyApproved', () => {
     expect(octokit.rest.pulls.listReviews).toHaveBeenCalledWith({
       owner: 'owner', repo: 'repo', pull_number: 1, per_page: 100,
     });
+  });
+
+  it('returns false when commitSha does not match approval commit_id', async () => {
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const octokit = makeMockOctokit([
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'APPROVED', submitted_at: twoMinutesAgo, commit_id: 'old-sha' },
+    ]);
+
+    expect(await isRecentlyApproved(octokit, 'owner', 'repo', 1, 'new-sha')).toBe(false);
+  });
+
+  it('returns true when commitSha matches approval commit_id', async () => {
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const octokit = makeMockOctokit([
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'APPROVED', submitted_at: twoMinutesAgo, commit_id: 'same-sha' },
+    ]);
+
+    expect(await isRecentlyApproved(octokit, 'owner', 'repo', 1, 'same-sha')).toBe(true);
+  });
+
+  it('skips commitSha check when not provided', async () => {
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const octokit = makeMockOctokit([
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'APPROVED', submitted_at: twoMinutesAgo, commit_id: 'any-sha' },
+    ]);
+
+    expect(await isRecentlyApproved(octokit, 'owner', 'repo', 1)).toBe(true);
+  });
+
+  it('returns true when multiple non-dismissed reviews end with APPROVED', async () => {
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const octokit = makeMockOctokit([
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'CHANGES_REQUESTED', submitted_at: twoMinutesAgo },
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'APPROVED', submitted_at: twoMinutesAgo },
+    ]);
+
+    expect(await isRecentlyApproved(octokit, 'owner', 'repo', 1)).toBe(true);
+  });
+
+  it('returns false when multiple non-dismissed reviews end with CHANGES_REQUESTED', async () => {
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const octokit = makeMockOctokit([
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'APPROVED', submitted_at: twoMinutesAgo },
+      { user: { login: 'manki-review[bot]', type: 'Bot' }, state: 'CHANGES_REQUESTED', submitted_at: twoMinutesAgo },
+    ]);
+
+    expect(await isRecentlyApproved(octokit, 'owner', 'repo', 1)).toBe(false);
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1013,6 +1013,7 @@ async function isRecentlyApproved(
   owner: string,
   repo: string,
   prNumber: number,
+  commitSha?: string,
 ): Promise<boolean> {
   try {
     const { data: reviews } = await octokit.rest.pulls.listReviews({
@@ -1027,6 +1028,8 @@ async function isRecentlyApproved(
 
     const latest = botReviews[botReviews.length - 1];
     if (latest.state !== 'APPROVED') return false;
+
+    if (commitSha && latest.commit_id !== commitSha) return false;
 
     const submittedAt = new Date(latest.submitted_at || 0);
     const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -776,6 +776,9 @@ describe('isRecentlyApproved guard', () => {
 
     expect(jest.mocked(core.info)).toHaveBeenCalledWith('Recently approved — skipping redundant review');
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 42, 'eyes',
+    );
   });
 
   it('force review bypasses the recently approved check', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,7 @@ async function handlePullRequest(): Promise<void> {
     return;
   }
 
-  if (await isRecentlyApproved(octokit, owner, repo, prNumber)) {
+  if (await isRecentlyApproved(octokit, owner, repo, prNumber, commitSha)) {
     core.info('Recently approved — skipping redundant review');
     return;
   }
@@ -248,6 +248,12 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
 
   const octokit = await getOctokit();
 
+  const { data: pr } = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
   if (!forceReview) {
     const remaining = await isReviewInProgress(octokit, owner, repo, prNumber);
     if (remaining !== false) {
@@ -259,7 +265,10 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
       return;
     }
 
-    if (await isRecentlyApproved(octokit, owner, repo, prNumber)) {
+    if (await isRecentlyApproved(octokit, owner, repo, prNumber, pr.head.sha)) {
+      if (payload.comment?.id) {
+        await reactToIssueComment(octokit, owner, repo, payload.comment.id, 'eyes');
+      }
       core.info('Recently approved — skipping redundant review');
       return;
     }
@@ -269,12 +278,6 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
   if (!forceReview && payload.comment?.id) {
     await reactToIssueComment(octokit, owner, repo, payload.comment.id, 'eyes');
   }
-
-  const { data: pr } = await octokit.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: prNumber,
-  });
 
   const prContext: PrContext = {
     title: pr.title,


### PR DESCRIPTION
## Summary
- Add `isRecentlyApproved` check that skips reviews when the latest bot review is APPROVED and < 5 minutes old
- Prevents the race where a new review starts immediately after auto-approval (from concurrent workflow runs triggered by thread resolution + `@manki review` comments)
- Force review (`- [x] Force review` checkbox) bypasses the check

Closes #420