### PR TITLE
fix: cancel in-progress review run when `@manki review` is requested

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  actions: write
 
 jobs:
   review:

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  # Required for cancelActiveReviewRun to cancel superseded review runs
   actions: write
 
 jobs:

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,4 +1,4 @@
-import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats } from './types';
 
 describe('formatFindingComment', () => {
@@ -2904,5 +2904,105 @@ describe('postAppWarningIfNeeded', () => {
 
     await expect(postAppWarningIfNeeded(octokit, 'owner', 'repo', 1)).resolves.toBeUndefined();
     expect(createComment).toHaveBeenCalled();
+  });
+});
+
+describe('cancelActiveReviewRun', () => {
+  type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
+
+  function makeRunIdBody(runId: number): string {
+    return `${BOT_MARKER}\n<!-- manki-run-id:${runId} -->\n**Manki** — Review in progress`;
+  }
+
+  function makeMockOctokit(opts: {
+    comment?: { id: number; body: string } | null;
+    cancelError?: Error;
+    updateComment?: jest.Mock;
+  }) {
+    const updateComment = opts.updateComment ?? jest.fn().mockResolvedValue({});
+    const cancelWorkflowRun = opts.cancelError
+      ? jest.fn().mockRejectedValue(opts.cancelError)
+      : jest.fn().mockResolvedValue({});
+    const octokit = {
+      rest: {
+        issues: {
+          listComments: jest.fn().mockResolvedValue({
+            data: opts.comment === null || opts.comment === undefined
+              ? []
+              : [{ id: opts.comment.id, body: opts.comment.body, user: { login: BOT_LOGIN, type: 'Bot' } }],
+          }),
+          updateComment,
+        },
+        actions: {
+          cancelWorkflowRun,
+        },
+      },
+    } as unknown as Octokit;
+    return { octokit, cancelWorkflowRun, updateComment };
+  }
+
+  it('returns false when no progress comment exists', async () => {
+    const { octokit, cancelWorkflowRun } = makeMockOctokit({ comment: null });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+    expect(cancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('returns false when progress comment has no runId', async () => {
+    const { octokit, cancelWorkflowRun } = makeMockOctokit({
+      comment: { id: 10, body: `${BOT_MARKER}\n**Manki** — Review in progress` },
+    });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+    expect(cancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('returns false and skips cancellation when runId matches current run', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ghCtx = require('@actions/github').context;
+    const originalRunIdAttr = ghCtx.runId;
+    Object.defineProperty(ghCtx, 'runId', { value: 9999, configurable: true, writable: true });
+    try {
+      const { octokit, cancelWorkflowRun } = makeMockOctokit({
+        comment: { id: 11, body: makeRunIdBody(9999) },
+      });
+
+      const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+      expect(result).toBe(false);
+      expect(cancelWorkflowRun).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(ghCtx, 'runId', { value: originalRunIdAttr, configurable: true, writable: true });
+    }
+  });
+
+  it('returns true and marks comment cancelled when cancellation succeeds', async () => {
+    const updateComment = jest.fn().mockResolvedValue({});
+    const { octokit, cancelWorkflowRun } = makeMockOctokit({
+      comment: { id: 20, body: makeRunIdBody(5555) },
+      updateComment,
+    });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(true);
+    expect(cancelWorkflowRun).toHaveBeenCalledWith({ owner: 'owner', repo: 'repo', run_id: 5555 });
+    expect(updateComment).toHaveBeenCalled();
+  });
+
+  it('returns false when cancelWorkflowRun throws', async () => {
+    const { octokit, cancelWorkflowRun } = makeMockOctokit({
+      comment: { id: 30, body: makeRunIdBody(7777) },
+      cancelError: new Error('API failure'),
+    });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+    expect(cancelWorkflowRun).toHaveBeenCalled();
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -3094,4 +3094,18 @@ describe('cancelActiveReviewRun', () => {
       }));
     },
   );
+
+  it('returns true when cancel succeeds but updateComment throws', async () => {
+    const updateComment = jest.fn().mockRejectedValue(new Error('forbidden'));
+    const { octokit, cancelWorkflowRun } = makeMockOctokit({
+      comment: { id: 99, body: makeRunIdBody(2222) },
+      updateComment,
+    });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(true);
+    expect(cancelWorkflowRun).toHaveBeenCalled();
+    expect(updateComment).toHaveBeenCalled();
+  });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2994,7 +2994,12 @@ describe('cancelActiveReviewRun', () => {
 
     expect(result).toBe(true);
     expect(cancelWorkflowRun).toHaveBeenCalledWith({ owner: 'owner', repo: 'repo', run_id: 5555 });
-    expect(updateComment).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining(CANCELLED_MARKER) }));
+    expect(updateComment).toHaveBeenCalledWith(expect.objectContaining({
+      owner: 'owner',
+      repo: 'repo',
+      comment_id: 20,
+      body: expect.stringContaining(CANCELLED_MARKER),
+    }));
   });
 
   it('returns false when cancelWorkflowRun throws', async () => {
@@ -3021,5 +3026,39 @@ describe('cancelActiveReviewRun', () => {
     expect(result).toBe(false);
     expect(cancelWorkflowRun).not.toHaveBeenCalled();
     expect(updateComment).not.toHaveBeenCalled();
+  });
+
+  it('returns false when listComments throws', async () => {
+    const octokit = {
+      rest: {
+        issues: {
+          listComments: jest.fn().mockRejectedValue(new Error('network error')),
+          updateComment: jest.fn(),
+        },
+        actions: { cancelWorkflowRun: jest.fn(), getWorkflowRun: jest.fn() },
+      },
+    } as unknown as Octokit;
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+    expect(octokit.rest.actions.cancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('returns true when run is queued', async () => {
+    const updateComment = jest.fn().mockResolvedValue({});
+    const { octokit, cancelWorkflowRun } = makeMockOctokit({
+      comment: { id: 21, body: makeRunIdBody(5556) },
+      updateComment,
+      runStatus: 'queued',
+    });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(true);
+    expect(cancelWorkflowRun).toHaveBeenCalledWith({ owner: 'owner', repo: 'repo', run_id: 5556 });
+    expect(updateComment).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining(CANCELLED_MARKER),
+    }));
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -3061,4 +3061,17 @@ describe('cancelActiveReviewRun', () => {
       body: expect.stringContaining(CANCELLED_MARKER),
     }));
   });
+
+  it('returns false when getWorkflowRun throws', async () => {
+    const { octokit, getWorkflowRun, cancelWorkflowRun, updateComment } = makeMockOctokit({
+      comment: { id: 50, body: makeRunIdBody(6666) },
+    });
+    getWorkflowRun.mockRejectedValue(new Error('Not Found'));
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+    expect(cancelWorkflowRun).not.toHaveBeenCalled();
+    expect(updateComment).not.toHaveBeenCalled();
+  });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2967,7 +2967,8 @@ describe('cancelActiveReviewRun', () => {
   it('returns false and skips cancellation when runId matches current run', async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const ghCtx = require('@actions/github').context;
-    const originalRunIdAttr = ghCtx.runId;
+    const hadOwnProp = Object.prototype.hasOwnProperty.call(ghCtx, 'runId');
+    const originalDescriptor = Object.getOwnPropertyDescriptor(ghCtx, 'runId');
     Object.defineProperty(ghCtx, 'runId', { value: 9999, configurable: true, writable: true });
     try {
       const { octokit, cancelWorkflowRun } = makeMockOctokit({
@@ -2979,7 +2980,11 @@ describe('cancelActiveReviewRun', () => {
       expect(result).toBe(false);
       expect(cancelWorkflowRun).not.toHaveBeenCalled();
     } finally {
-      Object.defineProperty(ghCtx, 'runId', { value: originalRunIdAttr, configurable: true, writable: true });
+      if (hadOwnProp && originalDescriptor) {
+        Object.defineProperty(ghCtx, 'runId', originalDescriptor);
+      } else {
+        delete (ghCtx as Record<string, unknown>).runId; // restore prototype getter
+      }
     }
   });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -3074,4 +3074,24 @@ describe('cancelActiveReviewRun', () => {
     expect(cancelWorkflowRun).not.toHaveBeenCalled();
     expect(updateComment).not.toHaveBeenCalled();
   });
+
+  it.each(['waiting', 'pending', 'requested', 'action_required'])(
+    'returns true and cancels when run status is %s',
+    async (runStatus) => {
+      const updateComment = jest.fn().mockResolvedValue({});
+      const { octokit, cancelWorkflowRun } = makeMockOctokit({
+        comment: { id: 60, body: makeRunIdBody(1111) },
+        updateComment,
+        runStatus,
+      });
+
+      const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+      expect(result).toBe(true);
+      expect(cancelWorkflowRun).toHaveBeenCalled();
+      expect(updateComment).toHaveBeenCalledWith(expect.objectContaining({
+        body: expect.stringContaining(CANCELLED_MARKER),
+      }));
+    },
+  );
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2918,11 +2918,13 @@ describe('cancelActiveReviewRun', () => {
     comment?: { id: number; body: string } | null;
     cancelError?: Error;
     updateComment?: jest.Mock;
+    runStatus?: string;
   }) {
     const updateComment = opts.updateComment ?? jest.fn().mockResolvedValue({});
     const cancelWorkflowRun = opts.cancelError
       ? jest.fn().mockRejectedValue(opts.cancelError)
       : jest.fn().mockResolvedValue({});
+    const getWorkflowRun = jest.fn().mockResolvedValue({ data: { status: opts.runStatus ?? 'in_progress' } });
     const octokit = {
       rest: {
         issues: {
@@ -2935,10 +2937,11 @@ describe('cancelActiveReviewRun', () => {
         },
         actions: {
           cancelWorkflowRun,
+          getWorkflowRun,
         },
       },
     } as unknown as Octokit;
-    return { octokit, cancelWorkflowRun, updateComment };
+    return { octokit, cancelWorkflowRun, getWorkflowRun, updateComment };
   }
 
   it('returns false when no progress comment exists', async () => {
@@ -2991,11 +2994,11 @@ describe('cancelActiveReviewRun', () => {
 
     expect(result).toBe(true);
     expect(cancelWorkflowRun).toHaveBeenCalledWith({ owner: 'owner', repo: 'repo', run_id: 5555 });
-    expect(updateComment).toHaveBeenCalled();
+    expect(updateComment).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining(CANCELLED_MARKER) }));
   });
 
   it('returns false when cancelWorkflowRun throws', async () => {
-    const { octokit, cancelWorkflowRun } = makeMockOctokit({
+    const { octokit, cancelWorkflowRun, updateComment } = makeMockOctokit({
       comment: { id: 30, body: makeRunIdBody(7777) },
       cancelError: new Error('API failure'),
     });
@@ -3004,5 +3007,19 @@ describe('cancelActiveReviewRun', () => {
 
     expect(result).toBe(false);
     expect(cancelWorkflowRun).toHaveBeenCalled();
+    expect(updateComment).not.toHaveBeenCalled();
+  });
+
+  it('returns false when run is not in_progress or queued', async () => {
+    const { octokit, cancelWorkflowRun, updateComment } = makeMockOctokit({
+      comment: { id: 40, body: makeRunIdBody(8888) },
+      runStatus: 'completed',
+    });
+
+    const result = await cancelActiveReviewRun(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+    expect(cancelWorkflowRun).not.toHaveBeenCalled();
+    expect(updateComment).not.toHaveBeenCalled();
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1295,7 +1295,8 @@ async function cancelActiveReviewRun(
 
   try {
     const { data: runData } = await octokit.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
-    if (runData.status !== 'in_progress' && runData.status !== 'queued') {
+    const cancellableStatuses = new Set(['in_progress', 'queued', 'waiting', 'pending', 'requested', 'action_required']);
+    if (!cancellableStatuses.has(runData.status ?? '')) {
       core.info(`Run ${runId} is already ${runData.status} — skipping cancel`);
       return false;
     }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1293,13 +1293,20 @@ async function cancelActiveReviewRun(
     return false;
   }
 
+  let runData: { status?: string | null };
   try {
-    const { data: runData } = await octokit.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
-    const cancellableStatuses = new Set(['in_progress', 'queued', 'waiting', 'pending', 'requested', 'action_required']);
-    if (!cancellableStatuses.has(runData.status ?? '')) {
-      core.info(`Run ${runId} is already ${runData.status} — skipping cancel`);
-      return false;
-    }
+    const { data } = await octokit.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+    runData = data;
+  } catch (error) {
+    core.warning(`Failed to query run ${runId}: ${error instanceof Error ? error.message : error}`);
+    return false;
+  }
+  const cancellableStatuses = new Set(['in_progress', 'queued', 'waiting', 'pending', 'requested', 'action_required']);
+  if (!cancellableStatuses.has(runData.status ?? '')) {
+    core.info(`Run ${runId} is already ${runData.status} — skipping cancel`);
+    return false;
+  }
+  try {
     await octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId });
     // cancelWorkflowRun transitions the run to 'cancelling' — the old run may
     // still complete in-flight API calls before stopping.

--- a/src/github.ts
+++ b/src/github.ts
@@ -1138,6 +1138,10 @@ async function findProgressComment(
   return { id: match.id, body: match.body, runId: extractRunIdFromBody(match.body) };
 }
 
+const ACTIVE_RUN_STATUSES = new Set([
+  'in_progress', 'queued', 'waiting', 'pending', 'requested', 'action_required',
+]);
+
 /**
  * Check whether a review is currently in progress for a PR by verifying the
  * embedded Actions run_id via the GitHub Actions API. Zombie comments from
@@ -1178,7 +1182,7 @@ async function isReviewInProgress(octokit: Octokit, owner: string, repo: string,
     return false;
   }
 
-  if (status === 'in_progress' || status === 'queued' || status === 'waiting' || status === 'pending' || status === 'requested' || status === 'action_required') {
+  if (ACTIVE_RUN_STATUSES.has(status ?? '')) {
     core.info(`Skipping — review already in progress (run ${progress.runId}, status=${status})`);
     return true;
   }
@@ -1301,8 +1305,7 @@ async function cancelActiveReviewRun(
     core.warning(`Failed to query run ${runId}: ${error instanceof Error ? error.message : error}`);
     return false;
   }
-  const cancellableStatuses = new Set(['in_progress', 'queued', 'waiting', 'pending', 'requested', 'action_required']);
-  if (!cancellableStatuses.has(runData.status ?? '')) {
+  if (!ACTIVE_RUN_STATUSES.has(runData.status ?? '')) {
     core.info(`Run ${runId} is already ${runData.status} — skipping cancel`);
     return false;
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1286,8 +1286,15 @@ async function cancelActiveReviewRun(
   const runId = progress.runId;
   if (!runId) return false;
 
+  if (runId === github.context.runId) {
+    core.warning('Skipping self-cancellation');
+    return false;
+  }
+
   try {
     await octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId });
+    // cancelWorkflowRun transitions the run to 'cancelling' — the old run may
+    // still complete in-flight API calls before stopping.
     core.info(`Cancelled in-progress review run ${runId}`);
     await markProgressCommentCancelled(octokit, owner, repo, progress.id, progress.body);
     return true;

--- a/src/github.ts
+++ b/src/github.ts
@@ -1265,4 +1265,36 @@ async function postAppWarningIfNeeded(
   });
 }
 
-export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };
+/**
+ * Cancel the in-progress review run for a PR, if one exists.
+ * Returns true if a run was successfully cancelled, false otherwise.
+ */
+async function cancelActiveReviewRun(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<boolean> {
+  let progress: ProgressComment | null;
+  try {
+    progress = await findProgressComment(octokit, owner, repo, prNumber);
+  } catch {
+    return false;
+  }
+  if (!progress) return false;
+
+  const runId = progress.runId;
+  if (!runId) return false;
+
+  try {
+    await octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId });
+    core.info(`Cancelled in-progress review run ${runId}`);
+    await markProgressCommentCancelled(octokit, owner, repo, progress.id, progress.body);
+    return true;
+  } catch (error) {
+    core.warning(`Failed to cancel run ${runId}: ${error instanceof Error ? error.message : error}`);
+    return false;
+  }
+}
+
+export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };

--- a/src/github.ts
+++ b/src/github.ts
@@ -1268,6 +1268,8 @@ async function postAppWarningIfNeeded(
 /**
  * Cancel the in-progress review run for a PR, if one exists.
  * Returns true if a run was successfully cancelled, false otherwise.
+ *
+ * Requires actions: write permission on the workflow token.
  */
 async function cancelActiveReviewRun(
   octokit: Octokit,
@@ -1292,6 +1294,11 @@ async function cancelActiveReviewRun(
   }
 
   try {
+    const { data: runData } = await octokit.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+    if (runData.status !== 'in_progress' && runData.status !== 'queued') {
+      core.info(`Run ${runId} is already ${runData.status} — skipping cancel`);
+      return false;
+    }
     await octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId });
     // cancelWorkflowRun transitions the run to 'cancelling' — the old run may
     // still complete in-flight API calls before stopping.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -812,6 +812,8 @@ describe('handleCommentTrigger', () => {
   });
 
   it('does not call cancelActiveReviewRun when forceReview is true', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true); // there IS an in-progress review
+
     setContext({
       eventName: 'issue_comment',
       payload: {
@@ -823,11 +825,14 @@ describe('handleCommentTrigger', () => {
 
     await handleCommentTrigger(true);
 
+    expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled(); // entire block skipped
     expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
   it('does not call cancelActiveReviewRun when no review is in progress', async () => {
-    // isReviewInProgress defaults to false in module mock
+    // Reset to clear any once-values leaked from preceding tests
+    jest.mocked(ghUtils.isReviewInProgress).mockReset().mockResolvedValue(false);
     setContext({
       eventName: 'issue_comment',
       payload: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -763,6 +763,31 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
+  it('skips review after cancel when already approved on current commit', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(true);
+    jest.mocked(ghUtils.isApprovedOnCommit).mockResolvedValueOnce(true);
+
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await handleCommentTrigger();
+
+    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 1,
+    );
+    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Cancelled in-progress review — proceeding with new review');
+    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalled();
+    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Already approved on this commit — skipping review');
+    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+  });
+
   it('proceeds even when cancel fails for in-progress review', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
     jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(false);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -786,6 +786,23 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
+  it('does not call cancelActiveReviewRun when forceReview is true', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await handleCommentTrigger(true);
+
+    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
+  });
+
   it('skips review when already approved on this commit', async () => {
     jest.mocked(ghUtils.isApprovedOnCommit).mockResolvedValueOnce(true);
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -812,8 +812,6 @@ describe('handleCommentTrigger', () => {
   });
 
   it('does not call cancelActiveReviewRun when forceReview is true', async () => {
-    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-
     setContext({
       eventName: 'issue_comment',
       payload: {
@@ -824,6 +822,22 @@ describe('handleCommentTrigger', () => {
     });
 
     await handleCommentTrigger(true);
+
+    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
+  });
+
+  it('does not call cancelActiveReviewRun when no review is in progress', async () => {
+    // isReviewInProgress defaults to false in module mock
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await handleCommentTrigger();
 
     expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -810,6 +810,9 @@ describe('handleCommentTrigger', () => {
       expect.anything(), 'test-owner', 'test-repo', 1,
     );
     expect(jest.mocked(core.info)).toHaveBeenCalledWith('Could not cancel in-progress review — proceeding anyway');
+    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 1, expect.any(String),
+    );
     expect(mockOctokitInstance.rest.pulls.get).toHaveBeenCalled();
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -756,6 +756,9 @@ describe('handleCommentTrigger', () => {
       expect.anything(), 'test-owner', 'test-repo', 1,
     );
     expect(jest.mocked(core.info)).toHaveBeenCalledWith('Cancelled in-progress review — proceeding with new review');
+    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 1, expect.any(String),
+    );
     expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalledWith(
       expect.objectContaining({ body: expect.stringContaining('Review skipped') }),
     );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -127,6 +127,7 @@ jest.mock('./github', () => ({
   isApprovedOnCommit: jest.fn().mockResolvedValue(false),
   markOwnProgressCommentCancelled: jest.fn().mockResolvedValue(false),
   postAppWarningIfNeeded: jest.fn().mockResolvedValue(undefined),
+  cancelActiveReviewRun: jest.fn().mockResolvedValue(false),
   BOT_LOGIN: 'manki-review[bot]',
   BOT_MARKER: '<!-- manki-bot -->',
   REVIEW_COMPLETE_MARKER: '<!-- manki-review-complete -->',
@@ -733,8 +734,9 @@ describe('handleCommentTrigger', () => {
     );
   });
 
-  it('reacts with eyes, posts skip comment, and skips when review is already in progress', async () => {
+  it('cancels in-progress review and proceeds when review is already running', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(true);
 
     setContext({
       eventName: 'issue_comment',
@@ -750,13 +752,38 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 42, 'eyes',
     );
-    expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
+    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 1,
+    );
+    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Cancelled in-progress review — proceeding with new review');
+    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalledWith(
       expect.objectContaining({ body: expect.stringContaining('Review skipped') }),
     );
-    const skipBody = mockOctokitInstance.rest.issues.createComment.mock.calls[0][0].body as string;
-    expect(skipBody).toContain(FORCE_REVIEW_MARKER);
-    expect(skipBody).toContain('- [ ] Force review');
-    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Review already in progress — skipping');
+    expect(mockOctokitInstance.rest.pulls.get).toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+  });
+
+  it('proceeds even when cancel fails for in-progress review', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(false);
+
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await handleCommentTrigger();
+
+    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 1,
+    );
+    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Could not cancel in-progress review — proceeding anyway');
+    expect(mockOctokitInstance.rest.pulls.get).toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
   it('skips review when already approved on this commit', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   isApprovedOnCommit,
   markOwnProgressCommentCancelled,
   postAppWarningIfNeeded,
+  cancelActiveReviewRun,
 } from './github';
 import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
@@ -271,9 +272,12 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
 
   if (!forceReview) {
     if (await isReviewInProgress(octokit, owner, repo, prNumber)) {
-      await postReviewSkippedComment(octokit, owner, repo, prNumber);
-      core.info('Review already in progress — skipping');
-      return;
+      const cancelled = await cancelActiveReviewRun(octokit, owner, repo, prNumber);
+      if (cancelled) {
+        core.info('Cancelled in-progress review — proceeding with new review');
+      } else {
+        core.info('Could not cancel in-progress review — proceeding anyway');
+      }
     }
 
     if (await isApprovedOnCommit(octokit, owner, repo, prNumber, pr.head.sha)) {


### PR DESCRIPTION
## Summary
- Adds `cancelActiveReviewRun` helper in `src/github.ts` that finds the active run via the progress comment's stored `runId` and cancels it
- When `@manki review` is posted with a review already in progress, the old run is cancelled and the new review proceeds (instead of silently skipping)
- If cancellation fails (no runId, run already done), the new review still proceeds

Closes #539