### PR TITLE
feat: verdict approval ceiling when only dismissed suggestions remain

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1561,6 +1561,7 @@ describe('runFullReview orchestration', () => {
       confidenceDistribution: { high: 2, medium: 1, low: 1 },
       severityChanges: 2,
       mergedDuplicates: 2,
+      verdictReason: 'novel_suggestion',
     });
 
     // fileMetrics

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1999,6 +1999,9 @@ describe('runFullReview orchestration', () => {
 
     const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
     expect(statsArg?.judgeMetrics?.verdictReason).toBe('novel_suggestion');
+    // result.verdictReason must also be updated alongside result.verdict after escalation
+    const reviewResultArg = jest.mocked(ghUtils.postReview).mock.calls[0][5];
+    expect(reviewResultArg?.verdictReason).toBe('novel_suggestion');
   });
 
   it('populates verdictReason in judgeMetrics on clean APPROVE with no findings', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1996,6 +1996,32 @@ describe('runFullReview orchestration', () => {
     );
     // Verdict recalculated after escalation
     expect(jest.mocked(reviewModule.determineVerdict)).toHaveBeenCalled();
+
+    const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    expect(statsArg?.judgeMetrics?.verdictReason).toBe('novel_suggestion');
+  });
+
+  it('populates verdictReason in judgeMetrics on clean APPROVE with no findings', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'APPROVE', summary: 'Looks good',
+      findings: [], highlights: [], reviewComplete: true,
+    });
+    jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [], duplicates: [] });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' });
+
+    await callRunFullReview();
+
+    const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    expect(statsArg?.judgeMetrics?.verdictReason).toBe('only_dismissed_or_nit');
   });
 
   it('enriches findings with code context from diff hunks', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -110,7 +110,7 @@ jest.mock('./review', () => ({
     highlights: [],
     reviewComplete: true,
   }),
-  determineVerdict: jest.fn().mockReturnValue('APPROVE'),
+  determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' }),
   selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
 }));
 
@@ -1339,7 +1339,7 @@ describe('runFullReview orchestration', () => {
       verdict: 'APPROVE', summary: 'Looks good',
       findings: [], highlights: [], reviewComplete: true,
     });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('APPROVE');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' });
     jest.mocked(reviewModule.selectTeam).mockReturnValue({ level: 'standard' as 'small', agents: [{ name: 'general', focus: '' }], lineCount: 0 });
     jest.mocked(ghUtils.postProgressComment).mockResolvedValue(1);
     jest.mocked(ghUtils.postReview).mockResolvedValue(123);
