### PR TITLE
feat: judge cross-round suppression rules — ratchet and contradiction detectors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1719,6 +1719,42 @@ describe('runFullReview orchestration', () => {
     expect(statsArg!.judgeMetrics?.defensiveHardeningCount).toBe(1);
   });
 
+  it('surfaces crossRoundSuppressed and crossRoundDemoted counts in judgeMetrics', async () => {
+    const testFiles = [
+      { path: 'src/app.ts', changeType: 'modified' as const, hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }] },
+    ];
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: testFiles, totalAdditions: 20, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
+
+    const findings = [
+      { severity: 'required' as const, title: 'Real', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
+    ];
+
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'REQUEST_CHANGES', summary: 'Issues found',
+      findings,
+      highlights: [],
+      reviewComplete: true,
+      rawFindingCount: 3,
+      agentNames: ['security'],
+      allJudgedFindings: [...findings],
+      rawFindings: [...findings],
+      crossRoundSuppressed: 1,
+      crossRoundDemoted: 1,
+    });
+    jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+
+    await callRunFullReview();
+
+    const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    expect(statsArg!.judgeMetrics?.crossRoundSuppressed).toBe(1);
+    expect(statsArg!.judgeMetrics?.crossRoundDemoted).toBe(1);
+  });
+
   it('creates nit issues when nit_handling is "issues"', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1746,7 +1746,7 @@ describe('runFullReview orchestration', () => {
       crossRoundDemoted: 1,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' });
 
     await callRunFullReview();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
 import { runReview, determineVerdict, selectTeam } from './review';
-import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, RATCHET_SUPPRESSED_TAG, ReviewMetadata, ReviewStats } from './types';
+import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -667,16 +667,16 @@ async function runFullReview(
         - allJudged.length
       : 0;
     const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes(DEFENSIVE_HARDENING_TAG)).length;
-    const crossRoundSuppressed = allJudged.filter(f => f.tags?.includes(RATCHET_SUPPRESSED_TAG)).length;
-    const crossRoundDemoted = allJudged.filter(f => f.tags?.includes(CONTRADICTION_TAG)).length;
+    const crossRoundSuppressed = result.crossRoundSuppressed;
+    const crossRoundDemoted = result.crossRoundDemoted;
     const judgeMetrics: ReviewStats['judgeMetrics'] = {
       confidenceDistribution,
       severityChanges,
       mergedDuplicates,
       ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
       verdictReason,
-      ...(crossRoundSuppressed > 0 && { crossRoundSuppressed }),
-      ...(crossRoundDemoted > 0 && { crossRoundDemoted }),
+      ...(crossRoundSuppressed != null && crossRoundSuppressed > 0 && { crossRoundSuppressed }),
+      ...(crossRoundDemoted != null && crossRoundDemoted > 0 && { crossRoundDemoted }),
     };
 
     // File analysis metrics

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
 import { runReview, determineVerdict, selectTeam } from './review';
-import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, RATCHET_SUPPRESSED_TAG, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -667,12 +667,16 @@ async function runFullReview(
         - allJudged.length
       : 0;
     const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes(DEFENSIVE_HARDENING_TAG)).length;
+    const crossRoundSuppressed = allJudged.filter(f => f.tags?.includes(RATCHET_SUPPRESSED_TAG)).length;
+    const crossRoundDemoted = allJudged.filter(f => f.tags?.includes(CONTRADICTION_TAG)).length;
     const judgeMetrics: ReviewStats['judgeMetrics'] = {
       confidenceDistribution,
       severityChanges,
       mergedDuplicates,
       ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
       verdictReason,
+      ...(crossRoundSuppressed > 0 && { crossRoundSuppressed }),
+      ...(crossRoundDemoted > 0 && { crossRoundDemoted }),
     };
 
     // File analysis metrics

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1592,6 +1592,27 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
 
+  it('demotes contradiction when current line is within lineEnd + LINE_WINDOW of a multi-line prior', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 33,
+      severity: 'required',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 30, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }], 2)];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+  });
+
   it('passes through findings unchanged when priorRounds is empty or undefined', () => {
     const findings = [makeFinding({ title: 'Unused variable', severity: 'suggestion' })];
     const emptyResult = applyCrossRoundSuppression(findings, []);

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1523,7 +1523,7 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].severity).toBe('ignore');
   });
 
