### PR TITLE
docs: add permission comments to workflow examples

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -135,11 +135,11 @@ on:
     types: [created]
 
 permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
-  actions: read
+  contents: read          # read repo files and diffs
+  pull-requests: write    # post review comments and approvals
+  issues: write           # create nit issues when configured
+  id-token: write         # OIDC token for GitHub App identity
+  actions: read           # verify workflow run is legitimate
 
 jobs:
   review:

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,11 +149,11 @@ on:
     types: [created]
 
 permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
-  actions: read
+  contents: read          # read repo files and diffs
+  pull-requests: write    # post review comments and approvals
+  issues: write           # create nit issues when configured
+  id-token: write         # OIDC token for GitHub App identity
+  actions: read           # verify workflow run is legitimate
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- Added inline comments explaining each permission in the workflow YAML (`contents: read # read repo files and diffs`, etc.)
- Updated both SETUP.md (authoritative source) and docs/index.html (landing page)

Closes #479