@@ -1489,7 +1489,7 @@ describe('runFullReview orchestration', () => {
       reviewComplete: true,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
 
     await callRunFullReview();
 
@@ -1543,7 +1543,7 @@ describe('runFullReview orchestration', () => {
       rawFindings,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
 
     await callRunFullReview();
 
@@ -1620,7 +1620,7 @@ describe('runFullReview orchestration', () => {
       llmDedupCount: 1,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
 
     await callRunFullReview();
 
@@ -1672,7 +1672,7 @@ describe('runFullReview orchestration', () => {
       suppressionCount: 2,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
 
     await callRunFullReview();
 
@@ -1710,7 +1710,7 @@ describe('runFullReview orchestration', () => {
       rawFindings: [...findings],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
 
     await callRunFullReview();
 
@@ -1748,7 +1748,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
     });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('COMMENT');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
 
     await callRunFullReview();
 
@@ -1788,7 +1788,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
     });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('COMMENT');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
 
     await callRunFullReview();
 
@@ -1986,7 +1986,7 @@ describe('runFullReview orchestration', () => {
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
     jest.mocked(memoryModule.applyEscalations).mockReturnValue([escalated]);
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('REQUEST_CHANGES');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
 
     await callRunFullReview();
 
@@ -2018,7 +2018,7 @@ describe('runFullReview orchestration', () => {
       findings: [finding], highlights: [], reviewComplete: true,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('COMMENT');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
 
     await callRunFullReview();
 
@@ -2286,7 +2286,7 @@ describe('runFullReview orchestration', () => {
         };
       },
     );
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue('COMMENT');
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
 
     await callRunFullReview();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -604,6 +604,7 @@ async function runFullReview(
     }
     const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat);
     result.verdict = recomputedVerdict;
+    result.verdictReason = verdictReason;
 
     // Enrich findings with code context from the diff for nit issues
     for (const finding of result.findings) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
 import { runReview, determineVerdict, selectTeam } from './review';
-import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
+import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats, VerdictReason } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -598,10 +598,12 @@ async function runFullReview(
       return;
     }
 
+    const priorFindingsFlat = handover?.rounds.flatMap(r => r.findings) ?? [];
     if (memory && memory.patterns.length > 0) {
       result.findings = applyEscalations(result.findings, memory.patterns);
-      result.verdict = determineVerdict(result.findings).verdict;
+      result.verdict = determineVerdict(result.findings, priorFindingsFlat).verdict;
     }
+    const verdictReason: VerdictReason = determineVerdict(result.findings, priorFindingsFlat).verdictReason;
 
     // Enrich findings with code context from the diff for nit issues
     for (const finding of result.findings) {
@@ -669,6 +671,7 @@ async function runFullReview(
         severityChanges,
         mergedDuplicates,
         ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
+        verdictReason,
       };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -600,7 +600,7 @@ async function runFullReview(
 
     if (memory && memory.patterns.length > 0) {
       result.findings = applyEscalations(result.findings, memory.patterns);
-      result.verdict = determineVerdict(result.findings);
+      result.verdict = determineVerdict(result.findings).verdict;
     }
 
     // Enrich findings with code context from the diff for nit issues

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
 import { runReview, determineVerdict, selectTeam } from './review';
-import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats, VerdictReason } from './types';
+import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -601,9 +601,9 @@ async function runFullReview(
     const priorFindingsFlat = handover?.rounds.flatMap(r => r.findings) ?? [];
     if (memory && memory.patterns.length > 0) {
       result.findings = applyEscalations(result.findings, memory.patterns);
-      result.verdict = determineVerdict(result.findings, priorFindingsFlat).verdict;
     }
-    const verdictReason: VerdictReason = determineVerdict(result.findings, priorFindingsFlat).verdictReason;
+    const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat);
+    result.verdict = recomputedVerdict;
 
     // Enrich findings with code context from the diff for nit issues
     for (const finding of result.findings) {
@@ -653,27 +653,26 @@ async function runFullReview(
       : undefined;
 
     // Judge calibration metrics
-    let judgeMetrics: ReviewStats['judgeMetrics'];
-    if (allJudged.length > 0) {
-      const confidenceDistribution = { high: 0, medium: 0, low: 0 };
-      for (const f of allJudged) {
-        if (f.judgeConfidence) confidenceDistribution[f.judgeConfidence]++;
-      }
-      const severityChanges = allJudged.filter(f => f.judgeNotes).length;
-      const mergedDuplicates = (result.rawFindingCount ?? 0)
+    const confidenceDistribution = { high: 0, medium: 0, low: 0 };
+    for (const f of allJudged) {
+      if (f.judgeConfidence) confidenceDistribution[f.judgeConfidence]++;
+    }
+    const severityChanges = allJudged.filter(f => f.judgeNotes).length;
+    const mergedDuplicates = allJudged.length > 0
+      ? (result.rawFindingCount ?? 0)
         - (result.suppressionCount ?? 0)
         - (result.staticDedupCount ?? 0)
         - (result.llmDedupCount ?? 0)
-        - allJudged.length;
-      const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes(DEFENSIVE_HARDENING_TAG)).length;
-      judgeMetrics = {
-        confidenceDistribution,
-        severityChanges,
-        mergedDuplicates,
-        ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
-        verdictReason,
-      };
-    }
+        - allJudged.length
+      : 0;
+    const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes(DEFENSIVE_HARDENING_TAG)).length;
+    const judgeMetrics: ReviewStats['judgeMetrics'] = {
+      confidenceDistribution,
+      severityChanges,
+      mergedDuplicates,
+      ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
+      verdictReason,
+    };
 
     // File analysis metrics
     const fileTypes: Record<string, number> = {};

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -317,26 +317,28 @@ describe('determineVerdict', () => {
   });
 
   it('only dismisses when the prior authorReply is "agree"', () => {
+    const title = 'T';
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'T', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+      { severity: 'suggestion', title, file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
-      fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: 'T' },
+      fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: titleToSlug(title) },
       severity: 'suggestion',
-      title: 'T',
+      title,
       authorReply: 'disagree',
     }];
     expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');
   });
 
   it.each(['partial', 'none'] as const)('does not dismiss when authorReply is "%s"', (reply) => {
+    const title = 'T';
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'T', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+      { severity: 'suggestion', title, file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
-      fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: 'T' },
+      fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: titleToSlug(title) },
       severity: 'suggestion',
-      title: 'T',
+      title,
       authorReply: reply,
     }];
     expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -22,8 +22,8 @@ import {
   PLANNER_TIMEOUT_MS,
 } from './review';
 import * as core from '@actions/core';
-import { LinkedIssue } from './github';
-import { Finding, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, MAX_AGENT_RETRIES } from './types';
+import { LinkedIssue, titleToSlug } from './github';
+import { Finding, HandoverFinding, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, MAX_AGENT_RETRIES } from './types';
 import { runJudgeAgent } from './judge';
 import { applySuppressions } from './memory';
 
@@ -241,48 +241,136 @@ describe('determineVerdict', () => {
       makeFinding({ severity: 'suggestion' }),
       makeFinding({ severity: 'required' }),
     ];
-    expect(determineVerdict(findings)).toBe('REQUEST_CHANGES');
+    expect(determineVerdict(findings).verdict).toBe('REQUEST_CHANGES');
+    expect(determineVerdict(findings).verdictReason).toBe('required_present');
   });
 
-  it('returns APPROVE when there are only suggestions', () => {
+  it('returns REQUEST_CHANGES when a novel suggestion exists', () => {
     const findings: Finding[] = [makeFinding({ severity: 'suggestion' })];
-    expect(determineVerdict(findings)).toBe('APPROVE');
+    expect(determineVerdict(findings).verdict).toBe('REQUEST_CHANGES');
+    expect(determineVerdict(findings).verdictReason).toBe('novel_suggestion');
   });
 
-  it('returns APPROVE when there are only nits', () => {
+  it('returns COMMENT when there are only nits', () => {
     const findings: Finding[] = [makeFinding({ severity: 'nit' })];
-    expect(determineVerdict(findings)).toBe('APPROVE');
+    expect(determineVerdict(findings).verdict).toBe('COMMENT');
+    expect(determineVerdict(findings).verdictReason).toBe('only_dismissed_or_nit');
   });
 
-  it('returns APPROVE when there are only ignores', () => {
+  it('returns COMMENT when there are only ignores', () => {
     const findings: Finding[] = [makeFinding({ severity: 'ignore' })];
-    expect(determineVerdict(findings)).toBe('APPROVE');
+    expect(determineVerdict(findings).verdict).toBe('COMMENT');
+    expect(determineVerdict(findings).verdictReason).toBe('only_dismissed_or_nit');
   });
 
   it('returns APPROVE when there are no findings', () => {
-    expect(determineVerdict([])).toBe('APPROVE');
+    expect(determineVerdict([]).verdict).toBe('APPROVE');
+    expect(determineVerdict([]).verdictReason).toBe('only_dismissed_or_nit');
   });
 
-  it('should REQUEST_CHANGES when 1+ high-confidence suggestions exist', () => {
+  it('returns REQUEST_CHANGES when a suggestion has no matching prior-round dismissal', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 1, description: 'The return value should be checked for null', reviewers: ['reviewer-1'], judgeConfidence: 'high' },
     ];
-    expect(determineVerdict(findings)).toBe('REQUEST_CHANGES');
+    const result = determineVerdict(findings, []);
+    expect(result.verdict).toBe('REQUEST_CHANGES');
+    expect(result.verdictReason).toBe('novel_suggestion');
   });
 
-  it('should APPROVE when no high-confidence suggestions exist', () => {
-    const findings: Finding[] = [];
-    expect(determineVerdict(findings)).toBe('APPROVE');
-  });
-
-  it('should APPROVE when suggestions are not high-confidence', () => {
+  it('returns COMMENT when the only suggestion matches a prior-round agreement', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 1, description: 'The return value should be checked for null', reviewers: ['reviewer-1'], judgeConfidence: 'medium' },
-      { severity: 'suggestion', title: 'Unused import detected', file: 'src/handler.ts', line: 2, description: 'This import is not referenced anywhere', reviewers: ['reviewer-1'], judgeConfidence: 'low' },
-      { severity: 'suggestion', title: 'Consider using const', file: 'src/utils.ts', line: 3, description: 'Variable is never reassigned', reviewers: ['reviewer-1'], judgeConfidence: 'medium' },
-      { severity: 'suggestion', title: 'Potential memory leak', file: 'src/utils.ts', line: 4, description: 'Event listener is never removed', reviewers: ['reviewer-1'] },
+      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
-    expect(determineVerdict(findings)).toBe('APPROVE');
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
+      severity: 'suggestion',
+      title: 'Missing null check',
+      authorReply: 'agree',
+    }];
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('COMMENT');
+    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+  });
+
+  it('returns REQUEST_CHANGES when mixing dismissed and novel suggestions', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'suggestion', title: 'Unused import', file: 'src/handler.ts', line: 20, description: 'desc', reviewers: ['reviewer-1'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
+      severity: 'suggestion',
+      title: 'Missing null check',
+      authorReply: 'agree',
+    }];
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('REQUEST_CHANGES');
+    expect(result.verdictReason).toBe('novel_suggestion');
+  });
+
+  it('treats undefined priorRounds as "all suggestions novel"', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'Something', file: 'a.ts', line: 3, description: 'desc', reviewers: ['r'] },
+    ];
+    expect(determineVerdict(findings).verdict).toBe('REQUEST_CHANGES');
+    expect(determineVerdict(findings).verdictReason).toBe('novel_suggestion');
+  });
+
+  it('only dismisses when the prior authorReply is "agree"', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'T', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: 'T' },
+      severity: 'suggestion',
+      title: 'T',
+      authorReply: 'disagree',
+    }];
+    expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');
+  });
+
+  it('tolerates ±5 line drift when matching a prior dismissal', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'Drifted', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'Drifted' },
+      severity: 'suggestion',
+      title: 'Drifted',
+      authorReply: 'agree',
+    }];
+    expect(determineVerdict(findings, priors).verdict).toBe('COMMENT');
+  });
+
+  it('rejects matches outside the ±5 line tolerance', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'FarAway', file: 'f.ts', line: 100, description: 'd', reviewers: ['r'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'FarAway' },
+      severity: 'suggestion',
+      title: 'FarAway',
+      authorReply: 'agree',
+    }];
+    expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');
+  });
+
+  it('returns COMMENT for a PR #106 R7 replay (4 suggestions all dismissed)', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'F1', file: 'src/a.ts', line: 10, description: 'd', reviewers: ['r'] },
+      { severity: 'suggestion', title: 'F2', file: 'src/b.ts', line: 20, description: 'd', reviewers: ['r'] },
+      { severity: 'suggestion', title: 'F3', file: 'src/c.ts', line: 30, description: 'd', reviewers: ['r'] },
+      { severity: 'suggestion', title: 'F4', file: 'src/d.ts', line: 40, description: 'd', reviewers: ['r'] },
+    ];
+    const priors: HandoverFinding[] = findings.map(f => ({
+      fingerprint: { file: f.file, lineStart: f.line, lineEnd: f.line, slug: titleToSlug(f.title) },
+      severity: 'suggestion' as const,
+      title: f.title,
+      authorReply: 'agree' as const,
+    }));
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('COMMENT');
+    expect(result.verdictReason).toBe('only_dismissed_or_nit');
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -329,6 +329,20 @@ describe('determineVerdict', () => {
     expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');
   });
 