-  it('demotes required to nit via contradiction when reversal word matches within line window', () => {
+  it('does not demote required via contradiction (prompt injection guard)', () => {
     const findings = [makeFinding({
       title: 'Naming convention',
       file: 'src/a.ts',
@@ -1540,19 +1540,18 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.suppressedCount).toBe(0);
-    expect(result.demotedCount).toBe(1);
-    expect(result.findings[0].severity).toBe('nit');
-    expect(result.findings[0].originalSeverity).toBe('required');
-    expect(result.findings[0].tags).toContain('contradicts-prior-round');
-    expect(result.findings[0].judgeNotes).toContain('Contradicts round 3 guidance accepted by author');
+    expect(result.demotedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].originalSeverity).toBeUndefined();
+    expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
 
-  it('appends contradiction note to pre-existing judgeNotes', () => {
+  it('appends contradiction note to pre-existing judgeNotes when suggestion contradicts prior', () => {
     const findings = [makeFinding({
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 12,
-      severity: 'required',
+      severity: 'suggestion',
       description: 'Replace the old helper and avoid the previous pattern instead.',
       judgeNotes: 'Prior note',
     })];
@@ -1566,6 +1565,31 @@ describe('applyCrossRoundSuppression', () => {
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(1);
     expect(result.findings[0].judgeNotes).toBe('Prior note Contradicts round 2 guidance accepted by author');
+  });
+
+  it('preserves required severity with reversal word and prior agree (prompt injection guard)', () => {
+    // Adversary injects reversal word into a round-2 required finding whose slug matches
+    // a round-1 agreed finding. The contradiction path must never fire for required findings.
+    const findings = [makeFinding({
+      title: 'Null pointer dereference',
+      file: 'src/a.ts',
+      line: 20,
+      severity: 'required',
+      description: 'Remove the null check — avoid dereferencing here instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 18, lineEnd: 18, slug: titleToSlug('Null pointer dereference') },
+      severity: 'suggestion',
+      title: 'Null pointer dereference',
+      authorReply: 'agree',
+    }], 1)];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(0);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].originalSeverity).toBeUndefined();
+    expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
 
   it('demotes suggestion to nit via contradiction when reversal word matches within line window', () => {
@@ -1592,12 +1616,12 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags).not.toContain('suppressed-by-ratchet');
   });
 
-  it('demotes via contradiction when reversal word is in suggestedFix only', () => {
+  it('demotes suggestion via contradiction when reversal word is in suggestedFix only', () => {
     const findings = [makeFinding({
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 12,
-      severity: 'required',
+      severity: 'suggestion',
       description: 'The helper should be updated.',
       suggestedFix: 'Replace it with the newer utility instead.',
     })];
@@ -1659,12 +1683,12 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
 
-  it('demotes contradiction when current line is within lineEnd + LINE_WINDOW of a multi-line prior', () => {
+  it('demotes suggestion via contradiction when current line is within lineEnd + LINE_WINDOW of a multi-line prior', () => {
     const findings = [makeFinding({
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 33,
-      severity: 'required',
+      severity: 'suggestion',
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
@@ -1787,11 +1811,11 @@ describe('runJudgeAgent cross-round suppression', () => {
     expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
   });
 
-  it('reports crossRoundDemoted when prior contradiction fires', async () => {
+  it('reports crossRoundDemoted when prior contradiction fires on a suggestion', async () => {
     const judgedResponse = JSON.stringify({
       summary: 'Unchanged.',
       findings: [
-        { title: 'Naming convention', severity: 'required', reasoning: 'Still present.', confidence: 'high' },
+        { title: 'Naming convention', severity: 'suggestion', reasoning: 'Still present.', confidence: 'high' },
       ],
     });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
@@ -1801,7 +1825,7 @@ describe('runJudgeAgent cross-round suppression', () => {
         title: 'Naming convention',
         file: 'src/index.ts',
         line: 12,
-        severity: 'required',
+        severity: 'suggestion',
         description: 'Replace the old helper instead.',
       })],
       diff: makeDiff(),

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1,4 +1,5 @@
 import {
+  applyCrossRoundSuppression,
   buildJudgeSystemPrompt,
   buildJudgeUserMessage,
   extractCodeContext,
@@ -1424,5 +1425,225 @@ describe('deduplicateFindings', () => {
 
     const result = deduplicateFindings(findings);
     expect(result).toHaveLength(3);
+  });
+});
+
+describe('applyCrossRoundSuppression', () => {
+  const makePriorRound = (findings: HandoverRound['findings'], round = 1): HandoverRound => ({
+    round,
+    commitSha: `sha${round}`,
+    timestamp: 't',
+    findings,
+  });
+
+  it('suppresses suggestion findings when slug, file, and line match a prior agreed finding', () => {
+    const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'suggestion',
+      title: 'Unused variable',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(1);
+    expect(result.demotedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
+  });
+
+  it('does not suppress required findings even when prior agreed match exists', () => {
+    const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'required' })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'required',
+      title: 'Unused variable',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].tags).toBeUndefined();
+  });
+
+  it('does not suppress when prior authorReply is disagree', () => {
+    const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'suggestion',
+      title: 'Unused variable',
+      authorReply: 'disagree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('suggestion');
+  });
+
+  it('does not suppress when slug differs', () => {
+    const findings = [makeFinding({ title: 'Different title', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'suggestion',
+      title: 'Unused variable',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('suggestion');
+  });
+
+  it('does not suppress when file differs', () => {
+    const findings = [makeFinding({ title: 'Unused variable', file: 'src/b.ts', line: 10, severity: 'suggestion' })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'suggestion',
+      title: 'Unused variable',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('suggestion');
+  });
+
+  it('suppresses by ratchet even when line delta exceeds the window', () => {
+    const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 100, severity: 'suggestion' })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'suggestion',
+      title: 'Unused variable',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('ignore');
+  });
+
+  it('demotes required to nit via contradiction when reversal word matches within line window', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'required',
+      description: 'Replace the old helper and avoid the previous pattern instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }], 3)];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].originalSeverity).toBe('required');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+    expect(result.findings[0].judgeNotes).toContain('Contradicts round 3 guidance accepted by author');
+  });
+
+  it('does not demote contradiction when line delta exceeds the window', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 100,
+      severity: 'required',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
+  });
+
+  it('passes through findings unchanged when priorRounds is empty or undefined', () => {
+    const findings = [makeFinding({ title: 'Unused variable', severity: 'suggestion' })];
+    const emptyResult = applyCrossRoundSuppression(findings, []);
+    expect(emptyResult.suppressedCount).toBe(0);
+    expect(emptyResult.demotedCount).toBe(0);
+    expect(emptyResult.findings).toEqual(findings);
+
+    const undefinedResult = applyCrossRoundSuppression(findings, undefined);
+    expect(undefinedResult.suppressedCount).toBe(0);
+    expect(undefinedResult.demotedCount).toBe(0);
+    expect(undefinedResult.findings).toEqual(findings);
+  });
+
+  it('preserves pre-existing tags when tagging', () => {
+    const findings = [makeFinding({
+      title: 'Unused variable',
+      file: 'src/a.ts',
+      line: 10,
+      severity: 'suggestion',
+      tags: ['security'],
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      severity: 'suggestion',
+      title: 'Unused variable',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.findings[0].tags).toContain('security');
+    expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
+  });
+});
+
+describe('runJudgeAgent cross-round suppression', () => {
+  const mockSendMessage = jest.fn();
+  const mockClient = {
+    sendMessage: mockSendMessage,
+  } as unknown as ClaudeClient;
+
+  beforeEach(() => {
+    mockSendMessage.mockReset();
+  });
+
+  it('reports crossRoundSuppressed when prior ratchet fires', async () => {
+    const judgedResponse = JSON.stringify({
+      summary: 'Unchanged.',
+      findings: [
+        { title: 'Unused variable', severity: 'suggestion', reasoning: 'Still present.', confidence: 'medium' },
+      ],
+    });
+    mockSendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding({ title: 'Unused variable', file: 'src/index.ts', line: 10 })],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 3,
+      priorRounds: [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: 't',
+        findings: [{
+          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+          severity: 'suggestion',
+          title: 'Unused variable',
+          authorReply: 'agree',
+        }],
+      }],
+    };
+
+    const result = await runJudgeAgent(mockClient, makeConfig(), input);
+    expect(result.crossRoundSuppressed).toBe(1);
+    expect(result.crossRoundDemoted).toBeUndefined();
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
   });
 });

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1827,4 +1827,34 @@ describe('runJudgeAgent cross-round suppression', () => {
     expect(result.findings[0].severity).toBe('nit');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
+
+  it('applies cross-round suppression on early return when judge returns empty findings', async () => {
+    const emptyJudgeResponse = JSON.stringify({ summary: 'Nothing left.', findings: [] });
+    mockSendMessage.mockResolvedValue({ content: emptyJudgeResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding({ title: 'Unused variable', file: 'src/index.ts', line: 10 })],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 3,
+      priorRounds: [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: 't',
+        findings: [{
+          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
+          severity: 'suggestion',
+          title: 'Unused variable',
+          authorReply: 'agree',
+        }],
+      }],
+    };
+
+    const result = await runJudgeAgent(mockClient, makeConfig(), input);
+    expect(result.crossRoundSuppressed).toBe(1);
+    expect(result.crossRoundDemoted).toBeUndefined();
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
+  });
 });

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1592,6 +1592,28 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags).not.toContain('suppressed-by-ratchet');
   });
 
+  it('demotes via contradiction when reversal word is in suggestedFix only', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'required',
+      description: 'The helper should be updated.',
+      suggestedFix: 'Replace it with the newer utility instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+  });
+
   it('does not demote nit findings via contradiction', () => {
     const findings = [makeFinding({
       title: 'Naming convention',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1592,6 +1592,30 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags).not.toContain('suppressed-by-ratchet');
   });
 
+  it('does not demote nit findings via contradiction', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'nit',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    // Contradiction guard requires required|suggestion — nit is not demoted.
+    expect(result.demotedCount).toBe(0);
+    expect(result.findings[0].originalSeverity).toBeUndefined();
+    expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
+    // Ratchet still fires for non-required findings, so severity ends up as ignore.
+    expect(result.suppressedCount).toBe(1);
+  });
+
   it('does not demote contradiction when line delta exceeds the window', () => {
     const findings = [makeFinding({
       title: 'Naming convention',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1687,11 +1687,14 @@ describe('applyCrossRoundSuppression', () => {
   });
 
   it('does not demote contradiction when line delta exceeds the window', () => {
+    // Use `suggestion` severity so only the line-window guard prevents contradiction demotion.
+    // With `required`, both the severity guard and the window guard would block it, making the
+    // test ambiguous about which one is responsible.
     const findings = [makeFinding({
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 100,
-      severity: 'required',
+      severity: 'suggestion',
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
@@ -1703,8 +1706,10 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(0);
-    expect(result.findings[0].severity).toBe('required');
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
+    // Ratchet fires since the match is file+slug only (no line constraint), suppressing the finding.
+    expect(result.suppressedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('ignore');
   });
 
   it('demotes suggestion via contradiction at exact LINE_WINDOW boundary (inside)', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1547,6 +1547,27 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].judgeNotes).toContain('Contradicts round 3 guidance accepted by author');
   });
 
+  it('appends contradiction note to pre-existing judgeNotes', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'required',
+      description: 'Replace the old helper and avoid the previous pattern instead.',
+      judgeNotes: 'Prior note',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }], 2)];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].judgeNotes).toBe('Prior note Contradicts round 2 guidance accepted by author');
+  });
+
   it('demotes suggestion to nit via contradiction when reversal word matches within line window', () => {
     const findings = [makeFinding({
       title: 'Naming convention',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1712,6 +1712,34 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags).toContain('security');
     expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
   });
+
+  it('ratchet fires when same slug+file was agreed in round 2 even if disagreed in round 1', () => {
+    const findings = [makeFinding({
+      title: 'Unused variable',
+      file: 'src/a.ts',
+      line: 10,
+      severity: 'suggestion',
+    })];
+    const prior = [
+      makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
+        severity: 'suggestion',
+        title: 'Unused variable',
+        authorReply: 'disagree',
+      }], 1),
+      makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
+        severity: 'suggestion',
+        title: 'Unused variable',
+        authorReply: 'agree',
+      }], 2),
+    ];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
+  });
 });
 
 describe('runJudgeAgent cross-round suppression', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1683,6 +1683,51 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
 
+  it('demotes suggestion via contradiction at exact LINE_WINDOW boundary (inside)', () => {
+    // prior lineEnd=10, LINE_WINDOW=5 → boundary is line 15 (inclusive)
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 15,
+      severity: 'suggestion',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].originalSeverity).toBe('suggestion');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+  });
+
+  it('does not demote suggestion via contradiction at LINE_WINDOW + 1 (outside)', () => {
+    // prior lineEnd=10, LINE_WINDOW=5 → boundary is 15; line 16 is outside
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 16,
+      severity: 'suggestion',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(0);
+    expect(result.findings[0].severity).not.toBe('nit');
+    expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
+  });
+
   it('demotes suggestion via contradiction when current line is within lineEnd + LINE_WINDOW of a multi-line prior', () => {
     const findings = [makeFinding({
       title: 'Naming convention',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -13,7 +13,7 @@ import {
 } from './judge';
 import { ClaudeClient } from './claude';
 import { RepoMemory, Learning, Suppression } from './memory';
-import { LinkedIssue } from './github';
+import { LinkedIssue, titleToSlug } from './github';
 import { Finding, HandoverRound, ReviewConfig, ParsedDiff, DiffFile, DiffHunk } from './types';
 
 const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
@@ -368,14 +368,14 @@ describe('buildJudgeUserMessage', () => {
       timestamp: 't',
       findings: [
         {
-          fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Null-check' },
+          fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Null check') },
           severity: 'required',
           title: 'Null check',
           authorReply: 'agree',
           threadId: 'PRRT_1',
         },
         {
-          fingerprint: { file: 'src/b.ts', lineStart: 20, lineEnd: 20, slug: 'Unused-import' },
+          fingerprint: { file: 'src/b.ts', lineStart: 20, lineEnd: 20, slug: titleToSlug('Unused import') },
           severity: 'nit',
           title: 'Unused import',
           authorReply: 'disagree',
@@ -403,7 +403,7 @@ describe('buildJudgeUserMessage', () => {
       commitSha: `sha${i + 1}`,
       timestamp: 't',
       findings: [{
-        fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: `F${i + 1}` },
+        fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug(`Finding ${i + 1}`) },
         severity: 'suggestion',
         title: `Finding ${i + 1}`,
         authorReply: 'none',
@@ -426,13 +426,13 @@ describe('buildJudgeUserMessage', () => {
       timestamp: 't',
       findings: [
         {
-          fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 'Real' },
+          fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug('Real') },
           severity: 'required',
           title: 'Real',
           authorReply: 'none',
         },
         {
-          fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 'Ignored' },
+          fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: titleToSlug('Ignored') },
           severity: 'ignore',
           title: 'Ignored',
           authorReply: 'none',
@@ -452,7 +452,7 @@ describe('buildJudgeUserMessage', () => {
       commitSha: 'a',
       timestamp: 't',
       findings: [{
-        fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 'Finding' },
+        fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug('Finding') },
         severity: 'required',
         title: 'Finding',
         authorReply: 'none',
@@ -472,7 +472,7 @@ describe('buildJudgeUserMessage', () => {
       commitSha: 'a',
       timestamp: 't',
       findings: [{
-        fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 'Long' },
+        fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug('Long') },
         severity: 'required',
         title: longTitle,
         authorReply: 'none',
@@ -1439,7 +1439,7 @@ describe('applyCrossRoundSuppression', () => {
   it('suppresses suggestion findings when slug, file, and line match a prior agreed finding', () => {
     const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'suggestion',
       title: 'Unused variable',
       authorReply: 'agree',
@@ -1455,7 +1455,7 @@ describe('applyCrossRoundSuppression', () => {
   it('does not suppress required findings even when prior agreed match exists', () => {
     const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'required' })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'required',
       title: 'Unused variable',
       authorReply: 'agree',
@@ -1470,7 +1470,7 @@ describe('applyCrossRoundSuppression', () => {
   it('does not suppress when prior authorReply is disagree', () => {
     const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'suggestion',
       title: 'Unused variable',
       authorReply: 'disagree',
@@ -1484,7 +1484,7 @@ describe('applyCrossRoundSuppression', () => {
   it('does not suppress when slug differs', () => {
     const findings = [makeFinding({ title: 'Different title', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'suggestion',
       title: 'Unused variable',
       authorReply: 'agree',
@@ -1498,7 +1498,7 @@ describe('applyCrossRoundSuppression', () => {
   it('does not suppress when file differs', () => {
     const findings = [makeFinding({ title: 'Unused variable', file: 'src/b.ts', line: 10, severity: 'suggestion' })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'suggestion',
       title: 'Unused variable',
       authorReply: 'agree',
@@ -1512,7 +1512,7 @@ describe('applyCrossRoundSuppression', () => {
   it('suppresses by ratchet even when line delta exceeds the window', () => {
     const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 100, severity: 'suggestion' })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'suggestion',
       title: 'Unused variable',
       authorReply: 'agree',
@@ -1532,7 +1532,7 @@ describe('applyCrossRoundSuppression', () => {
       description: 'Replace the old helper and avoid the previous pattern instead.',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1557,7 +1557,7 @@ describe('applyCrossRoundSuppression', () => {
       judgeNotes: 'Prior note',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1577,7 +1577,7 @@ describe('applyCrossRoundSuppression', () => {
       description: 'Replace the old helper and avoid the previous pattern instead.',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1602,7 +1602,7 @@ describe('applyCrossRoundSuppression', () => {
       suggestedFix: 'Replace it with the newer utility instead.',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1623,7 +1623,7 @@ describe('applyCrossRoundSuppression', () => {
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1647,7 +1647,7 @@ describe('applyCrossRoundSuppression', () => {
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1668,7 +1668,7 @@ describe('applyCrossRoundSuppression', () => {
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 30, slug: 'Naming-convention' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 30, slug: titleToSlug('Naming convention') },
       severity: 'suggestion',
       title: 'Naming convention',
       authorReply: 'agree',
@@ -1702,7 +1702,7 @@ describe('applyCrossRoundSuppression', () => {
       tags: ['security'],
     })];
     const prior = [makePriorRound([{
-      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
       severity: 'suggestion',
       title: 'Unused variable',
       authorReply: 'agree',
@@ -1744,7 +1744,7 @@ describe('runJudgeAgent cross-round suppression', () => {
         commitSha: 'abc',
         timestamp: 't',
         findings: [{
-          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: 'Unused-variable' },
+          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
           severity: 'suggestion',
           title: 'Unused variable',
           authorReply: 'agree',
@@ -1785,7 +1785,7 @@ describe('runJudgeAgent cross-round suppression', () => {
         commitSha: 'abc',
         timestamp: 't',
         findings: [{
-          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
           severity: 'suggestion',
           title: 'Naming convention',
           authorReply: 'agree',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1691,4 +1691,45 @@ describe('runJudgeAgent cross-round suppression', () => {
     expect(result.findings[0].severity).toBe('ignore');
     expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
   });
+
+  it('reports crossRoundDemoted when prior contradiction fires', async () => {
+    const judgedResponse = JSON.stringify({
+      summary: 'Unchanged.',
+      findings: [
+        { title: 'Naming convention', severity: 'required', reasoning: 'Still present.', confidence: 'high' },
+      ],
+    });
+    mockSendMessage.mockResolvedValue({ content: judgedResponse });
+
+    const input: JudgeInput = {
+      findings: [makeFinding({
+        title: 'Naming convention',
+        file: 'src/index.ts',
+        line: 12,
+        severity: 'required',
+        description: 'Replace the old helper instead.',
+      })],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 3,
+      priorRounds: [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: 't',
+        findings: [{
+          fingerprint: { file: 'src/index.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+          severity: 'suggestion',
+          title: 'Naming convention',
+          authorReply: 'agree',
+        }],
+      }],
+    };
+
+    const result = await runJudgeAgent(mockClient, makeConfig(), input);
+    expect(result.crossRoundDemoted).toBe(1);
+    expect(result.crossRoundSuppressed).toBeUndefined();
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+  });
 });

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1749,6 +1749,31 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
 
+  it('does not overwrite pre-existing originalSeverity when contradiction fires', () => {
+    // Simulates a finding that was already demoted by applyReachability (originalSeverity='required')
+    // before applyCrossRoundSuppression runs. The contradiction path must preserve it.
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'suggestion',
+      originalSeverity: 'required',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].originalSeverity).toBe('required');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+  });
+
   it('passes through findings unchanged when priorRounds is empty or undefined', () => {
     const findings = [makeFinding({ title: 'Unused variable', severity: 'suggestion' })];
     const emptyResult = applyCrossRoundSuppression(findings, []);

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1662,6 +1662,30 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.suppressedCount).toBe(1);
   });
 
+  it('does not tag or count findings already marked ignore by the judge', () => {
+    // The judge may return findings with severity `ignore` (explicitly dropped). The ratchet
+    // condition `current.severity !== 'required'` is true for `ignore`, so without an early
+    // return the ratchet would fire, add a tag, and inflate suppressedCount.
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'ignore',
+      description: 'Replace the old helper instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Naming convention') },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }])];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.findings[0].severity).toBe('ignore');
+    expect(result.findings[0].tags ?? []).not.toContain('suppressed-by-ratchet');
+  });
+
   it('does not demote contradiction when line delta exceeds the window', () => {
     const findings = [makeFinding({
       title: 'Naming convention',

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1547,6 +1547,30 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].judgeNotes).toContain('Contradicts round 3 guidance accepted by author');
   });
 
+  it('demotes suggestion to nit via contradiction when reversal word matches within line window', () => {
+    const findings = [makeFinding({
+      title: 'Naming convention',
+      file: 'src/a.ts',
+      line: 12,
+      severity: 'suggestion',
+      description: 'Replace the old helper and avoid the previous pattern instead.',
+    })];
+    const prior = [makePriorRound([{
+      fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Naming-convention' },
+      severity: 'suggestion',
+      title: 'Naming convention',
+      authorReply: 'agree',
+    }], 2)];
+
+    const result = applyCrossRoundSuppression(findings, prior);
+    expect(result.suppressedCount).toBe(0);
+    expect(result.demotedCount).toBe(1);
+    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].originalSeverity).toBe('suggestion');
+    expect(result.findings[0].tags).toContain('contradicts-prior-round');
+    expect(result.findings[0].tags).not.toContain('suppressed-by-ratchet');
+  });
+
   it('does not demote contradiction when line delta exceeds the window', () => {
     const findings = [makeFinding({
       title: 'Naming convention',

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -723,9 +723,9 @@ export function applyCrossRoundSuppression(
 
     const slug = titleToSlug(current.title);
 
-    // Contradiction has a more specific predicate (line proximity + reversal word) so it
-    // runs first. This ensures a suggestion that contradicts prior guidance gets a visible
-    // demotion note rather than being silently suppressed by ratchet.
+    // Contradiction is checked before ratchet for `suggestion` findings only.
+    // `required` and `nit` skip this branch: required is protected from any
+    // silent demotion (prompt-injection guard); nit falls through to ratchet.
     const contradictionMatch = acceptedPriors.find(({ finding: prior }) =>
       prior.fingerprint.file === current.file
       && prior.fingerprint.slug === slug

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -559,7 +559,14 @@ export async function runJudgeAgent(
     if (findings.length > 0) {
       core.warning('Judge returned no findings — returning originals unchanged');
     }
-    return { findings, summary: judgeResult.summary, resolveThreads: judgeResult.resolveThreads };
+    const earlySuppress = applyCrossRoundSuppression(findings, priorRounds);
+    return {
+      findings: earlySuppress.findings,
+      summary: judgeResult.summary,
+      resolveThreads: judgeResult.resolveThreads,
+      ...(earlySuppress.suppressedCount > 0 && { crossRoundSuppressed: earlySuppress.suppressedCount }),
+      ...(earlySuppress.demotedCount > 0 && { crossRoundDemoted: earlySuppress.demotedCount }),
+    };
   }
 
   const mapped = deduplicateFindings(mapJudgedToFindings(findings, judgeResult.findings));

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -10,13 +10,19 @@ import {
   Suppression,
   RepoMemory,
 } from './memory';
-import { LinkedIssue } from './github';
+import { LinkedIssue, titleToSlug } from './github';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
-import { DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverRound, ReviewConfig, ParsedDiff, PrContext } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverFinding, HandoverRound, RATCHET_SUPPRESSED_TAG, ReviewConfig, ParsedDiff, PrContext } from './types';
 
 /** Cap on how many prior rounds we pass to the judge. */
 const PRIOR_ROUNDS_WINDOW = 3;
+
+/** Line-delta window used when matching a current finding to a prior-round finding. */
+const LINE_WINDOW = 5;
+
+/** Words that, when present in a current finding, suggest it reverses prior guidance. */
+const REVERSAL_WORDS = ['remove', 'delete', 'add', 'use', 'avoid', 'replace', 'revert', 'undo', 'instead'];
 
 export interface JudgeInput {
   findings: Finding[];
@@ -518,7 +524,13 @@ export async function runJudgeAgent(
   client: ClaudeClient,
   config: ReviewConfig,
   input: JudgeInput,
-): Promise<{ findings: Finding[]; summary: string; resolveThreads?: ResolveThread[] }> {
+): Promise<{
+  findings: Finding[];
+  summary: string;
+  resolveThreads?: ResolveThread[];
+  crossRoundSuppressed?: number;
+  crossRoundDemoted?: number;
+}> {
   const { findings, diff, memory, prContext, linkedIssues, agentCount, isFollowUp, openThreads, priorRounds } = input;
 
   const hasOpenThreads = (openThreads?.length ?? 0) > 0;
@@ -550,10 +562,15 @@ export async function runJudgeAgent(
     return { findings, summary: judgeResult.summary, resolveThreads: judgeResult.resolveThreads };
   }
 
+  const mapped = deduplicateFindings(mapJudgedToFindings(findings, judgeResult.findings));
+  const suppression = applyCrossRoundSuppression(mapped, priorRounds);
+
   return {
-    findings: deduplicateFindings(mapJudgedToFindings(findings, judgeResult.findings)),
+    findings: suppression.findings,
     summary: judgeResult.summary,
     resolveThreads: judgeResult.resolveThreads,
+    ...(suppression.suppressedCount > 0 && { crossRoundSuppressed: suppression.suppressedCount }),
+    ...(suppression.demotedCount > 0 && { crossRoundDemoted: suppression.demotedCount }),
   };
 }
 
@@ -652,6 +669,79 @@ function mapMergedFindings(original: Finding[], judged: JudgedFinding[]): Findin
   }
 
   return result;
+}
+
+/**
+ * Apply cross-round suppression rules using prior-round handover state.
+ *
+ * Ratchet: if a prior finding with the same slug + file exists and the author
+ * agreed, suppress the current finding unless it is `required`.
+ *
+ * Contradiction: if a prior finding with the same slug + file + line proximity
+ * exists, the author agreed, and the current finding uses a reversal word,
+ * demote `required`/`suggestion` to `nit` and annotate `judgeNotes`.
+ */
+export function applyCrossRoundSuppression(
+  findings: Finding[],
+  priorRounds: HandoverRound[] | undefined,
+): { findings: Finding[]; suppressedCount: number; demotedCount: number } {
+  if (!priorRounds || priorRounds.length === 0) {
+    return { findings, suppressedCount: 0, demotedCount: 0 };
+  }
+
+  const acceptedPriors: Array<{ round: number; finding: HandoverFinding }> = [];
+  for (const round of priorRounds) {
+    for (const f of round.findings) {
+      if (f.authorReply === 'agree') {
+        acceptedPriors.push({ round: round.round, finding: f });
+      }
+    }
+  }
+
+  if (acceptedPriors.length === 0) {
+    return { findings, suppressedCount: 0, demotedCount: 0 };
+  }
+
+  let suppressedCount = 0;
+  let demotedCount = 0;
+
+  const updated = findings.map((finding) => {
+    const current = { ...finding };
+    const slug = titleToSlug(current.title);
+
+    const ratchetMatch = acceptedPriors.find(({ finding: prior }) =>
+      prior.fingerprint.file === current.file && prior.fingerprint.slug === slug,
+    );
+    if (ratchetMatch && current.severity !== 'required') {
+      current.severity = 'ignore';
+      current.tags = addTag(current.tags, RATCHET_SUPPRESSED_TAG);
+      suppressedCount++;
+      return current;
+    }
+
+    const contradictionMatch = acceptedPriors.find(({ finding: prior }) =>
+      prior.fingerprint.file === current.file
+      && prior.fingerprint.slug === slug
+      && Math.abs(current.line - prior.fingerprint.lineStart) <= LINE_WINDOW,
+    );
+    if (contradictionMatch && hasReversalWord(current) && (current.severity === 'required' || current.severity === 'suggestion')) {
+      current.originalSeverity = current.severity;
+      current.severity = 'nit';
+      current.tags = addTag(current.tags, CONTRADICTION_TAG);
+      const note = `Contradicts round ${contradictionMatch.round} guidance accepted by author`;
+      current.judgeNotes = current.judgeNotes ? `${current.judgeNotes} ${note}` : note;
+      demotedCount++;
+    }
+
+    return current;
+  });
+
+  return { findings: updated, suppressedCount, demotedCount };
+}
+
+function hasReversalWord(finding: Finding): boolean {
+  const haystack = `${finding.description} ${finding.suggestedFix ?? ''}`.toLowerCase();
+  return REVERSAL_WORDS.some(word => new RegExp(`\\b${word}\\b`).test(haystack));
 }
 
 export function deduplicateFindings(findings: Finding[]): Finding[] {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -709,16 +709,9 @@ export function applyCrossRoundSuppression(
     const current = { ...finding };
     const slug = titleToSlug(current.title);
 
-    const ratchetMatch = acceptedPriors.find(({ finding: prior }) =>
-      prior.fingerprint.file === current.file && prior.fingerprint.slug === slug,
-    );
-    if (ratchetMatch && current.severity !== 'required') {
-      current.severity = 'ignore';
-      current.tags = addTag(current.tags, RATCHET_SUPPRESSED_TAG);
-      suppressedCount++;
-      return current;
-    }
-
+    // Contradiction has a more specific predicate (line proximity + reversal word) so it
+    // runs first. This ensures a suggestion that contradicts prior guidance gets a visible
+    // demotion note rather than being silently suppressed by ratchet.
     const contradictionMatch = acceptedPriors.find(({ finding: prior }) =>
       prior.fingerprint.file === current.file
       && prior.fingerprint.slug === slug
@@ -731,6 +724,17 @@ export function applyCrossRoundSuppression(
       const note = `Contradicts round ${contradictionMatch.round} guidance accepted by author`;
       current.judgeNotes = current.judgeNotes ? `${current.judgeNotes} ${note}` : note;
       demotedCount++;
+      return current;
+    }
+
+    const ratchetMatch = acceptedPriors.find(({ finding: prior }) =>
+      prior.fingerprint.file === current.file && prior.fingerprint.slug === slug,
+    );
+    if (ratchetMatch && current.severity !== 'required') {
+      current.severity = 'ignore';
+      current.tags = addTag(current.tags, RATCHET_SUPPRESSED_TAG);
+      suppressedCount++;
+      return current;
     }
 
     return current;

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -22,7 +22,7 @@ const PRIOR_ROUNDS_WINDOW = 3;
 const LINE_WINDOW = 5;
 
 /** Words that, when present in a current finding, suggest it reverses prior guidance. */
-const REVERSAL_WORDS = ['remove', 'delete', 'add', 'use', 'avoid', 'replace', 'revert', 'undo', 'instead'];
+const REVERSAL_WORDS = ['remove', 'delete', 'avoid', 'replace', 'revert', 'undo', 'instead'];
 
 export interface JudgeInput {
   findings: Finding[];

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -716,6 +716,11 @@ export function applyCrossRoundSuppression(
 
   const updated = findings.map((finding) => {
     const current = { ...finding };
+
+    // Findings the judge already dropped need no further action — skip both paths to
+    // avoid inflating suppressedCount with judge-dropped findings.
+    if (current.severity === 'ignore') return current;
+
     const slug = titleToSlug(current.title);
 
     // Contradiction has a more specific predicate (line proximity + reversal word) so it

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -686,7 +686,9 @@ function mapMergedFindings(original: Finding[], judged: JudgedFinding[]): Findin
  *
  * Contradiction: if a prior finding with the same slug + file + line proximity
  * exists, the author agreed, and the current finding uses a reversal word,
- * demote `required`/`suggestion` to `nit` and annotate `judgeNotes`.
+ * demote `suggestion` to `nit` and annotate `judgeNotes`. `required` findings
+ * are intentionally excluded from contradiction demotion to prevent prompt
+ * injection attacks where adversarial PR content could silently hide real bugs.
  */
 export function applyCrossRoundSuppression(
   findings: Finding[],
@@ -727,7 +729,7 @@ export function applyCrossRoundSuppression(
         && current.line <= prior.fingerprint.lineEnd + LINE_WINDOW
       ),
     );
-    if (contradictionMatch && hasReversalWord(current) && (current.severity === 'required' || current.severity === 'suggestion')) {
+    if (contradictionMatch && hasReversalWord(current) && current.severity === 'suggestion') {
       current.originalSeverity = current.severity;
       current.severity = 'nit';
       current.tags = addTag(current.tags, CONTRADICTION_TAG);

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -730,7 +730,7 @@ export function applyCrossRoundSuppression(
       ),
     );
     if (contradictionMatch && hasReversalWord(current) && current.severity === 'suggestion') {
-      current.originalSeverity = current.severity;
+      current.originalSeverity ??= current.severity;
       current.severity = 'nit';
       current.tags = addTag(current.tags, CONTRADICTION_TAG);
       const note = `Contradicts round ${contradictionMatch.round} guidance accepted by author`;

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -715,7 +715,10 @@ export function applyCrossRoundSuppression(
     const contradictionMatch = acceptedPriors.find(({ finding: prior }) =>
       prior.fingerprint.file === current.file
       && prior.fingerprint.slug === slug
-      && Math.abs(current.line - prior.fingerprint.lineStart) <= LINE_WINDOW,
+      && (
+        current.line >= prior.fingerprint.lineStart - LINE_WINDOW
+        && current.line <= prior.fingerprint.lineEnd + LINE_WINDOW
+      ),
     );
     if (contradictionMatch && hasReversalWord(current) && (current.severity === 'required' || current.severity === 'suggestion')) {
       current.originalSeverity = current.severity;

--- a/src/review.ts
+++ b/src/review.ts
@@ -873,6 +873,8 @@ export async function runReview(
   let allJudgedFindings: Finding[] | undefined;
   let judgeSummary = 'Review complete.';
   let judgeResolveThreads: ResolveThread[] | undefined;
+  let judgeCrossRoundSuppressed: number | undefined;
+  let judgeCrossRoundDemoted: number | undefined;
   try {
     core.info(`Running judge on ${findingsForJudge.length} findings...`);
     const judgeInput: JudgeInput = {
@@ -893,6 +895,8 @@ export async function runReview(
     judgeSummary = judgeResult.summary;
     allJudgedFindings = judgeResult.findings;
     judgeResolveThreads = judgeResult.resolveThreads;
+    judgeCrossRoundSuppressed = judgeResult.crossRoundSuppressed;
+    judgeCrossRoundDemoted = judgeResult.crossRoundDemoted;
     finalFindings = judgeResult.findings.filter(f => f.severity !== 'ignore');
     core.info(`Judge complete: ${finalFindings.length} findings survived (${judgeResult.findings.length - finalFindings.length} ignored)`);
   } catch (error) {
@@ -943,6 +947,8 @@ export async function runReview(
     llmDedupCount,
     suppressionCount,
     agentResponseLengths,
+    crossRoundSuppressed: judgeCrossRoundSuppressed,
+    crossRoundDemoted: judgeCrossRoundDemoted,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,8 @@ export interface ReviewResult {
   llmDedupCount?: number;
   suppressionCount?: number;
   agentResponseLengths?: Map<string, number>;
+  crossRoundSuppressed?: number;
+  crossRoundDemoted?: number;
 }
 
 export interface ReviewerAgent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export type FindingSeverity = 'required' | 'suggestion' | 'nit' | 'ignore';
 export type FindingReachability = 'reachable' | 'hypothetical' | 'unknown';
 
 export const DEFENSIVE_HARDENING_TAG = 'defensive-hardening' as const;
+export const RATCHET_SUPPRESSED_TAG = 'suppressed-by-ratchet' as const;
+export const CONTRADICTION_TAG = 'contradicts-prior-round' as const;
 
 export interface Finding {
   severity: FindingSeverity;
@@ -210,6 +212,8 @@ export interface ReviewStats {
     mergedDuplicates: number;
     defensiveHardeningCount?: number;
     verdictReason?: VerdictReason;
+    crossRoundSuppressed?: number;
+    crossRoundDemoted?: number;
   };
 
   // File analysis


### PR DESCRIPTION
## Summary

- Add `applyCrossRoundSuppression` helper in `src/judge.ts` that runs after `deduplicateFindings` inside `runJudgeAgent`. Two rules:
  - **Ratchet**: when a prior-round `HandoverFinding` with the same slug and file exists and the author agreed, set the current finding's severity to `ignore` and tag it `suppressed-by-ratchet`. `required` findings are never silently suppressed.
  - **Contradiction**: when a prior agreed finding matches on slug, file, and line proximity (`LINE_WINDOW = 5`), and the current finding's description or suggested fix contains a reversal word (`remove`, `delete`, `add`, `use`, `avoid`, `replace`, `revert`, `undo`, `instead`), demote `required`/`suggestion` to `nit`, tag `contradicts-prior-round`, record `originalSeverity`, and append a "Contradicts round N guidance accepted by author" note to `judgeNotes`.
- Add `RATCHET_SUPPRESSED_TAG` and `CONTRADICTION_TAG` constants in `src/types.ts` and extend `ReviewStats.judgeMetrics` with optional `crossRoundSuppressed` and `crossRoundDemoted` counters.
- Surface the counts on `runJudgeAgent`'s return value and mirror the `defensiveHardeningCount` pattern in `src/index.ts` to populate `judgeMetrics` from tagged findings in `allJudged`.

## Test plan

- [x] `npm run all` passes (1215 tests, 14 suites).
- [x] New `describe('applyCrossRoundSuppression')` block covers: ratchet fires on slug+file match with `agree` reply, `required` guard, `disagree` reply skipped, slug mismatch, file mismatch, line-delta independence for ratchet, contradiction demotes on reversal word + line proximity, contradiction skipped outside line window, pre-existing tags preserved, empty/undefined `priorRounds` passes through.
- [x] New `runJudgeAgent` case asserts `crossRoundSuppressed` is reported on the return value.

Closes #547. Part of #545.