### PR TITLE
chore: reorder `models` config keys by pipeline order

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,10 +14,10 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   review_level: 'auto',
   review_thresholds: { small: 200, medium: 1000 },
   models: {
+    planner: 'claude-haiku-4-5',
     reviewer: 'claude-sonnet-4-6',
     judge: 'claude-opus-4-6',
     dedup: 'claude-haiku-4-5',
-    planner: 'claude-haiku-4-5',
   },
   planner: {
     enabled: true,
@@ -140,6 +140,9 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
     if (!models || typeof models !== 'object' || Array.isArray(models)) {
       errors.push('`models` must be an object');
     } else {
+      if ('planner' in models && typeof models.planner !== 'string') {
+        errors.push('`models.planner` must be a string');
+      }
       if ('reviewer' in models && typeof models.reviewer !== 'string') {
         errors.push('`models.reviewer` must be a string');
       }
@@ -148,9 +151,6 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
       }
       if ('dedup' in models && typeof models.dedup !== 'string') {
         errors.push('`models.dedup` must be a string');
-      }
-      if ('planner' in models && typeof models.planner !== 'string') {
-        errors.push('`models.planner` must be a string');
       }
     }
   }
@@ -276,7 +276,7 @@ export function loadConfigFromFile(filePath: string): ReviewConfig {
   return loadConfigFromContent(content);
 }
 
-export function resolveModel(config: ReviewConfig, stage: 'reviewer' | 'judge' | 'dedup' | 'planner'): string {
+export function resolveModel(config: ReviewConfig, stage: 'planner' | 'reviewer' | 'judge' | 'dedup'): string {
   return config.models?.[stage] || DEFAULT_CONFIG.models![stage]!;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,11 +342,11 @@ async function runFullReview(
       oauthToken: oauthToken || undefined,
       apiKey: apiKey || undefined,
     };
+    const plannerModel = resolveModel(config, 'planner');
     const reviewerModel = resolveModel(config, 'reviewer');
     const judgeModel = resolveModel(config, 'judge');
     const dedupModel = resolveModel(config, 'dedup');
-    const plannerModel = resolveModel(config, 'planner');
-    core.info(`Models — reviewer: ${reviewerModel}, judge: ${judgeModel}, dedup: ${dedupModel}, planner: ${plannerModel}`);
+    core.info(`Models — planner: ${plannerModel}, reviewer: ${reviewerModel}, judge: ${judgeModel}, dedup: ${dedupModel}`);
 
     const reviewerClient = new ClaudeClient({ ...authOptions, model: reviewerModel });
     const judgeClient = new ClaudeClient({ ...authOptions, model: judgeModel });

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,10 +68,10 @@ export interface ReviewConfig {
     repo: string;
   };
   models?: {
+    planner?: string;
     reviewer?: string;
     judge?: string;
     dedup?: string;
-    planner?: string;
   };
   planner?: {
     enabled?: boolean;


### PR DESCRIPTION
## Summary

Pure ordering change. Reorders the `models` config keys to match the pipeline execution order everywhere they appear:

1. `planner` — pre-review team/effort selection
2. `reviewer` — parallel specialist agents
3. `judge` — evaluates + classifies findings
4. `dedup` — post-judge filter against dismissed findings

### Changes

- `src/config.ts`: `DEFAULT_CONFIG.models` entries, `validateConfig` model key checks, `resolveModel` stage union
- `src/types.ts`: `ReviewConfig['models']` field order
- `src/index.ts`: log line and variable extraction order in the main run path

No behavior changes — tests access by key name, so ordering is purely cosmetic alignment with the pipeline mental model.

Closes #449

Note: PR #446 (docs) will need a small rebase after this lands since it touches the same docs surface area.