### PR TITLE
refactor: add `trivial` level variant to `TeamRoster`

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1860,7 +1860,7 @@ describe('selectTeam with teamSizeOverride', () => {
     const roster = selectTeam(diff, config, undefined, 1);
     expect(roster.agents).toHaveLength(1);
     expect(roster.agents[0]).toBe(TRIVIAL_VERIFIER_AGENT);
-    expect(roster.level).toBe('small');
+    expect(roster.level).toBe('trivial');
     expect(roster.lineCount).toBe(2);
   });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -67,7 +67,7 @@ export function selectTeam(
     if (customReviewers && customReviewers.length > 0) {
       core.info(`teamSize=1: skipping custom reviewers [${customReviewers.map(r => r.name).join(', ')}]`);
     }
-    return { level: 'small', agents: [TRIVIAL_VERIFIER_AGENT], lineCount };
+    return { level: 'trivial', agents: [TRIVIAL_VERIFIER_AGENT], lineCount };
   }
 
   if (teamSizeOverride) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface ReviewThresholds {
 }
 
 export interface TeamRoster {
-  level: 'small' | 'medium' | 'large';  // resolved, never 'auto'
+  level: 'trivial' | 'small' | 'medium' | 'large';  // resolved, never 'auto'
   agents: ReviewerAgent[];
   lineCount: number;
 }


### PR DESCRIPTION
## Summary

Extends `TeamRoster.level` union from `'small' | 'medium' | 'large'` to `'trivial' | 'small' | 'medium' | 'large'`, and returns `'trivial'` for the `teamSize=1` branch in `selectTeam`. Previously, 1-agent trivial reviews and 3-agent small reviews both reported `level: 'small'`, conflating two distinct cases in dashboards, progress comments, and logs.

## Changes

- `src/types.ts`: widen `TeamRoster.level` union to include `'trivial'`.
- `src/review.ts`: `selectTeam` `teamSizeOverride === 1` branch returns `level: 'trivial'`.
- `src/review.test.ts`: updated the teamSize=1 assertion to expect `'trivial'`.

No consumers needed changes — `team.level` is only passed through as a display string (`core.info` logs and `metadata.config.reviewLevel` for progress comments), and there are no `switch` statements on it.

Closes #440