### PR TITLE
fix: update docs footer attribution to manki-review org

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -248,7 +248,7 @@ jobs:
         <a href="https://github.com/manki-review/manki/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/manki-review/manki/blob/main/LICENSE">AGPL-3.0 License</a>
       </div>
-      <p>Built with care by <a href="https://github.com/manki-review">manki-review</a></p>
+      <p>Built by <a href="https://github.com/manki-review">manki-review</a></p>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary

- Updated footer in `docs/index.html` from `xdustinface` to `manki-review`

Closes #486