### PR TITLE
feat: telemetry for reviewer-agent responses (empty vs malformed)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -612,6 +612,7 @@ async function runFullReview(
         name,
         findingsRaw: rawFindings.filter(f => f.reviewers.includes(name)).length,
         findingsKept: result.findings.filter(f => f.reviewers.includes(name)).length,
+        responseLength: result.agentResponseLengths?.get(name),
       }))
       : undefined;
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -95,18 +95,74 @@ describe('parseFindings', () => {
   });
 
   it('returns empty array for invalid JSON', () => {
-    const findings = parseFindings('this is not json', 'Reviewer');
-    expect(findings).toEqual([]);
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const findings = parseFindings('this is not json', 'Reviewer');
+      expect(findings).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('returns empty array for non-array JSON', () => {
-    const findings = parseFindings('{"not": "an array"}', 'Reviewer');
-    expect(findings).toEqual([]);
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const findings = parseFindings('{"not": "an array"}', 'Reviewer');
+      expect(findings).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('parses empty array', () => {
     const findings = parseFindings('[]', 'Reviewer');
     expect(findings).toEqual([]);
+  });
+
+  it('does not warn for empty array response', () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const findings = parseFindings('[]', 'TestAgent');
+      expect(findings).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn for empty response', () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const findings = parseFindings('', 'TestAgent');
+      expect(findings).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns on malformed non-empty response', () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const findings = parseFindings('this is garbage text', 'SecurityAgent');
+      expect(findings).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/SecurityAgent.*malformed.*length: 20/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns when parsed result is not an array', () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const findings = parseFindings('{"key": "value"}', 'ArchAgent');
+      expect(findings).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/ArchAgent.*expected array.*object/);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('handles missing fields gracefully', () => {
@@ -1724,6 +1780,84 @@ describe('runReview', () => {
     expect(result.reviewComplete).toBe(true);
     // Should gracefully fall back to heuristic
     expect(result.agentNames).toHaveLength(3);
+  });
+
+  it('warns when agent returns 0 findings with short duration', async () => {
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      await runReview(clients, config, diff, 'raw diff', 'repo context');
+
+      const fastWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('suspiciously fast'),
+      );
+      // All 3 agents return [] near-instantly, so all should trigger
+      expect(fastWarnings.length).toBe(3);
+    } finally {
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('does not warn for 0 findings with normal duration', async () => {
+    // Simulate a slow response by delaying the mock
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockImplementation(() => {
+          // Use fake timers to simulate passage of time
+          jest.advanceTimersByTime(20_000);
+          return Promise.resolve({ content: '[]' });
+        }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn(),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'nextTick', 'queueMicrotask'] });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      await runReview(clients, config, diff, 'raw diff', 'repo context');
+
+      const fastWarnings = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('suspiciously fast'),
+      );
+      expect(fastWarnings.length).toBe(0);
+    } finally {
+      jest.useRealTimers();
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('includes agentResponseLengths in result', async () => {
+    const response = JSON.stringify([
+      { severity: 'suggestion', title: 'Test', file: 'a.ts', line: 1, description: 'Desc' },
+    ]);
+    const clients = makeClients(response);
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [
+        { severity: 'suggestion', title: 'Test', file: 'a.ts', line: 1, description: 'Desc', reviewers: ['Security & Safety'] },
+      ],
+      summary: 'One finding.',
+    });
+
+    const result = await runReview(clients, config, diff, 'raw diff', 'repo context');
+    expect(result.agentResponseLengths).toBeDefined();
+    expect(result.agentResponseLengths!.size).toBe(3);
+    for (const [, length] of result.agentResponseLengths!) {
+      expect(length).toBe(response.length);
+    }
   });
 });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -378,6 +378,7 @@ export async function runReview(
 
   const allFindings: Finding[] = [];
   const failedAgents: string[] = [];
+  const agentResponseLengths = new Map<string, number>();
 
   let completedCount = 0;
   let progressFindingCount = 0;
@@ -395,14 +396,17 @@ export async function runReview(
       );
 
       const passFindings: Finding[][] = [];
+      let totalResponseLength = 0;
       for (const result of passResults) {
         if (result.status === 'fulfilled') {
-          passFindings.push(result.value);
+          passFindings.push(result.value.findings);
+          totalResponseLength += result.value.responseLength;
         } else {
           core.warning(`${agent.name} pass failed: ${result.reason}`);
         }
       }
 
+      agentResponseLengths.set(agent.name, totalResponseLength);
       completedCount++;
 
       if (passFindings.length > 0) {
@@ -412,12 +416,17 @@ export async function runReview(
         core.info(`Multi-pass: ${agent.name} — ${passFindings.length} passes, ${consistent.length} consistent findings (from ${totalRaw} raw)`);
         allFindings.push(...consistent);
 
+        const durationMs = Date.now() - startTime;
+        if (consistent.length === 0 && durationMs < 15_000) {
+          core.warning(`${agent.name}: 0 findings in ${(durationMs / 1000).toFixed(1)}s — suspiciously fast`);
+        }
+
         if (onProgress) {
           onProgress({
             phase: 'agent-complete',
             agentName: agent.name,
             agentFindingCount: consistent.length,
-            agentDurationMs: Date.now() - startTime,
+            agentDurationMs: durationMs,
             agentStatus: 'success',
             rawFindingCount: allFindings.length,
             completedAgents: completedCount,
@@ -448,22 +457,29 @@ export async function runReview(
     const agentPromises = team.agents.map(agent => {
       const startTime = Date.now();
       return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, reviewerEffort)
-        .then(findings => {
+        .then(agentResult => {
           completedCount++;
-          progressFindingCount += findings.length;
+          agentResponseLengths.set(agent.name, agentResult.responseLength);
+          progressFindingCount += agentResult.findings.length;
+          const durationMs = Date.now() - startTime;
+
+          if (agentResult.findings.length === 0 && durationMs < 15_000) {
+            core.warning(`${agent.name}: 0 findings in ${(durationMs / 1000).toFixed(1)}s — suspiciously fast`);
+          }
+
           if (onProgress) {
             onProgress({
               phase: 'agent-complete',
               agentName: agent.name,
-              agentFindingCount: findings.length,
-              agentDurationMs: Date.now() - startTime,
+              agentFindingCount: agentResult.findings.length,
+              agentDurationMs: durationMs,
               agentStatus: 'success',
               rawFindingCount: progressFindingCount,
               completedAgents: completedCount,
               totalAgents: team.agents.length,
             });
           }
-          return findings;
+          return agentResult.findings;
         })
         .catch(error => {
           completedCount++;
@@ -623,7 +639,13 @@ export async function runReview(
     staticDedupCount,
     llmDedupCount,
     suppressionCount,
+    agentResponseLengths,
   };
+}
+
+interface AgentResult {
+  findings: Finding[];
+  responseLength: number;
 }
 
 async function runReviewerAgent(
@@ -637,13 +659,14 @@ async function runReviewerAgent(
   memoryContext?: string,
   linkedIssues?: LinkedIssue[],
   effort?: 'low' | 'medium' | 'high',
-): Promise<Finding[]> {
+): Promise<AgentResult> {
   const systemPrompt = buildReviewerSystemPrompt(reviewer, config);
   const userMessage = buildReviewerUserMessage(rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues);
 
   const options = effort ? { effort } : undefined;
   const response = await client.sendMessage(systemPrompt, userMessage, options);
-  return parseFindings(response.content, reviewer.name);
+  const findings = parseFindings(response.content, reviewer.name);
+  return { findings, responseLength: response.content.length };
 }
 
 export function buildReviewerSystemPrompt(reviewer: ReviewerAgent, config: ReviewConfig): string {
@@ -763,12 +786,18 @@ export function buildReviewerUserMessage(
 }
 
 export function parseFindings(responseText: string, reviewerName: string): Finding[] {
+  core.debug(`${reviewerName} response length: ${responseText.length}`);
+
+  if (responseText.trim().length === 0) {
+    return [];
+  }
+
   const jsonText = extractJSON(responseText);
 
   try {
     const parsed = JSON.parse(jsonText);
     if (!Array.isArray(parsed)) {
-      core.warning(`${reviewerName} did not return an array, got: ${typeof parsed}`);
+      core.warning(`${reviewerName}: expected array but got ${typeof parsed} (response length: ${responseText.length})`);
       return [];
     }
 
@@ -782,7 +811,8 @@ export function parseFindings(responseText: string, reviewerName: string): Findi
       reviewers: [reviewerName],
     }));
   } catch (e) {
-    core.warning(`Failed to parse findings from ${reviewerName}: ${e}`);
+    const errorMsg = e instanceof Error ? e.message : String(e);
+    core.warning(`${reviewerName}: malformed response (length: ${responseText.length}, error: ${errorMsg.slice(0, 200)})`);
     return [];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface ReviewResult {
   staticDedupCount?: number;
   llmDedupCount?: number;
   suppressionCount?: number;
+  agentResponseLengths?: Map<string, number>;
 }
 
 export interface ReviewerAgent {
@@ -135,6 +136,7 @@ export interface ReviewStats {
     findingsRaw: number;
     findingsKept: number;
     failureReason?: string;
+    responseLength?: number;
   }>;
 
   // Judge calibration


### PR DESCRIPTION
## Summary

- `parseFindings()` now warns on malformed non-empty responses (distinguishes from legitimate empty)
- Short-duration + zero-findings agents flagged as suspicious
- `responseLength` tracked per agent and included in Review stats JSON

Closes #460