### PR TITLE
feat: judge practical-reachability check, cap hypothetical findings at `nit`

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -155,6 +155,7 @@ describe('formatFindingComment', () => {
       tags: ['defensive-hardening'],
       originalSeverity: 'required',
       reachability: 'hypothetical',
+      reachabilityReasoning: 'no caller passes a negative value',
     };
     const comment = formatFindingComment(finding);
     expect(comment).toContain('[defensive hardening — capped from required]');
@@ -162,6 +163,7 @@ describe('formatFindingComment', () => {
     const parsed = JSON.parse(jsonMatch![1]);
     expect(parsed.tags).toEqual(['defensive-hardening']);
     expect(parsed.reachability).toBe('hypothetical');
+    expect(parsed.reachabilityReasoning).toBe('no caller passes a negative value');
     expect(parsed.originalSeverity).toBe('required');
   });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -147,6 +147,39 @@ describe('formatFindingComment', () => {
     const comment = formatFindingComment(baseFinding);
     expect(comment).not.toContain('confidence]');
   });
+
+  it('renders defensive-hardening tag with original severity when tagged', () => {
+    const finding: Finding = {
+      ...baseFinding,
+      severity: 'nit',
+      tags: ['defensive-hardening'],
+      originalSeverity: 'required',
+      reachability: 'hypothetical',
+    };
+    const comment = formatFindingComment(finding);
+    expect(comment).toContain('[defensive hardening — capped from required]');
+    const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
+    const parsed = JSON.parse(jsonMatch![1]);
+    expect(parsed.tags).toEqual(['defensive-hardening']);
+    expect(parsed.reachability).toBe('hypothetical');
+    expect(parsed.originalSeverity).toBe('required');
+  });
+
+  it('omits defensive-hardening line when finding has no tags', () => {
+    const comment = formatFindingComment(baseFinding);
+    expect(comment).not.toContain('defensive hardening');
+    const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
+    const parsed = JSON.parse(jsonMatch![1]);
+    expect(parsed.tags).toBeUndefined();
+    expect(parsed.reachability).toBeUndefined();
+    expect(parsed.originalSeverity).toBeUndefined();
+  });
+
+  it('omits defensive-hardening line when tag is absent but originalSeverity is set', () => {
+    const finding: Finding = { ...baseFinding, originalSeverity: 'required' };
+    const comment = formatFindingComment(finding);
+    expect(comment).not.toContain('defensive hardening');
+  });
 });
 
 describe('mapVerdictToEvent', () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { AgentProgressEntry, DashboardData, Finding, FindingSeverity, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats, ReviewVerdict } from './types';
+import { AgentProgressEntry, DEFENSIVE_HARDENING_TAG, DashboardData, Finding, FindingSeverity, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats, ReviewVerdict } from './types';
 import { isLineInDiff, findClosestDiffLine } from './diff';
 import { MAX_AGENT_RETRIES } from './types';
 
@@ -730,7 +730,7 @@ function formatFindingComment(finding: Finding): string {
 
   const confidence = finding.judgeConfidence ? ` <sub>[${finding.judgeConfidence} confidence]</sub>` : '';
   let comment = `${severityEmoji} **${severityLabel}**${confidence}: ${safeTitle}`;
-  if (finding.tags?.includes('defensive-hardening') && finding.originalSeverity) {
+  if (finding.tags?.includes(DEFENSIVE_HARDENING_TAG) && finding.originalSeverity) {
     comment += `\n<sub>[defensive hardening — capped from ${finding.originalSeverity}]</sub>`;
   }
   comment += `\n\n${safeDescription}`;

--- a/src/github.ts
+++ b/src/github.ts
@@ -758,6 +758,7 @@ function formatFindingComment(finding: Finding): string {
     ...(finding.suggestedFix && { fix: finding.suggestedFix.slice(0, 200) }),
     ...(finding.tags && finding.tags.length > 0 && { tags: finding.tags }),
     ...(finding.reachability && { reachability: finding.reachability }),
+    ...(finding.reachabilityReasoning && { reachabilityReasoning: finding.reachabilityReasoning }),
     ...(finding.originalSeverity && { originalSeverity: finding.originalSeverity }),
   };
   comment += `\n\n<details>\n<summary>AI context</summary>\n\n\`\`\`json\n${JSON.stringify(aiContext, null, 2)}\n\`\`\`\n</details>`;

--- a/src/github.ts
+++ b/src/github.ts
@@ -729,7 +729,11 @@ function formatFindingComment(finding: Finding): string {
   const safeDescription = sanitizeMarkdown(finding.description);
 
   const confidence = finding.judgeConfidence ? ` <sub>[${finding.judgeConfidence} confidence]</sub>` : '';
-  let comment = `${severityEmoji} **${severityLabel}**${confidence}: ${safeTitle}\n\n${safeDescription}`;
+  let comment = `${severityEmoji} **${severityLabel}**${confidence}: ${safeTitle}`;
+  if (finding.tags?.includes('defensive-hardening') && finding.originalSeverity) {
+    comment += `\n<sub>[defensive hardening — capped from ${finding.originalSeverity}]</sub>`;
+  }
+  comment += `\n\n${safeDescription}`;
 
   if (finding.suggestedFix) {
     // Content inside dynamically-fenced code blocks is rendered literally by GitHub,
@@ -752,6 +756,9 @@ function formatFindingComment(finding: Finding): string {
     flaggedBy: finding.reviewers,
     title: finding.title,
     ...(finding.suggestedFix && { fix: finding.suggestedFix.slice(0, 200) }),
+    ...(finding.tags && finding.tags.length > 0 && { tags: finding.tags }),
+    ...(finding.reachability && { reachability: finding.reachability }),
+    ...(finding.originalSeverity && { originalSeverity: finding.originalSeverity }),
   };
   comment += `\n\n<details>\n<summary>AI context</summary>\n\n\`\`\`json\n${JSON.stringify(aiContext, null, 2)}\n\`\`\`\n</details>`;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1678,6 +1678,41 @@ describe('runFullReview orchestration', () => {
     expect(statsArg!.judgeMetrics?.mergedDuplicates).toBe(1);
   });
 
+  it('counts defensive-hardening findings in judgeMetrics', async () => {
+    const testFiles = [
+      { path: 'src/app.ts', changeType: 'modified' as const, hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }] },
+    ];
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: testFiles, totalAdditions: 20, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
+
+    const findings = [
+      { severity: 'nit' as const, title: 'Guard', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, tags: ['defensive-hardening'], originalSeverity: 'required' as const, reachability: 'hypothetical' as const },
+      { severity: 'required' as const, title: 'Real', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, reachability: 'reachable' as const },
+    ];
+    const allJudged = [...findings];
+
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'REQUEST_CHANGES', summary: 'Issues found',
+      findings,
+      highlights: [],
+      reviewComplete: true,
+      rawFindingCount: 2,
+      agentNames: ['security'],
+      allJudgedFindings: allJudged,
+      rawFindings: [...findings],
+    });
+    jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+
+    await callRunFullReview();
+
+    const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    expect(statsArg!.judgeMetrics?.defensiveHardeningCount).toBe(1);
+  });
+
   it('creates nit issues when nit_handling is "issues"', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { fetchRecapState } from './recap';
 import { runReview, determineVerdict, selectTeam } from './review';
-import { DashboardData, PrContext, ReviewMetadata, ReviewStats } from './types';
+import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -652,7 +652,7 @@ async function runFullReview(
         - (result.staticDedupCount ?? 0)
         - (result.llmDedupCount ?? 0)
         - allJudged.length;
-      const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes('defensive-hardening')).length;
+      const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes(DEFENSIVE_HARDENING_TAG)).length;
       judgeMetrics = {
         confidenceDistribution,
         severityChanges,

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,7 +640,7 @@ async function runFullReview(
       : undefined;
 
     // Judge calibration metrics
-    let judgeMetrics: { confidenceDistribution: { high: number; medium: number; low: number }; severityChanges: number; mergedDuplicates: number; defensiveHardeningCount?: number } | undefined;
+    let judgeMetrics: ReviewStats['judgeMetrics'];
     if (allJudged.length > 0) {
       const confidenceDistribution = { high: 0, medium: 0, low: 0 };
       for (const f of allJudged) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,7 +640,7 @@ async function runFullReview(
       : undefined;
 
     // Judge calibration metrics
-    let judgeMetrics: { confidenceDistribution: { high: number; medium: number; low: number }; severityChanges: number; mergedDuplicates: number } | undefined;
+    let judgeMetrics: { confidenceDistribution: { high: number; medium: number; low: number }; severityChanges: number; mergedDuplicates: number; defensiveHardeningCount?: number } | undefined;
     if (allJudged.length > 0) {
       const confidenceDistribution = { high: 0, medium: 0, low: 0 };
       for (const f of allJudged) {
@@ -652,7 +652,13 @@ async function runFullReview(
         - (result.staticDedupCount ?? 0)
         - (result.llmDedupCount ?? 0)
         - allJudged.length;
-      judgeMetrics = { confidenceDistribution, severityChanges, mergedDuplicates };
+      const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes('defensive-hardening')).length;
+      judgeMetrics = {
+        confidenceDistribution,
+        severityChanges,
+        mergedDuplicates,
+        ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
+      };
     }
 
     // File analysis metrics

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -583,6 +583,7 @@ describe('parseJudgeResponse', () => {
         reasoning: 'x',
         confidence: 'medium',
         reachability: 'yes',
+        reachabilityReasoning: 'because reasons',
       },
     ]);
 

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1093,6 +1093,25 @@ describe('mapJudgedToFindings', () => {
     expect(result[0].reachability).toBe('hypothetical');
   });
 
+  it('leaves hypothetical ignore findings unchanged and does not tag', () => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'required' })];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Bug',
+        severity: 'ignore',
+        reasoning: 'False positive.',
+        confidence: 'high',
+        reachability: 'hypothetical',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].severity).toBe('ignore');
+    expect(result[0].originalSeverity).toBeUndefined();
+    expect(result[0].tags).toBeUndefined();
+    expect(result[0].reachability).toBe('hypothetical');
+  });
+
   it('preserves severity when reachability is reachable', () => {
     const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
     const judged: JudgedFinding[] = [

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -212,6 +212,21 @@ describe('buildJudgeSystemPrompt', () => {
     expect(prompt).not.toContain('resolveThreads');
   });
 
+  it('contains Practical Reachability section and classification values', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig(), 5);
+    expect(prompt).toContain('## Practical Reachability');
+    expect(prompt).toContain('**reachable**');
+    expect(prompt).toContain('**hypothetical**');
+    expect(prompt).toContain('**unknown**');
+  });
+
+  it('lists reachability fields in the output schema', () => {
+    const prompt = buildJudgeSystemPrompt(makeConfig(), 5);
+    expect(prompt).toContain('"reachability"');
+    expect(prompt).toContain('"reachabilityReasoning"');
+    expect(prompt).toContain('"reachable" | "hypothetical" | "unknown"');
+  });
+
 });
 
 describe('buildJudgeUserMessage', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -839,6 +839,67 @@ describe('runJudgeAgent', () => {
     expect(userMessage).toContain('Null check missing');
   });
 
+  it('demotes hypothetical required findings to nit with defensive-hardening tag', async () => {
+    const judgedResponse = JSON.stringify({
+      summary: 'One defensive guard flagged.',
+      findings: [
+        {
+          title: 'Unused variable',
+          severity: 'required',
+          reasoning: 'Technically a bug.',
+          confidence: 'high',
+          reachability: 'hypothetical',
+          reachabilityReasoning: 'No visible caller triggers the failure.',
+        },
+      ],
+    });
+    mockSendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding()],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 3,
+    };
+
+    const result = await runJudgeAgent(mockClient, makeConfig(), input);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].originalSeverity).toBe('required');
+    expect(result.findings[0].tags).toEqual(['defensive-hardening']);
+    expect(result.findings[0].reachability).toBe('hypothetical');
+  });
+
+  it('preserves severity when judge marks finding reachable', async () => {
+    const judgedResponse = JSON.stringify({
+      summary: 'Real bug.',
+      findings: [
+        {
+          title: 'Unused variable',
+          severity: 'required',
+          reasoning: 'Null deref on every call.',
+          confidence: 'high',
+          reachability: 'reachable',
+        },
+      ],
+    });
+    mockSendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding()],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 3,
+    };
+
+    const result = await runJudgeAgent(mockClient, makeConfig(), input);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].tags).toBeUndefined();
+    expect(result.findings[0].reachability).toBe('reachable');
+  });
+
   it('calls judge with only openThreads when findings are empty', async () => {
     const judgedResponse = JSON.stringify({
       summary: 'Threads evaluated.',
@@ -938,6 +999,124 @@ describe('mapJudgedToFindings', () => {
     const result = mapJudgedToFindings(originals, judged);
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe('This is a much more detailed description of the null check issue.');
+  });
+
+  it.each([
+    ['required' as const],
+    ['suggestion' as const],
+  ])('demotes hypothetical %s findings to nit and tags defensive-hardening', (severity) => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Bug',
+        severity,
+        reasoning: 'Correct but unreachable.',
+        confidence: 'high',
+        reachability: 'hypothetical',
+        reachabilityReasoning: 'No caller passes negative values.',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].severity).toBe('nit');
+    expect(result[0].originalSeverity).toBe(severity);
+    expect(result[0].tags).toEqual(['defensive-hardening']);
+    expect(result[0].reachability).toBe('hypothetical');
+    expect(result[0].reachabilityReasoning).toBe('No caller passes negative values.');
+  });
+
+  it('leaves hypothetical nit findings unchanged and does not tag', () => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Bug',
+        severity: 'nit',
+        reasoning: 'Minor.',
+        confidence: 'low',
+        reachability: 'hypothetical',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].severity).toBe('nit');
+    expect(result[0].originalSeverity).toBeUndefined();
+    expect(result[0].tags).toBeUndefined();
+    expect(result[0].reachability).toBe('hypothetical');
+  });
+
+  it('preserves severity when reachability is reachable', () => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Bug',
+        severity: 'required',
+        reasoning: 'Real bug.',
+        confidence: 'high',
+        reachability: 'reachable',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].severity).toBe('required');
+    expect(result[0].originalSeverity).toBeUndefined();
+    expect(result[0].tags).toBeUndefined();
+    expect(result[0].reachability).toBe('reachable');
+  });
+
+  it('preserves severity when reachability is unknown', () => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Bug',
+        severity: 'required',
+        reasoning: 'Callers outside diff.',
+        confidence: 'medium',
+        reachability: 'unknown',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].severity).toBe('required');
+    expect(result[0].originalSeverity).toBeUndefined();
+    expect(result[0].tags).toBeUndefined();
+    expect(result[0].reachability).toBe('unknown');
+  });
+
+  it('does not demote when reachability is absent', () => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
+    const judged: JudgedFinding[] = [
+      { title: 'Bug', severity: 'required', reasoning: 'Real bug.', confidence: 'high' },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].severity).toBe('required');
+    expect(result[0].originalSeverity).toBeUndefined();
+    expect(result[0].tags).toBeUndefined();
+    expect(result[0].reachability).toBeUndefined();
+  });
+
+  it('demotes hypothetical findings when merging duplicates', () => {
+    const originals = [
+      makeFinding({ title: 'Defensive guard', severity: 'required', reviewers: ['R1'] }),
+      makeFinding({ title: 'Defensive guard missing', severity: 'suggestion', reviewers: ['R2'] }),
+    ];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Defensive guard',
+        severity: 'required',
+        reasoning: 'Merged.',
+        confidence: 'high',
+        reachability: 'hypothetical',
+        reachabilityReasoning: 'No caller exercises this branch.',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result).toHaveLength(1);
+    expect(result[0].severity).toBe('nit');
+    expect(result[0].originalSeverity).toBe('required');
+    expect(result[0].tags).toEqual(['defensive-hardening']);
+    expect(result[0].reachability).toBe('hypothetical');
   });
 });
 

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -554,6 +554,52 @@ describe('parseJudgeResponse', () => {
     expect(result.findings[0].severity).toBe('required');
     expect(result.findings[1].severity).toBe('ignore');
   });
