### PR TITLE
chore: migrate token service to manki-api.dustinface.me

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,9 @@ inputs:
     description: 'GitHub App private key (PEM format) for generating installation tokens'
     required: false
   manki_token_url:
-    description: 'Token service URL for GitHub App identity (default: https://api.manki.dustinface.me/token)'
+    description: 'Token service URL for GitHub App identity (default: https://manki-api.dustinface.me/token)'
     required: false
-    default: 'https://api.manki.dustinface.me/token'
+    default: 'https://manki-api.dustinface.me/token'
 
 outputs:
   review_id:

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -80,7 +80,7 @@ describe('getMemoryToken', () => {
 });
 
 const GITHUB_TOKEN = 'ghp_test_token_123';
-const TOKEN_URL = 'https://api.manki.dustinface.me/token';
+const TOKEN_URL = 'https://manki-api.dustinface.me/token';
 const OWNER = 'test-owner';
 const REPO = 'test-repo';
 const APP_TOKEN = 'ghs_app_token_456';

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,7 +29,7 @@ export async function resolveGitHubToken(
     // Request OIDC token from GitHub Actions
     let oidcToken: string;
     try {
-      oidcToken = await core.getIDToken('api.manki.dustinface.me');
+      oidcToken = await core.getIDToken('manki-api.dustinface.me');
     } catch {
       core.info('OIDC token not available — using github-actions[bot] identity');
       return { token: githubToken, identity: 'actions' };
@@ -89,7 +89,7 @@ export async function createAuthenticatedOctokit(): Promise<AuthResult> {
     throw new Error('No authentication configured. Provide either github_token or both github_app_id and github_app_private_key.');
   }
 
-  const tokenUrl = core.getInput('manki_token_url') || 'https://api.manki.dustinface.me/token';
+  const tokenUrl = core.getInput('manki_token_url') || 'https://manki-api.dustinface.me/token';
   const { owner, repo: repoName } = github.context.repo;
   const { token } = await resolveGitHubToken(githubToken, tokenUrl, owner, repoName);
 


### PR DESCRIPTION
## Summary
- Moved token service URL from `manki.dustinface.me` to `manki-api.dustinface.me` (action.yml default, src/auth.ts, tests)
- Added `docs/CNAME` for GitHub Pages custom domain at `manki.dustinface.me`
- Frees up `manki.dustinface.me` for the landing page