### PR TITLE
chore: ignore .claude/ and coverage/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 *.tgz
 .env
 dist/
+.claude/
+coverage/


### PR DESCRIPTION
Adds local Claude Code state (`.claude/worktrees/`, scheduled task locks) and Jest coverage output (`coverage/`) to `.gitignore` so they stop appearing as untracked.

## Test plan
- [ ] `git status` in a clean checkout no longer surfaces `.claude/` or `coverage/`