### PR TITLE
feat: warn on PR when GitHub App is not installed

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -257,6 +257,7 @@ describe('createAuthenticatedOctokit', () => {
     expect(core.setSecret).toHaveBeenCalledWith('installation-token-abc');
     expect(result.octokit).toBeDefined();
     expect(result.resolvedToken).toBe('installation-token-abc');
+    expect(result.identity).toBe('app');
   });
 
   it('throws when github_app_id is not a number', async () => {
@@ -293,6 +294,7 @@ describe('createAuthenticatedOctokit', () => {
 
     expect(result.octokit).toBeDefined();
     expect(result.resolvedToken).toBe('ghp_fallback');
+    expect(result.identity).toBe('actions');
     expect(mockGetOctokit).toHaveBeenCalledWith('ghp_fallback');
   });
 
@@ -315,6 +317,7 @@ describe('createAuthenticatedOctokit', () => {
     const result = await createAuthenticatedOctokit();
 
     expect(result.resolvedToken).toBe('resolved-app-token');
+    expect(result.identity).toBe('app');
     expect(getMemoryToken(result.resolvedToken)).toBe('resolved-app-token');
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,6 +8,7 @@ type Octokit = ReturnType<typeof github.getOctokit>;
 export interface AuthResult {
   octokit: Octokit;
   resolvedToken: string;
+  identity: 'app' | 'actions';
 }
 
 export interface TokenResult {
@@ -82,7 +83,7 @@ export async function createAuthenticatedOctokit(): Promise<AuthResult> {
   if (appId && privateKey) {
     core.info('Using GitHub App authentication for custom bot identity');
     const token = await getInstallationToken(appId, privateKey);
-    return { octokit: github.getOctokit(token), resolvedToken: token };
+    return { octokit: github.getOctokit(token), resolvedToken: token, identity: 'app' };
   }
 
   if (!githubToken) {
@@ -91,9 +92,9 @@ export async function createAuthenticatedOctokit(): Promise<AuthResult> {
 
   const tokenUrl = core.getInput('manki_token_url') || 'https://manki-api.dustinface.me/token';
   const { owner, repo: repoName } = github.context.repo;
-  const { token } = await resolveGitHubToken(githubToken, tokenUrl, owner, repoName);
+  const { token, identity } = await resolveGitHubToken(githubToken, tokenUrl, owner, repoName);
 
-  return { octokit: github.getOctokit(token), resolvedToken: token };
+  return { octokit: github.getOctokit(token), resolvedToken: token, identity };
 }
 
 /**

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2862,7 +2862,17 @@ describe('postAppWarningIfNeeded', () => {
     }));
   });
 
-  it('skips posting when bot has already posted the warning', async () => {
+  it('skips posting when github-actions[bot] has already posted the warning', async () => {
+    const { octokit, createComment } = makeOctokit([
+      { body: `${APP_WARNING_MARKER}\nWarning text`, user: { login: 'github-actions[bot]' } },
+    ]);
+
+    await postAppWarningIfNeeded(octokit, 'owner', 'repo', 1);
+
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it('skips posting when manki-review[bot] has already posted the warning', async () => {
     const { octokit, createComment } = makeOctokit([
       { body: `${APP_WARNING_MARKER}\nWarning text`, user: { login: BOT_LOGIN } },
     ]);

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2860,6 +2860,9 @@ describe('postAppWarningIfNeeded', () => {
     expect(createComment).toHaveBeenCalledWith(expect.objectContaining({
       body: expect.stringContaining(APP_WARNING_MARKER),
     }));
+    expect(createComment).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('https://github.com/apps/manki-review'),
+    }));
   });
 
   it('skips posting when github-actions[bot] has already posted the warning', async () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,4 +1,4 @@
-import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, extractRunIdFromBody, extractVersionFromBody, INDENT } from './github';
+import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats } from './types';
 
 describe('formatFindingComment', () => {
@@ -2836,5 +2836,51 @@ describe('isApprovedOnCommit', () => {
     ]);
 
     expect(await isApprovedOnCommit(octokit, 'owner', 'repo', 1, 'sha-123')).toBe(false);
+  });
+});
+
+describe('postAppWarningIfNeeded', () => {
+  type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
+
+  function makeOctokit(comments: Array<{ body: string; user: { login: string } }>) {
+    const createComment = jest.fn().mockResolvedValue({});
+    const paginate = jest.fn().mockResolvedValue(comments);
+    const octokit = {
+      paginate,
+      rest: { issues: { listComments: {}, createComment } },
+    } as unknown as Octokit;
+    return { octokit, createComment, paginate };
+  }
+
+  it('posts warning comment when no existing warning is present', async () => {
+    const { octokit, createComment } = makeOctokit([]);
+
+    await postAppWarningIfNeeded(octokit, 'owner', 'repo', 1);
+
+    expect(createComment).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining(APP_WARNING_MARKER),
+    }));
+  });
+
+  it('skips posting when bot has already posted the warning', async () => {
+    const { octokit, createComment } = makeOctokit([
+      { body: `${APP_WARNING_MARKER}\nWarning text`, user: { login: BOT_LOGIN } },
+    ]);
+
+    await postAppWarningIfNeeded(octokit, 'owner', 'repo', 1);
+
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it('posts warning when a human (not the bot) has the marker in their comment', async () => {
+    const { octokit, createComment } = makeOctokit([
+      { body: `${APP_WARNING_MARKER}\nCopied marker`, user: { login: 'some-human' } },
+    ]);
+
+    await postAppWarningIfNeeded(octokit, 'owner', 'repo', 1);
+
+    expect(createComment).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining(APP_WARNING_MARKER),
+    }));
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2842,7 +2842,7 @@ describe('isApprovedOnCommit', () => {
 describe('postAppWarningIfNeeded', () => {
   type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
 
-  function makeOctokit(comments: Array<{ body: string; user: { login: string } }>) {
+  function makeOctokit(comments: Array<{ body: string; user: { login: string } | null }>) {
     const createComment = jest.fn().mockResolvedValue({});
     const paginate = jest.fn().mockResolvedValue(comments);
     const octokit = {
@@ -2895,5 +2895,14 @@ describe('postAppWarningIfNeeded', () => {
     expect(createComment).toHaveBeenCalledWith(expect.objectContaining({
       body: expect.stringContaining(APP_WARNING_MARKER),
     }));
+  });
+
+  it('does not throw and re-posts warning when a comment has no user', async () => {
+    const { octokit, createComment } = makeOctokit([
+      { body: `${APP_WARNING_MARKER}\nWarning`, user: null },
+    ]);
+
+    await expect(postAppWarningIfNeeded(octokit, 'owner', 'repo', 1)).resolves.toBeUndefined();
+    expect(createComment).toHaveBeenCalled();
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1239,4 +1239,26 @@ async function isApprovedOnCommit(octokit: Octokit, owner: string, repo: string,
   }
 }
 
-export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, extractRunIdFromBody, extractVersionFromBody };
+const APP_WARNING_MARKER = '<!-- manki-app-warning -->';
+
+async function postAppWarningIfNeeded(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<void> {
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner, repo, issue_number: prNumber, per_page: 100,
+  });
+
+  if (comments.some(c => c.body?.includes(APP_WARNING_MARKER))) {
+    return;
+  }
+
+  await octokit.rest.issues.createComment({
+    owner, repo, issue_number: prNumber,
+    body: `${APP_WARNING_MARKER}\n**Manki** — The [Manki GitHub App](https://github.com/apps/manki-review) is not installed on this repository. Reviews are posting as \`github-actions[bot]\` instead of \`manki-review[bot]\`. Some features (memory repo access, bot identity for review dismissal) may not work correctly.\n\nInstall the app at: https://github.com/apps/manki-review`,
+  });
+}
+
+export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };

--- a/src/github.ts
+++ b/src/github.ts
@@ -10,6 +10,7 @@ import { MAX_AGENT_RETRIES } from './types';
 type Octokit = ReturnType<typeof github.getOctokit>;
 
 const BOT_LOGIN = 'manki-review[bot]';
+const ACTIONS_BOT_LOGIN = 'github-actions[bot]';
 const BOT_MARKER = '<!-- manki-bot -->';
 const REVIEW_COMPLETE_MARKER = '<!-- manki-review-complete -->';
 const FORCE_REVIEW_MARKER = '<!-- manki-force-review -->';
@@ -1251,7 +1252,10 @@ async function postAppWarningIfNeeded(
     owner, repo, issue_number: prNumber,
   });
 
-  if (comments.some(c => c.user?.login === BOT_LOGIN && c.body?.includes(APP_WARNING_MARKER))) {
+  if (comments.some(c =>
+    (c.user?.login === BOT_LOGIN || c.user?.login === ACTIONS_BOT_LOGIN) &&
+    c.body?.includes(APP_WARNING_MARKER)
+  )) {
     return;
   }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1247,11 +1247,11 @@ async function postAppWarningIfNeeded(
   repo: string,
   prNumber: number,
 ): Promise<void> {
-  const { data: comments } = await octokit.rest.issues.listComments({
-    owner, repo, issue_number: prNumber, per_page: 100,
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    owner, repo, issue_number: prNumber,
   });
 
-  if (comments.some(c => c.body?.includes(APP_WARNING_MARKER))) {
+  if (comments.some(c => c.user?.login === BOT_LOGIN && c.body?.includes(APP_WARNING_MARKER))) {
     return;
   }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2390,6 +2390,24 @@ describe('runFullReview orchestration', () => {
 
     expect(jest.mocked(ghUtils.postAppWarningIfNeeded)).not.toHaveBeenCalled();
   });
+
+  it('continues review and warns when postAppWarningIfNeeded throws', async () => {
+    _resetOctokitCache();
+    jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      octokit: mockOctokitInstance as any,
+      resolvedToken: 'mock-token',
+      identity: 'actions',
+    });
+    jest.mocked(ghUtils.postAppWarningIfNeeded).mockRejectedValueOnce(new Error('API error'));
+
+    await callRunFullReview();
+
+    expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to post app warning'),
+    );
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+  });
 });
 
 describe('handleInteraction', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2362,6 +2362,7 @@ describe('runFullReview orchestration', () => {
   });
 
   it('posts app warning when identity is actions', async () => {
+    _resetOctokitCache();
     jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       octokit: mockOctokitInstance as any,
@@ -2377,6 +2378,7 @@ describe('runFullReview orchestration', () => {
   });
 
   it('does not post app warning when identity is app', async () => {
+    _resetOctokitCache();
     jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       octokit: mockOctokitInstance as any,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -48,7 +48,7 @@ const mockOctokitInstance = {
 };
 
 jest.mock('./auth', () => ({
-  createAuthenticatedOctokit: jest.fn().mockResolvedValue({ octokit: mockOctokitInstance, resolvedToken: 'mock-resolved-token' }),
+  createAuthenticatedOctokit: jest.fn().mockResolvedValue({ octokit: mockOctokitInstance, resolvedToken: 'mock-resolved-token', identity: 'app' }),
   getMemoryToken: jest.fn().mockReturnValue(null),
 }));
 
@@ -126,10 +126,12 @@ jest.mock('./github', () => ({
   isReviewInProgress: jest.fn().mockResolvedValue(false),
   isApprovedOnCommit: jest.fn().mockResolvedValue(false),
   markOwnProgressCommentCancelled: jest.fn().mockResolvedValue(false),
+  postAppWarningIfNeeded: jest.fn().mockResolvedValue(undefined),
   BOT_LOGIN: 'manki-review[bot]',
   BOT_MARKER: '<!-- manki-bot -->',
   REVIEW_COMPLETE_MARKER: '<!-- manki-review-complete -->',
   FORCE_REVIEW_MARKER: '<!-- manki-force-review -->',
+  APP_WARNING_MARKER: '<!-- manki-app-warning -->',
 }));
 
 jest.mock('./state', () => ({
@@ -2357,6 +2359,34 @@ describe('runFullReview orchestration', () => {
 
     expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+  });
+
+  it('posts app warning when identity is actions', async () => {
+    jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      octokit: mockOctokitInstance as any,
+      resolvedToken: 'mock-token',
+      identity: 'actions',
+    });
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.postAppWarningIfNeeded)).toHaveBeenCalledWith(
+      mockOctokitInstance, 'test-owner', 'test-repo', 42,
+    );
+  });
+
+  it('does not post app warning when identity is app', async () => {
+    jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      octokit: mockOctokitInstance as any,
+      resolvedToken: 'mock-token',
+      identity: 'app',
+    });
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.postAppWarningIfNeeded)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   isReviewInProgress,
   isApprovedOnCommit,
   markOwnProgressCommentCancelled,
+  postAppWarningIfNeeded,
 } from './github';
 import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
@@ -38,13 +39,15 @@ type Octokit = ReturnType<typeof github.getOctokit>;
 const octokitCache = {
   instance: null as Octokit | null,
   resolvedToken: null as string | null,
+  identity: null as 'app' | 'actions' | null,
 };
 
 async function getOctokit(): Promise<Octokit> {
   if (!octokitCache.instance) {
-    const { octokit, resolvedToken } = await createAuthenticatedOctokit();
+    const { octokit, resolvedToken, identity } = await createAuthenticatedOctokit();
     octokitCache.instance = octokit;
     octokitCache.resolvedToken = resolvedToken;
+    octokitCache.identity = identity;
   }
   return octokitCache.instance;
 }
@@ -309,6 +312,10 @@ async function runFullReview(
   const startTime = Date.now();
   const configPathInput = core.getInput('config_path');
   const octokit = await getOctokit();
+
+  if (octokitCache.identity === 'actions') {
+    await postAppWarningIfNeeded(octokit, owner, repo, prNumber);
+  }
 
   const progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);
 
@@ -1073,6 +1080,7 @@ if (process.env.NODE_ENV !== 'test') {
 function _resetOctokitCache(): void {
   octokitCache.instance = null;
   octokitCache.resolvedToken = null;
+  octokitCache.identity = null;
 }
 
 export { run, handlePullRequest, handleCommentTrigger, handleInteraction, handleIssueInteraction, handleReviewCommentInteraction, handleReviewStateCheck, runFullReview, main, _resetOctokitCache };

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,11 @@ async function runFullReview(
   const octokit = await getOctokit();
 
   if (octokitCache.identity === 'actions') {
-    await postAppWarningIfNeeded(octokit, owner, repo, prNumber);
+    try {
+      await postAppWarningIfNeeded(octokit, owner, repo, prNumber);
+    } catch (error) {
+      core.warning(`Failed to post app warning: ${error}`);
+    }
   }
 
   const progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);


### PR DESCRIPTION
## Summary
- Adds `identity: 'app' | 'actions'` to `AuthResult` so callers know which identity was resolved
- Posts a one-time warning comment on the PR when running as `github-actions[bot]` (app not installed), linking to the install page
- Idempotent — checks for `<!-- manki-app-warning -->` marker before posting

Closes #540