+
+  it.each(['reachable', 'hypothetical', 'unknown'] as const)(
+    'parses reachability value %s and reachabilityReasoning when present',
+    (value) => {
+      const json = JSON.stringify([
+        {
+          title: 'T',
+          severity: 'suggestion',
+          reasoning: 'x',
+          confidence: 'medium',
+          reachability: value,
+          reachabilityReasoning: 'because reasons',
+        },
+      ]);
+
+      const result = parseJudgeResponse(json);
+      expect(result.findings[0].reachability).toBe(value);
+      expect(result.findings[0].reachabilityReasoning).toBe('because reasons');
+    },
+  );
+
+  it('falls back to undefined for invalid reachability value', () => {
+    const json = JSON.stringify([
+      {
+        title: 'T',
+        severity: 'suggestion',
+        reasoning: 'x',
+        confidence: 'medium',
+        reachability: 'yes',
+      },
+    ]);
+
+    const result = parseJudgeResponse(json);
+    expect(result.findings[0].reachability).toBeUndefined();
+    expect(result.findings[0].reachabilityReasoning).toBeUndefined();
+  });
+
+  it('leaves reachability undefined when missing from the response', () => {
+    const json = JSON.stringify([
+      { title: 'T', severity: 'suggestion', reasoning: 'x', confidence: 'medium' },
+    ]);
+
+    const result = parseJudgeResponse(json);
+    expect(result.findings[0].reachability).toBeUndefined();
+    expect(result.findings[0].reachabilityReasoning).toBeUndefined();
+  });
 });
 
 describe('filterMemoryForFindings', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -872,6 +872,36 @@ describe('runJudgeAgent', () => {
     expect(result.findings[0].reachability).toBe('hypothetical');
   });
 
+  it('demotes hypothetical suggestion findings to nit with defensive-hardening tag', async () => {
+    const judgedResponse = JSON.stringify({
+      summary: 'Suggestion demoted.',
+      findings: [
+        {
+          title: 'Unused variable',
+          severity: 'suggestion',
+          reasoning: 'Defensive guard.',
+          confidence: 'medium',
+          reachability: 'hypothetical',
+          reachabilityReasoning: 'No caller exercises this path.',
+        },
+      ],
+    });
+    mockSendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding()],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 3,
+    };
+
+    const result = await runJudgeAgent(mockClient, makeConfig(), input);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].originalSeverity).toBe('suggestion');
+    expect(result.findings[0].tags).toEqual(['defensive-hardening']);
+  });
+
   it('preserves severity when judge marks finding reachable', async () => {
     const judgedResponse = JSON.stringify({
       summary: 'Real bug.',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1056,6 +1056,24 @@ describe('mapJudgedToFindings', () => {
     expect(result[0].reachabilityReasoning).toBe('No caller passes negative values.');
   });
 
+  it('appends defensive-hardening without dropping pre-existing tags', () => {
+    const originals = [makeFinding({ title: 'Bug', severity: 'required', tags: ['security'] })];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Bug',
+        severity: 'required',
+        reasoning: 'Correct but unreachable.',
+        confidence: 'high',
+        reachability: 'hypothetical',
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result[0].tags).toContain('security');
+    expect(result[0].tags).toContain('defensive-hardening');
+    expect(result[0].tags).toHaveLength(2);
+  });
+
   it('leaves hypothetical nit findings unchanged and does not tag', () => {
     const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
     const judged: JudgedFinding[] = [

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1186,6 +1186,32 @@ describe('mapJudgedToFindings', () => {
     expect(result[0].tags).toEqual(['defensive-hardening']);
     expect(result[0].reachability).toBe('hypothetical');
   });
+
+  it.each([
+    ['reachable' as const],
+    ['unknown' as const],
+  ])('preserves severity when merging duplicates with reachability %s', (reachability) => {
+    const originals = [
+      makeFinding({ title: 'Null check', severity: 'suggestion', reviewers: ['R1'] }),
+      makeFinding({ title: 'Null check missing', severity: 'required', reviewers: ['R2'] }),
+    ];
+    const judged: JudgedFinding[] = [
+      {
+        title: 'Null check',
+        severity: 'required',
+        reasoning: 'Merged.',
+        confidence: 'high',
+        reachability,
+      },
+    ];
+
+    const result = mapJudgedToFindings(originals, judged);
+    expect(result).toHaveLength(1);
+    expect(result[0].severity).toBe('required');
+    expect(result[0].originalSeverity).toBeUndefined();
+    expect(result[0].tags).toBeUndefined();
+    expect(result[0].reachability).toBe(reachability);
+  });
 });
 
 describe('buildJudgeUserMessage with linked issues', () => {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -152,6 +152,18 @@ Examples of **ignore**:
   - Known workaround documented in comments
   - Style preference that does not affect correctness
 
+## Practical Reachability
+
+For every finding, decide whether the failure mode it describes is **practically reachable** given the code you can see in this PR and the surrounding diff context. Classify into exactly one of:
+
+- **reachable**: there is a concrete call site, input path, or execution flow visible in the diff (or the changed files it touches) that would actually trigger the failure described by the finding. Defaults here when in doubt about active code paths.
+- **hypothetical**: the finding is technically correct about the code as written, but no caller, input, or control flow visible in the diff would exercise the failure mode. Typical examples: defensive guards on values that are always produced by trusted internal code, branches that cannot be reached with the current call graph, edge cases that would require the author to change unrelated code to trigger.
+- **unknown**: you cannot determine reachability from the diff alone. Use this when the flagged code is exported or called from outside the changed files and you have no visibility into its callers.
+
+Populate \`reachability\` on every finding. When you choose \`hypothetical\`, also give a one-sentence \`reachabilityReasoning\` explaining why no current caller triggers the failure — this is how the author audits a demotion.
+
+Reachability is independent of severity. A finding can be \`required\` and \`hypothetical\`, or \`nit\` and \`reachable\`. Severity captures how bad the failure is; reachability captures whether it can actually happen today.
+
 ## Evaluation Criteria
 
 For each finding, evaluate:
@@ -159,6 +171,7 @@ For each finding, evaluate:
 1. **Accuracy**: Is the finding technically correct given the code context?
 2. **Actionability**: Can the developer fix this? Is the fix clear?
 3. **Severity**: Based on actual impact, not the reviewer's original assessment.
+4. **Reachability**: See "Practical Reachability" above.
 
 ## Guidelines
 
@@ -214,7 +227,9 @@ Respond with ONLY a JSON object (no markdown fences, no explanation):
       "title": "Short title matching or close to the original finding title",
       "severity": "required" | "suggestion" | "nit" | "ignore",
       "reasoning": "1-2 sentences explaining your judgment",
-      "confidence": "high" | "medium" | "low"
+      "confidence": "high" | "medium" | "low",
+      "reachability": "reachable" | "hypothetical" | "unknown",
+      "reachabilityReasoning": "Required when reachability is 'hypothetical'. One sentence explaining why no current caller triggers the failure"
     }
   ]${hasOpenThreads ? `,
   "resolveThreads": [

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -430,12 +430,20 @@ export function parseJudgeResponse(responseText: string): JudgeResult {
     const parsed = JSON.parse(jsonText);
 
     const parseFindings = (arr: unknown[]): JudgedFinding[] =>
-      arr.map((item: unknown) => item as Record<string, unknown>).map((f) => ({
-        title: String(f.title || 'Untitled'),
-        severity: validateSeverity(f.severity),
-        reasoning: String(f.reasoning || ''),
-        confidence: validateConfidence(f.confidence),
-      }));
+      arr.map((item: unknown) => item as Record<string, unknown>).map((f) => {
+        const reachability = validateReachability(f.reachability);
+        const reachabilityReasoning = typeof f.reachabilityReasoning === 'string' && f.reachabilityReasoning
+          ? f.reachabilityReasoning
+          : undefined;
+        return {
+          title: String(f.title || 'Untitled'),
+          severity: validateSeverity(f.severity),
+          reasoning: String(f.reasoning || ''),
+          confidence: validateConfidence(f.confidence),
+          ...(reachability && { reachability }),
+          ...(reachabilityReasoning && { reachabilityReasoning }),
+        };
+      });
 
     // New object format with summary + findings + resolveThreads
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
@@ -469,6 +477,13 @@ function validateConfidence(value: unknown): 'high' | 'medium' | 'low' {
     return value;
   }
   return 'medium';
+}
+
+function validateReachability(value: unknown): FindingReachability | undefined {
+  if (value === 'reachable' || value === 'hypothetical' || value === 'unknown') {
+    return value;
+  }
+  return undefined;
 }
 
 export async function runJudgeAgent(

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -13,7 +13,7 @@ import {
 import { LinkedIssue } from './github';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
-import { DiffFile, Finding, FindingReachability, FindingSeverity, ReviewConfig, ParsedDiff, PrContext } from './types';
+import { DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, ReviewConfig, ParsedDiff, PrContext } from './types';
 
 export interface JudgeInput {
   findings: Finding[];
@@ -576,7 +576,7 @@ function applyReachability(finding: Finding, judged: JudgedFinding): void {
   if (finding.severity !== 'required' && finding.severity !== 'suggestion') return;
   finding.originalSeverity = finding.severity;
   finding.severity = 'nit';
-  finding.tags = addTag(finding.tags, 'defensive-hardening');
+  finding.tags = addTag(finding.tags, DEFENSIVE_HARDENING_TAG);
 }
 
 function addTag(tags: string[] | undefined, tag: string): string[] {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -13,7 +13,7 @@ import {
 import { LinkedIssue } from './github';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
-import { DiffFile, Finding, FindingSeverity, ReviewConfig, ParsedDiff, PrContext } from './types';
+import { DiffFile, Finding, FindingReachability, FindingSeverity, ReviewConfig, ParsedDiff, PrContext } from './types';
 
 export interface JudgeInput {
   findings: Finding[];
@@ -34,6 +34,8 @@ export interface JudgedFinding {
   severity: FindingSeverity;
   reasoning: string;
   confidence: 'high' | 'medium' | 'low';
+  reachability?: FindingReachability;
+  reachabilityReasoning?: string;
 }
 
 export interface ResolveThread {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -573,8 +573,8 @@ function applyReachability(finding: Finding, judged: JudgedFinding): void {
     finding.reachabilityReasoning = judged.reachabilityReasoning;
   }
   if (judged.reachability !== 'hypothetical') return;
-  if (finding.severity !== 'required' && finding.severity !== 'suggestion') return;
-  finding.originalSeverity = finding.severity;
+  if (judged.severity !== 'required' && judged.severity !== 'suggestion') return;
+  finding.originalSeverity = judged.severity;
   finding.severity = 'nit';
   finding.tags = addTag(finding.tags, DEFENSIVE_HARDENING_TAG);
 }

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -432,7 +432,7 @@ export function parseJudgeResponse(responseText: string): JudgeResult {
     const parseFindings = (arr: unknown[]): JudgedFinding[] =>
       arr.map((item: unknown) => item as Record<string, unknown>).map((f) => {
         const reachability = validateReachability(f.reachability);
-        const reachabilityReasoning = typeof f.reachabilityReasoning === 'string' && f.reachabilityReasoning
+        const reachabilityReasoning = reachability && typeof f.reachabilityReasoning === 'string' && f.reachabilityReasoning
           ? f.reachabilityReasoning
           : undefined;
         return {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -557,12 +557,32 @@ export function mapJudgedToFindings(original: Finding[], judged: JudgedFinding[]
       finding.severity = match.severity;
       finding.judgeNotes = match.reasoning;
       finding.judgeConfidence = match.confidence;
+      applyReachability(finding, match);
     }
 
     result.push(finding);
   }
 
   return result;
+}
+
+function applyReachability(finding: Finding, judged: JudgedFinding): void {
+  if (!judged.reachability) return;
+  finding.reachability = judged.reachability;
+  if (judged.reachabilityReasoning) {
+    finding.reachabilityReasoning = judged.reachabilityReasoning;
+  }
+  if (judged.reachability !== 'hypothetical') return;
+  if (finding.severity !== 'required' && finding.severity !== 'suggestion') return;
+  finding.originalSeverity = finding.severity;
+  finding.severity = 'nit';
+  finding.tags = addTag(finding.tags, 'defensive-hardening');
+}
+
+function addTag(tags: string[] | undefined, tag: string): string[] {
+  if (!tags || tags.length === 0) return [tag];
+  if (tags.includes(tag)) return tags;
+  return [...tags, tag];
 }
 
 function mapMergedFindings(original: Finding[], judged: JudgedFinding[]): Finding[] {
@@ -582,6 +602,7 @@ function mapMergedFindings(original: Finding[], judged: JudgedFinding[]): Findin
     merged.severity = j.severity;
     merged.judgeNotes = j.reasoning;
     merged.judgeConfidence = j.confidence;
+    applyReachability(merged, j);
 
     // Combine reviewers from all matched originals
     const allReviewers = new Set<string>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export interface ReviewStats {
     confidenceDistribution: { high: number; medium: number; low: number };
     severityChanges: number;
     mergedDuplicates: number;
+    defensiveHardeningCount?: number;
   };
 
   // File analysis

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export type FindingSeverity = 'required' | 'suggestion' | 'nit' | 'ignore';
 
 export type FindingReachability = 'reachable' | 'hypothetical' | 'unknown';
 
+export const DEFENSIVE_HARDENING_TAG = 'defensive-hardening' as const;
+
 export interface Finding {
   severity: FindingSeverity;
   title: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export const MAX_AGENT_RETRIES = 1;
 
 export type FindingSeverity = 'required' | 'suggestion' | 'nit' | 'ignore';
 
+export type FindingReachability = 'reachable' | 'hypothetical' | 'unknown';
+
 export interface Finding {
   severity: FindingSeverity;
   title: string;
@@ -13,6 +15,10 @@ export interface Finding {
   codeContext?: string;
   judgeNotes?: string;
   judgeConfidence?: 'high' | 'medium' | 'low';
+  reachability?: FindingReachability;
+  reachabilityReasoning?: string;
+  tags?: string[];
+  originalSeverity?: FindingSeverity;
 }
 
 export type ReviewVerdict = 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';


### PR DESCRIPTION
## Summary

- Adds `reachability` (`reachable` / `hypothetical` / `unknown`) to the judge's per-finding output schema via a new "Practical Reachability" prompt section in `buildJudgeSystemPrompt`. No extra LLM call.
- `parseJudgeResponse` validates the new fields with a fallback to `undefined` on invalid input.
- `applyReachability` in `judge.ts` demotes any `required`/`suggestion` finding with `reachability === 'hypothetical'` to `nit`, stores the original severity, and tags it `defensive-hardening`. Applied in both `mapJudgedToFindings` and `mapMergedFindings`.
- `formatFindingComment` renders `<sub>[defensive hardening — capped from {originalSeverity}]</sub>` under the severity/confidence line (matches the existing confidence sub-tag styling). `tags`, `reachability`, and `originalSeverity` surface in the AI-context JSON for audit.
- `ReviewStats.judgeMetrics` gains optional `defensiveHardeningCount` (emitted only when non-zero, preserving existing exact-match tests).

Rule: `required` and `suggestion` findings with `reachability === 'hypothetical'` cap at `nit`. `unknown` preserves severity (safe default).

## Test plan

- [x] Extended `buildJudgeSystemPrompt` tests for the new section and schema fields.
- [x] Extended `parseJudgeResponse` for all three reachability values, invalid input, missing field.
- [x] `mapJudgedToFindings` covers all reachability × severity combinations, including idempotent tag behaviour.
- [x] End-to-end `runJudgeAgent` test proving a PR #106-style sign-guard finding (`reachability: 'hypothetical'`) gets demoted + tagged.
- [x] `formatFindingComment` tests verify the sub-tag rendering and AI-context JSON contents.
- [x] `npm run all` passes (lint + typecheck + 1159 jest tests + build).

Closes #549
Part of #545