+  it.each(['partial', 'none'] as const)('does not dismiss when authorReply is "%s"', (reply) => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'T', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: 'T' },
+      severity: 'suggestion',
+      title: 'T',
+      authorReply: reply,
+    }];
+    expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');
+    expect(determineVerdict(findings, priors).verdictReason).toBe('novel_suggestion');
+  });
+
   it('tolerates ±5 line drift when matching a prior dismissal', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'Drifted', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
@@ -1094,6 +1108,7 @@ describe('runReview', () => {
 
     const result = await runReview(clients, config, diff, 'raw diff', 'repo context');
     expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_dismissed_or_nit');
     expect(result.reviewComplete).toBe(true);
     expect(result.findings).toEqual([]);
   });

--- a/src/review.ts
+++ b/src/review.ts
@@ -907,7 +907,7 @@ export async function runReview(
   }
 
   const priorFindingsFlat: HandoverFinding[] = (priorRounds ?? []).flatMap(r => r.findings);
-  const { verdict } = determineVerdict(finalFindings, priorFindingsFlat);
+  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat);
 
   const summary = judgeSummary;
 
@@ -925,6 +925,7 @@ export async function runReview(
 
   return {
     verdict,
+    verdictReason,
     summary,
     findings: finalFindings,
     highlights: [],

--- a/src/review.ts
+++ b/src/review.ts
@@ -3,12 +3,12 @@ import * as core from '@actions/core';
 import { ClaudeClient } from './claude';
 import { runJudgeAgent, JudgeInput, ResolveThread } from './judge';
 import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
-import { LinkedIssue } from './github';
+import { LinkedIssue, titleToSlug } from './github';
 import { deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
-import { ReviewConfig, ReviewerAgent, Finding, HandoverRound, ReviewResult, ReviewVerdict, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, EffortLevel, AgentPick, MAX_AGENT_RETRIES } from './types';
+import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, EffortLevel, AgentPick, MAX_AGENT_RETRIES } from './types';
 import { extractJSON } from './json';
 
-export const HIGH_CONF_SUGGESTION_THRESHOLD = 1;
+const DISMISSED_LINE_TOLERANCE = 5;
 
 export const PLANNER_TIMEOUT_MS = 30_000;
 
@@ -906,7 +906,8 @@ export async function runReview(
     };
   }
 
-  const verdict = determineVerdict(finalFindings);
+  const priorFindingsFlat: HandoverFinding[] = (priorRounds ?? []).flatMap(r => r.findings);
+  const { verdict } = determineVerdict(finalFindings, priorFindingsFlat);
 
   const summary = judgeSummary;
 
@@ -1146,16 +1147,54 @@ export function validateSeverity(severity: unknown): Finding['severity'] {
   return 'suggestion';
 }
 
-export function determineVerdict(findings: Finding[]): ReviewVerdict {
-  const hasRequired = findings.some(f => f.severity === 'required');
-  if (hasRequired) return 'REQUEST_CHANGES';
+/**
+ * Check whether a current finding matches a prior-round `HandoverFinding`.
+ * Uses file + title-slug with a line-window tolerance so small drift between
+ * rounds does not break the match. Thread-resolved status is not consulted
+ * (not in the handover today).
+ */
+function matchesDismissedPrior(finding: Finding, prior: HandoverFinding): boolean {
+  if (finding.file !== prior.fingerprint.file) return false;
+  if (titleToSlug(finding.title) !== prior.fingerprint.slug) return false;
+  const line = finding.line;
+  const lo = prior.fingerprint.lineStart - DISMISSED_LINE_TOLERANCE;
+  const hi = prior.fingerprint.lineEnd + DISMISSED_LINE_TOLERANCE;
+  return line >= lo && line <= hi;
+}
 
-  const highConfSuggestions = findings.filter(
-    f => f.severity === 'suggestion' && f.judgeConfidence === 'high',
+function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding[]): boolean {
+  return priorRounds.some(p => p.authorReply === 'agree' && matchesDismissedPrior(finding, p));
+}
+
+/**
+ * Pick a verdict plus a machine-readable reason.
+ *
+ * Decision order:
+ *   1. any surviving `required` finding → REQUEST_CHANGES / required_present
+ *   2. any `suggestion` that is NOT a prior-round dismissed match → REQUEST_CHANGES / novel_suggestion
+ *   3. otherwise (only nits / previously-dismissed suggestions / empty) → COMMENT / only_dismissed_or_nit
+ *
+ * Empty `findings` yields APPROVE / only_dismissed_or_nit so callers can still
+ * distinguish "clean review" from "ceiling triggered".
+ */
+export function determineVerdict(
+  findings: Finding[],
+  priorRounds?: HandoverFinding[],
+): { verdict: ReviewVerdict; verdictReason: VerdictReason } {
+  if (findings.some(f => f.severity === 'required')) {
+    return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
+  }
+
+  const prior = priorRounds ?? [];
+  const hasNovelSuggestion = findings.some(
+    f => f.severity === 'suggestion' && !wasDismissedInPriorRound(f, prior),
   );
-  if (highConfSuggestions.length >= HIGH_CONF_SUGGESTION_THRESHOLD) return 'REQUEST_CHANGES';
+  if (hasNovelSuggestion) {
+    return { verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' };
+  }
 
-  return 'APPROVE';
+  const verdict: ReviewVerdict = findings.length === 0 ? 'APPROVE' : 'COMMENT';
+  return { verdict, verdictReason: 'only_dismissed_or_nit' };
 }
 
 export function truncateDiff(rawDiff: string, maxLength: number = 50000): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export type VerdictReason = 'required_present' | 'novel_suggestion' | 'only_dism
 
 export interface ReviewResult {
   verdict: ReviewVerdict;
+  verdictReason?: VerdictReason;
   summary: string;
   findings: Finding[];
   highlights: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,8 @@ export interface PrHandover {
 
 export type ReviewVerdict = 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
 
+export type VerdictReason = 'required_present' | 'novel_suggestion' | 'only_dismissed_or_nit';
+
 export interface ReviewResult {
   verdict: ReviewVerdict;
   summary: string;
@@ -206,6 +208,7 @@ export interface ReviewStats {
     severityChanges: number;
     mergedDuplicates: number;
     defensiveHardeningCount?: number;
+    verdictReason?: VerdictReason;
   };
 
   // File analysis


### PR DESCRIPTION
## Summary

Closes [#550](https://github.com/manki-review/manki/issues/550). Part of [#545](https://github.com/manki-review/manki/issues/545).

Prevents unbounded `CHANGES_REQUESTED` cycling on late review rounds by making `determineVerdict` prior-round-aware. When every surviving `suggestion` already matches a prior-round finding the author agreed with, the verdict relaxes to `COMMENT` instead of gating.

### What changed

- Removed `HIGH_CONF_SUGGESTION_THRESHOLD` from `src/review.ts`. Rule 2 below subsumes it.
- New `VerdictReason` union type in `src/types.ts`: `'required_present' | 'novel_suggestion' | 'only_dismissed_or_nit'`.
- `determineVerdict(findings, priorRounds?)` now returns `{ verdict, verdictReason }`. Three-rule decision tree:
  1. any `required` finding -> `REQUEST_CHANGES` / `required_present`
  2. any `suggestion` without a prior-round dismissed match -> `REQUEST_CHANGES` / `novel_suggestion`
  3. otherwise -> `COMMENT` / `only_dismissed_or_nit` (`APPROVE` when findings is empty)
- `priorRounds` is a flat `HandoverFinding[]`. `runReview` and `src/index.ts` flatten `handover.rounds` at the call site (no new `runReview` parameter).
- Dismissal predicate: file match, `titleToSlug` match, ±5 line tolerance, and `authorReply === 'agree'`.
- `ReviewStats.judgeMetrics.verdictReason` populated in `src/index.ts`.

### Acceptance criteria

- [x] Verdict logic consumes cross-round state from [#546](https://github.com/manki-review/manki/issues/546).
- [x] Fresh `required` or genuinely novel `suggestion` still gates.
- [x] PR #106 R7 scenario (4 prior-agreed suggestions) resolves to `COMMENT` — covered by an explicit replay test.
- [x] Reason recorded in `judgeMetrics.verdictReason`.

## Test plan

- [x] `npm run all` passes (14 suites, 1209 tests).
- [x] New `determineVerdict` cases cover: required present, novel suggestion, prior-agreed suggestion, only nits, empty findings, mixed dismissed + novel, undefined `priorRounds`, prior `disagree` (still gates), ±5 line drift match, outside-tolerance rejection, PR #106 R7 replay.
- [x] Existing `determineVerdict` mocks in `src/index.test.ts` updated to the new `{ verdict, verdictReason }` shape.
- [x] Post-escalation verdict recompute in `src/index.ts` passes the flattened prior findings.

## Behavior change beyond the original issue

Removing the `HIGH_CONF_SUGGESTION_THRESHOLD` shortcut is an intentional tightening that goes beyond #550's bare acceptance criteria, flagged during review:

- **Before**: a medium- or low-confidence novel `suggestion` did not gate — verdict reached `APPROVE` via the fall-through.
- **After**: any `suggestion` without a matching prior-round `agree` dismissal yields `REQUEST_CHANGES` with `verdictReason: 'novel_suggestion'`, regardless of confidence.
- **Rationale**: the confidence-threshold shortcut was inconsistent with the new three-rule dismissed-match decision tree. Rule 2 subsumes it cleanly, and authors get explicit feedback on every novel suggestion rather than silent approval of medium-confidence ones. The plan decision log noted this as a deliberate tightening.
- **Approval path for clean PRs is unchanged**: `APPROVE` now only fires on empty findings (same as the old fall-through when findings were empty). The `only_dismissed_or_nit` state now maps to `COMMENT` (a new, softer outcome), not `APPROVE`.

If the team prefers the prior semantics, the two knobs to tune are: (a) re-introduce a confidence gate at rule 2, or (b) let rule 3 map to `APPROVE` instead of `COMMENT`.
