### PR TITLE
chore: prepare v4.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Manki will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.3] - 2026-04-10
+
+### Fixed
+
+- LLM-triggering commands (`review`, `explain`, generic questions, inline reply handling) now require `OWNER`, `MEMBER`, `COLLABORATOR`, or `CONTRIBUTOR` association — or be the PR author — preventing arbitrary users from consuming API quota on public repos (#530)
+- PR-author bypass correctly guarded against absent payload fields with diagnostic logging (#530)
+
 ## [4.5.2] - 2026-04-07
 
 ### Changed
@@ -351,6 +358,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic review posting with inline comments
 - Configuration via `.manki.yml`
 
+[4.5.3]: https://github.com/manki-review/manki/compare/v4.5.2...v4.5.3
 [4.5.2]: https://github.com/manki-review/manki/compare/v4.5.1...v4.5.2
 [4.5.1]: https://github.com/manki-review/manki/compare/v4.5.0...v4.5.1
 [4.5.0]: https://github.com/manki-review/manki/compare/v4.4.0...v4.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manki",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "Multi-agent AI code review GitHub Action",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version to `4.5.3`
- Adds CHANGELOG entry for the access-control security fix (#530)