### PR TITLE
feat: planner per-round summary for agent budget allocation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -102,17 +102,21 @@ jest.mock('./recap', () => ({
   fingerprintFinding: jest.fn((title: string, file: string, line: number) => ({ file, lineStart: line, lineEnd: line, slug: title })),
 }));
 
-jest.mock('./review', () => ({
-  runReview: jest.fn().mockResolvedValue({
-    verdict: 'APPROVE',
-    summary: 'Looks good',
-    findings: [],
-    highlights: [],
-    reviewComplete: true,
-  }),
-  determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' }),
-  selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
-}));
+jest.mock('./review', () => {
+  const actual = jest.requireActual('./review') as typeof import('./review');
+  return {
+    runReview: jest.fn().mockResolvedValue({
+      verdict: 'APPROVE',
+      summary: 'Looks good',
+      findings: [],
+      highlights: [],
+      reviewComplete: true,
+    }),
+    determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' }),
+    selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
+    buildPlannerHints: actual.buildPlannerHints,
+  };
+});
 
 jest.mock('./github', () => ({
   fetchPRDiff: jest.fn().mockResolvedValue(''),
@@ -1911,7 +1915,22 @@ describe('runFullReview orchestration', () => {
       round: 1,
       commitSha: 'abc',
       timestamp: '2025-01-01T00:00:00Z',
-      findings: [],
+      findings: [
+        {
+          fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's' },
+          severity: 'required' as const,
+          title: 't',
+          authorReply: 'agree' as const,
+          specialist: 'Security & Safety',
+        },
+        {
+          fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' },
+          severity: 'required' as const,
+          title: 't2',
+          authorReply: 'agree' as const,
+          specialist: 'Security & Safety',
+        },
+      ],
     }];
     jest.mocked(memoryModule.loadHandover).mockResolvedValue({
       prNumber: 1, repo: 'test-repo', rounds: priorRounds,
@@ -1921,6 +1940,15 @@ describe('runFullReview orchestration', () => {
 
     const runReviewCall = jest.mocked(reviewModule.runReview).mock.calls[0];
     expect(runReviewCall[13]).toEqual(priorRounds);
+    // priorRoundHints (index 14) should be derived from the loaded handover rounds.
+    expect(runReviewCall[14]).toEqual([
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 2 },
+        ],
+      },
+    ]);
 
     // Write path: appendHandoverRound must be called once with the loaded handover
     expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
@@ -1947,6 +1975,8 @@ describe('runFullReview orchestration', () => {
     const runReviewCall = jest.mocked(reviewModule.runReview).mock.calls[0];
     // priorRounds param (index 13) should be undefined when memory is disabled
     expect(runReviewCall[13]).toBeUndefined();
+    // priorRoundHints (index 14) falls back to [] when no handover is loaded
+    expect(runReviewCall[14]).toEqual([]);
   });
 
   it('applies memory escalations when patterns exist', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention, parseCommand, isLLMAccessAllowed } from './interaction';
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
-import { runReview, determineVerdict, selectTeam } from './review';
+import { runReview, determineVerdict, selectTeam, buildPlannerHints } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
@@ -582,6 +582,7 @@ async function runFullReview(
       openThreads,
       recap.previousFindings,
       handover?.rounds,
+      buildPlannerHints(handover?.rounds),
     );
     const judgeEndTime = Date.now();
 

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -1049,7 +1049,9 @@ describe('appendHandoverRound', () => {
 
   it('appends a new round without overwriting prior rounds', async () => {
     const octokit = mockJsonOctokit({});
-    const finding = makeFinding({ title: 'Null check', file: 'src/a.ts', line: 5 });
+    const finding = makeFinding({
+      title: 'Null check', file: 'src/a.ts', line: 5, reviewers: ['Security & Safety'],
+    });
 
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
@@ -1062,6 +1064,7 @@ describe('appendHandoverRound', () => {
     expect(loaded!.rounds[0].round).toBe(1);
     expect(loaded!.rounds[0].findings[0].title).toBe('Null check');
     expect(loaded!.rounds[0].findings[0].authorReply).toBe('none');
+    expect(loaded!.rounds[0].findings[0].specialist).toBe('Security & Safety');
     expect(loaded!.rounds[0].judgeSummary).toBe('One issue found');
 
     await appendHandoverRound(
@@ -1073,6 +1076,20 @@ describe('appendHandoverRound', () => {
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
     expect(reloaded!.rounds).toHaveLength(2);
     expect(reloaded!.rounds[1].round).toBe(2);
+  });
+
+  it('omits specialist when the finding has no reviewers', async () => {
+    const octokit = mockJsonOctokit({});
+    const finding = makeFinding({ title: 'Null check', file: 'src/a.ts', line: 5, reviewers: [] });
+
+    await appendHandoverRound(
+      octokit, 'owner/memory', 'rust-dashcore', 106,
+      'sha1', [finding], [],
+      'One issue found', noopFingerprint, noopClassify,
+    );
+
+    const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
+    expect(loaded!.rounds[0].findings[0]).not.toHaveProperty('specialist');
   });
 
   it('uses pre-loaded handover and skips the extra loadHandover fetch', async () => {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -644,6 +644,8 @@ export async function appendHandoverRound(
       title: f.title,
       authorReply: 'none',
     };
+    const specialist = f.reviewers?.[0];
+    if (specialist) entry.specialist = specialist;
     return entry;
   });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1898,6 +1898,112 @@ describe('runReview', () => {
     expect(result.agentNames).toContain('Domain Expert');
   });
 
+  it('clamps high effort to low when last-round dismiss rate is 100% with sample size >= 2', async () => {
+    const plannerResponse = JSON.stringify({
+      teamSize: 3,
+      reviewerEffort: 'medium',
+      judgeEffort: 'medium',
+      prType: 'feature',
+      agents: [
+        { name: 'Security & Safety', effort: 'high' },
+        { name: 'Correctness & Logic', effort: 'high' },
+        { name: 'Architecture & Design', effort: 'medium' },
+      ],
+    });
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn(),
+      } as unknown as import('./claude').ClaudeClient,
+      planner: {
+        sendMessage: jest.fn().mockResolvedValue({ content: plannerResponse }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig({ review_level: 'auto' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 3 },
+          { specialist: 'Correctness & Logic', findingsKept: 1, findingsDismissed: 2 },
+        ],
+      },
+    ];
+
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const result = await runReview(
+        clients, config, diff, 'raw diff', 'repo context',
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        hints,
+      );
+      expect(result.plannerResult?.agents).toBeDefined();
+      const secPick = result.plannerResult!.agents!.find(a => a.name === 'Security & Safety');
+      const corPick = result.plannerResult!.agents!.find(a => a.name === 'Correctness & Logic');
+      // 100% dismiss rate with sample >= 2 and effort high -> clamp to low
+      expect(secPick?.effort).toBe('low');
+      // Non-zero keep rate, guard does not fire
+      expect(corPick?.effort).toBe('high');
+
+      const clampLogs = infoSpy.mock.calls.filter(
+        c => typeof c[0] === 'string' && c[0].includes('Downgrading "Security & Safety"'),
+      );
+      expect(clampLogs.length).toBe(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('does not downgrade effort when dismiss sample is below threshold', async () => {
+    const plannerResponse = JSON.stringify({
+      teamSize: 3,
+      reviewerEffort: 'medium',
+      judgeEffort: 'medium',
+      prType: 'feature',
+      agents: [
+        { name: 'Security & Safety', effort: 'high' },
+        { name: 'Correctness & Logic', effort: 'medium' },
+        { name: 'Architecture & Design', effort: 'low' },
+      ],
+    });
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn(),
+      } as unknown as import('./claude').ClaudeClient,
+      planner: {
+        sendMessage: jest.fn().mockResolvedValue({ content: plannerResponse }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig({ review_level: 'auto' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 1 },
+        ],
+      },
+    ];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      hints,
+    );
+    const secPick = result.plannerResult!.agents!.find(a => a.name === 'Security & Safety');
+    expect(secPick?.effort).toBe('high');
+  });
+
   it('forwards priorRoundHints to the planner prompt', async () => {
     const plannerResponse = JSON.stringify({
       teamSize: 3,

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -5,6 +5,7 @@ import {
   buildReviewerSystemPrompt,
   buildReviewerUserMessage,
   buildPlannerSystemPrompt,
+  buildPlannerHints,
   selectTeam,
   titlesMatch,
   truncateDiff,
@@ -23,7 +24,7 @@ import {
 } from './review';
 import * as core from '@actions/core';
 import { LinkedIssue, titleToSlug } from './github';
-import { Finding, HandoverFinding, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, MAX_AGENT_RETRIES } from './types';
+import { Finding, HandoverFinding, HandoverRound, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, MAX_AGENT_RETRIES } from './types';
 import { runJudgeAgent } from './judge';
 import { applySuppressions } from './memory';
 
@@ -2739,6 +2740,86 @@ describe('selectTeam with teamSizeOverride', () => {
     expect(roster.level).toBe('small');
     expect(roster.agents.map(a => a.name)).toContain('Security & Safety');
     expect(roster.agents.map(a => a.name)).toContain('Correctness & Logic');
+  });
+});
+
+describe('buildPlannerHints', () => {
+  const makeRound = (round: number, findings: HandoverRound['findings']): HandoverRound => ({
+    round,
+    commitSha: `sha${round}`,
+    timestamp: '2025-01-01T00:00:00Z',
+    findings,
+  });
+
+  it('returns [] for undefined or empty rounds', () => {
+    expect(buildPlannerHints(undefined)).toEqual([]);
+    expect(buildPlannerHints([])).toEqual([]);
+  });
+
+  it('groups findings by specialist with kept/dismissed counts', () => {
+    const rounds = [
+      makeRound(1, [
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'suggestion', title: 't3', authorReply: 'none', specialist: 'Testing & Coverage' },
+      ]),
+    ];
+    const hints = buildPlannerHints(rounds);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].round).toBe(1);
+    const sec = hints[0].specialistOutcomes.find(o => o.specialist === 'Security & Safety');
+    const test = hints[0].specialistOutcomes.find(o => o.specialist === 'Testing & Coverage');
+    expect(sec).toEqual({ specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 2 });
+    expect(test).toEqual({ specialist: 'Testing & Coverage', findingsKept: 1, findingsDismissed: 0 });
+  });
+
+  it('skips findings without a specialist field (legacy handover entries)', () => {
+    const rounds = [
+      makeRound(1, [
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'none', specialist: 'Correctness & Logic' },
+      ]),
+    ];
+    const hints = buildPlannerHints(rounds);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].specialistOutcomes).toHaveLength(1);
+    expect(hints[0].specialistOutcomes[0].specialist).toBe('Correctness & Logic');
+  });
+
+  it('consumes only the last two rounds when more are present', () => {
+    const make = (n: number, spec: string): HandoverRound => makeRound(n, [
+      { fingerprint: { file: 'a.ts', lineStart: n, lineEnd: n, slug: `s${n}` }, severity: 'required', title: `t${n}`, authorReply: 'none', specialist: spec },
+    ]);
+    const rounds = [make(1, 'Security & Safety'), make(2, 'Architecture & Design'), make(3, 'Testing & Coverage')];
+    const hints = buildPlannerHints(rounds);
+    expect(hints.map(h => h.round)).toEqual([2, 3]);
+  });
+
+  it('omits rounds whose findings all lack a specialist', () => {
+    const rounds = [
+      makeRound(1, [
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree' },
+      ]),
+      makeRound(2, [
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'none', specialist: 'Correctness & Logic' },
+      ]),
+    ];
+    const hints = buildPlannerHints(rounds);
+    expect(hints.map(h => h.round)).toEqual([2]);
+  });
+
+  it('treats disagree/partial/none replies as kept', () => {
+    const rounds = [
+      makeRound(1, [
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'disagree', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'partial', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'none', specialist: 'Security & Safety' },
+      ]),
+    ];
+    const hints = buildPlannerHints(rounds);
+    expect(hints[0].specialistOutcomes[0]).toEqual({
+      specialist: 'Security & Safety', findingsKept: 3, findingsDismissed: 0,
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2004,6 +2004,163 @@ describe('runReview', () => {
     expect(secPick?.effort).toBe('high');
   });
 
+  it('uses only the most recent hint when an older round has 100% dismissals but the latest does not', async () => {
+    const plannerResponse = JSON.stringify({
+      teamSize: 1,
+      reviewerEffort: 'medium',
+      judgeEffort: 'medium',
+      prType: 'feature',
+      agents: [{ name: 'Security & Safety', effort: 'high' }],
+    });
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: { sendMessage: jest.fn() } as unknown as import('./claude').ClaudeClient,
+      planner: {
+        sendMessage: jest.fn().mockResolvedValue({ content: plannerResponse }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig({ review_level: 'auto' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    // Round 1: 100% dismiss rate (would trigger downgrade). Round 2 (most recent): 50% keep rate (guard must NOT fire).
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 3 },
+        ],
+      },
+      {
+        round: 2,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 2, findingsDismissed: 2 },
+        ],
+      },
+    ];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      hints,
+    );
+    const secPick = result.plannerResult!.agents!.find(a => a.name === 'Security & Safety');
+    // Most recent round has kept findings — guard must not fire even though round 1 had 100% dismissals.
+    expect(secPick?.effort).toBe('high');
+  });
+
+  it('downgrades based on most recent hint when an older round has non-zero keeps', async () => {
+    const plannerResponse = JSON.stringify({
+      teamSize: 1,
+      reviewerEffort: 'medium',
+      judgeEffort: 'medium',
+      prType: 'feature',
+      agents: [{ name: 'Security & Safety', effort: 'high' }],
+    });
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: { sendMessage: jest.fn() } as unknown as import('./claude').ClaudeClient,
+      planner: {
+        sendMessage: jest.fn().mockResolvedValue({ content: plannerResponse }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig({ review_level: 'auto' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    // Round 1: non-zero keeps (guard would not fire). Round 2 (most recent): 100% dismissals (guard SHOULD fire).
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 2, findingsDismissed: 1 },
+        ],
+      },
+      {
+        round: 2,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 3 },
+        ],
+      },
+    ];
+
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const result = await runReview(
+        clients, config, diff, 'raw diff', 'repo context',
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        hints,
+      );
+      const secPick = result.plannerResult!.agents!.find(a => a.name === 'Security & Safety');
+      // Most recent round dismissed all findings — guard fires based on last hint.
+      expect(secPick?.effort).toBe('low');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('applies effort downgrade per-specialist independently when hints cover multiple specialists', async () => {
+    const plannerResponse = JSON.stringify({
+      teamSize: 3,
+      reviewerEffort: 'medium',
+      judgeEffort: 'medium',
+      prType: 'feature',
+      agents: [
+        { name: 'Security & Safety', effort: 'high' },
+        { name: 'Correctness & Logic', effort: 'high' },
+        { name: 'Architecture & Design', effort: 'high' },
+      ],
+    });
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: { sendMessage: jest.fn() } as unknown as import('./claude').ClaudeClient,
+      planner: {
+        sendMessage: jest.fn().mockResolvedValue({ content: plannerResponse }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig({ review_level: 'auto' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    // Single round hint with three specialists: two should downgrade, one should not.
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Security & Safety', findingsKept: 0, findingsDismissed: 3 },
+          { specialist: 'Correctness & Logic', findingsKept: 1, findingsDismissed: 2 },
+          { specialist: 'Architecture & Design', findingsKept: 0, findingsDismissed: 4 },
+        ],
+      },
+    ];
+
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const result = await runReview(
+        clients, config, diff, 'raw diff', 'repo context',
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        hints,
+      );
+      const secPick = result.plannerResult!.agents!.find(a => a.name === 'Security & Safety');
+      const corPick = result.plannerResult!.agents!.find(a => a.name === 'Correctness & Logic');
+      const archPick = result.plannerResult!.agents!.find(a => a.name === 'Architecture & Design');
+      // 100% dismiss, sample >= 2 -> downgrade
+      expect(secPick?.effort).toBe('low');
+      // Non-zero keeps -> no downgrade
+      expect(corPick?.effort).toBe('high');
+      // 100% dismiss, sample >= 2 -> downgrade
+      expect(archPick?.effort).toBe('low');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
   it('forwards priorRoundHints to the planner prompt', async () => {
     const plannerResponse = JSON.stringify({
       teamSize: 3,

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1898,6 +1898,47 @@ describe('runReview', () => {
     expect(result.agentNames).toContain('Domain Expert');
   });
 
+  it('forwards priorRoundHints to the planner prompt', async () => {
+    const plannerResponse = JSON.stringify({
+      teamSize: 3,
+      reviewerEffort: 'medium',
+      judgeEffort: 'medium',
+      prType: 'feature',
+    });
+    const plannerSpy = jest.fn().mockResolvedValue({ content: plannerResponse });
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn(),
+      } as unknown as import('./claude').ClaudeClient,
+      planner: { sendMessage: plannerSpy } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig({ review_level: 'auto' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Architecture & Design', findingsKept: 3, findingsDismissed: 2 },
+        ],
+      },
+    ];
+
+    await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      hints,
+    );
+
+    const systemPrompt = plannerSpy.mock.calls[0][0] as string;
+    expect(systemPrompt).toContain('Prior Round Outcomes');
+    expect(systemPrompt).toContain('"Architecture & Design" — 3 kept, 2 dismissed');
+  });
+
   it('falls back to selectTeam when planner returns error', async () => {
     const clients: ReviewClients = {
       reviewer: {
@@ -3044,6 +3085,31 @@ describe('runPlanner with agents and language', () => {
     expect(systemPrompt).toContain('"Security & Safety"');
     expect(systemPrompt).toContain('"Domain Expert"');
     expect(systemPrompt).toContain('"agents"');
+  });
+
+  it('forwards prior-round hints into the planner system prompt', async () => {
+    const response = JSON.stringify({
+      teamSize: 3,
+      reviewerEffort: 'low',
+      judgeEffort: 'low',
+      prType: 'chore',
+    });
+    const client = makeClient(response);
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const hints = [
+      {
+        round: 1,
+        specialistOutcomes: [
+          { specialist: 'Testing & Coverage', findingsKept: 0, findingsDismissed: 3 },
+        ],
+      },
+    ];
+
+    await runPlanner(client, diff, undefined, undefined, hints);
+
+    const systemPrompt = (client.sendMessage as jest.Mock).mock.calls[0][0] as string;
+    expect(systemPrompt).toContain('Prior Round Outcomes');
+    expect(systemPrompt).toContain('"Testing & Coverage" — 0 kept, 3 dismissed');
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2849,6 +2849,47 @@ describe('buildPlannerSystemPrompt', () => {
     // (it may appear in the example output but not in the "Decide" section)
     expect(prompt).not.toContain('reviewerEffort:');
   });
+
+  it('renders prior round outcomes when hints are provided', () => {
+    const hints = [
+      {
+        round: 2,
+        specialistOutcomes: [
+          { specialist: 'Testing & Coverage', findingsKept: 0, findingsDismissed: 7 },
+          { specialist: 'Architecture & Design', findingsKept: 3, findingsDismissed: 2 },
+        ],
+      },
+      {
+        round: 3,
+        specialistOutcomes: [
+          { specialist: 'Testing & Coverage', findingsKept: 7, findingsDismissed: 0 },
+        ],
+      },
+    ];
+    const prompt = buildPlannerSystemPrompt([{ name: 'A', focus: 'test focus' }], hints);
+
+    expect(prompt).toContain('Prior Round Outcomes');
+    expect(prompt).toContain('Round 3: "Testing & Coverage" — 7 kept, 0 dismissed');
+    expect(prompt).toContain('Round 2: "Testing & Coverage" — 0 kept, 7 dismissed');
+    expect(prompt).toContain('"Architecture & Design" — 3 kept, 2 dismissed');
+
+    // Most recent round first.
+    const r3 = prompt.indexOf('Round 3:');
+    const r2 = prompt.indexOf('Round 2:');
+    expect(r3).toBeGreaterThan(-1);
+    expect(r2).toBeGreaterThan(r3);
+
+    // Outcomes block appears before the "Decide:" section.
+    expect(r3).toBeLessThan(prompt.indexOf('Decide:'));
+  });
+
+  it('produces identical output to no-hint call when hints array is empty', () => {
+    const agents = [{ name: 'A', focus: 'test focus' }];
+    const baseline = buildPlannerSystemPrompt(agents);
+    const withEmptyHints = buildPlannerSystemPrompt(agents, []);
+    expect(withEmptyHints).toBe(baseline);
+    expect(withEmptyHints).not.toContain('Prior Round Outcomes');
+  });
 });
 
 describe('runPlanner with agents and language', () => {

--- a/src/review.ts
+++ b/src/review.ts
@@ -311,12 +311,34 @@ export function buildPlannerHints(rounds: HandoverRound[] | undefined): PlannerR
   return hints;
 }
 
-export function buildPlannerSystemPrompt(agents: Array<{ name: string; focus: string }>): string {
+function renderPlannerHints(hints: PlannerRoundHint[]): string {
+  // Most recent round first — helps the model weight recent signal strongest.
+  const ordered = [...hints].sort((a, b) => b.round - a.round);
+  const lines = ordered.map(hint => {
+    const entries = hint.specialistOutcomes
+      .map(o => `"${o.specialist}" — ${o.findingsKept} kept, ${o.findingsDismissed} dismissed`)
+      .join(' | ');
+    return `Round ${hint.round}: ${entries}`;
+  });
+  return `## Prior Round Outcomes (most recent first)
+
+${lines.join('\n')}
+
+Specialists whose recent findings were entirely dismissed warrant lower priority. Specialists with strong keep rates warrant full weight. Use this to calibrate agent selection and effort levels.
+
+`;
+}
+
+export function buildPlannerSystemPrompt(
+  agents: Array<{ name: string; focus: string }>,
+  hints?: PlannerRoundHint[],
+): string {
   const agentList = agents.map(a => `  - "${a.name}" — ${a.focus}`).join('\n');
+  const hintsBlock = hints && hints.length > 0 ? renderPlannerHints(hints) : '';
 
   return `You are a code review planning assistant. Analyze this PR and decide how to review it.
 
-Decide:
+${hintsBlock}Decide:
 1. teamSize: 1-7 reviewer agents.
    Default to 3. Use 2 when the change is small but non-trivial. Scale to 4-5 for broader changes. 7 is rare — reserve it for changes where missing a specialist would be dangerous. Diff size alone doesn't determine team size — a 50-line auth change needs more eyes than a 500-line rename.
    - 1: changes where a bug is unrealistic (docs, comments, renames)

--- a/src/review.ts
+++ b/src/review.ts
@@ -426,6 +426,7 @@ export async function runPlanner(
   diff: ParsedDiff,
   prContext?: PrContext,
   customReviewers?: ReviewerAgent[],
+  priorRoundHints?: PlannerRoundHint[],
 ): Promise<PlannerResult | null> {
   let timeoutId: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -435,7 +436,7 @@ export async function runPlanner(
   try {
     const pool = buildAgentPool(customReviewers);
     const availableNames = new Set(pool.map(a => a.name));
-    const systemPrompt = buildPlannerSystemPrompt(pool);
+    const systemPrompt = buildPlannerSystemPrompt(pool, priorRoundHints);
 
     const userMessage = buildPlannerSummary(diff, prContext);
     const response = await Promise.race([
@@ -512,6 +513,7 @@ export async function runReview(
   openThreads?: Array<{ threadId: string; title: string; file: string; line: number; severity: string }>,
   previousFindings?: PreviousFinding[],
   priorRounds?: HandoverRound[],
+  priorRoundHints?: PlannerRoundHint[],
 ): Promise<ReviewResult> {
   let team: TeamRoster;
   let plannerResult: PlannerResult | null = null;
@@ -521,7 +523,7 @@ export async function runReview(
       onProgress({ phase: 'planning', rawFindingCount: 0 });
     }
     const plannerStart = Date.now();
-    plannerResult = await runPlanner(clients.planner, diff, prContext, config.reviewers);
+    plannerResult = await runPlanner(clients.planner, diff, prContext, config.reviewers, priorRoundHints);
     const plannerDurationMs = Date.now() - plannerStart;
     if (plannerResult) {
       team = selectTeam(diff, config, config.reviewers, plannerResult.teamSize, plannerResult.agents);

--- a/src/review.ts
+++ b/src/review.ts
@@ -498,6 +498,34 @@ function heuristicFallback(diff: ParsedDiff, config: ReviewConfig): TeamRoster {
   return team;
 }
 
+/** Minimum dismissed-finding sample size required before a 100% dismiss rate triggers an effort downgrade. */
+const EFFORT_DOWNGRADE_MIN_SAMPLE = 2;
+
+/**
+ * Safety net for when the planner LLM keeps an agent at \`high\` effort despite
+ * the most recent round dismissing all of that specialist's findings. Clamps
+ * such picks to \`low\` and logs the change. Mutates picks in place for
+ * simplicity; the planner result object is not shared across reviews.
+ */
+function applyEffortDowngrade(picks: AgentPick[], hints: PlannerRoundHint[]): void {
+  if (hints.length === 0) return;
+
+  const lastHint = hints[hints.length - 1];
+  const byName = new Map(lastHint.specialistOutcomes.map(o => [o.specialist, o]));
+
+  for (const pick of picks) {
+    if (pick.effort !== 'high') continue;
+    const outcome = byName.get(pick.name);
+    if (!outcome) continue;
+    if (outcome.findingsDismissed < EFFORT_DOWNGRADE_MIN_SAMPLE) continue;
+    if (outcome.findingsKept !== 0) continue;
+    core.info(
+      `Downgrading "${pick.name}" effort from high to low — round ${lastHint.round} dismissed all ${outcome.findingsDismissed} findings from this specialist`,
+    );
+    pick.effort = 'low';
+  }
+}
+
 export async function runReview(
   clients: ReviewClients,
   config: ReviewConfig,
@@ -526,6 +554,9 @@ export async function runReview(
     plannerResult = await runPlanner(clients.planner, diff, prContext, config.reviewers, priorRoundHints);
     const plannerDurationMs = Date.now() - plannerStart;
     if (plannerResult) {
+      if (plannerResult.agents && priorRoundHints && priorRoundHints.length > 0) {
+        applyEffortDowngrade(plannerResult.agents, priorRoundHints);
+      }
       team = selectTeam(diff, config, config.reviewers, plannerResult.teamSize, plannerResult.agents);
       core.info(`Planner: ${plannerResult.teamSize} agents, reviewer: ${plannerResult.reviewerEffort}, judge: ${plannerResult.judgeEffort} (${plannerResult.prType})`);
       if (plannerResult.teamSize === 1) {

--- a/src/review.ts
+++ b/src/review.ts
@@ -5,7 +5,7 @@ import { runJudgeAgent, JudgeInput, ResolveThread } from './judge';
 import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
 import { LinkedIssue, titleToSlug } from './github';
 import { deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
-import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, EffortLevel, AgentPick, MAX_AGENT_RETRIES } from './types';
+import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, SpecialistOutcome, EffortLevel, AgentPick, MAX_AGENT_RETRIES } from './types';
 import { extractJSON } from './json';
 
 const DISMISSED_LINE_TOLERANCE = 5;
@@ -274,6 +274,41 @@ function buildPlannerSummary(diff: ParsedDiff, prContext?: PrContext): string {
   }
 
   return summary.slice(0, 2000);
+}
+
+/** Number of most recent rounds consumed when building planner hints. */
+const PLANNER_HINTS_ROUND_WINDOW = 2;
+
+/**
+ * Summarize recent rounds from the per-PR handover as per-specialist outcome
+ * counts for the planner. Groups each round's findings by `specialist`,
+ * skipping entries that predate the `specialist` field. Returns an empty
+ * array when no round carries specialist attribution.
+ */
+export function buildPlannerHints(rounds: HandoverRound[] | undefined): PlannerRoundHint[] {
+  if (!rounds || rounds.length === 0) return [];
+
+  const recent = rounds.slice(-PLANNER_HINTS_ROUND_WINDOW);
+  const hints: PlannerRoundHint[] = [];
+
+  for (const round of recent) {
+    const bySpecialist = new Map<string, SpecialistOutcome>();
+    for (const f of round.findings) {
+      if (!f.specialist) continue;
+      let entry = bySpecialist.get(f.specialist);
+      if (!entry) {
+        entry = { specialist: f.specialist, findingsKept: 0, findingsDismissed: 0 };
+        bySpecialist.set(f.specialist, entry);
+      }
+      if (f.authorReply === 'agree') entry.findingsDismissed++;
+      else entry.findingsKept++;
+    }
+
+    if (bySpecialist.size === 0) continue;
+    hints.push({ round: round.round, specialistOutcomes: Array.from(bySpecialist.values()) });
+  }
+
+  return hints;
 }
 
 export function buildPlannerSystemPrompt(agents: Array<{ name: string; focus: string }>): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface HandoverFinding {
   title: string;
   authorReply: AuthorReplyClass;
   threadId?: string;
+  /** Originating specialist name (from `Finding.reviewers[0]`). Absent in handover files written before this field was added. */
+  specialist?: string;
 }
 
 /** A single completed review round recorded in the per-PR handover. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,21 @@ export interface PlannerResult {
   context?: string;
 }
 
+/** Per-specialist outcome aggregate for a single prior round. */
+export interface SpecialistOutcome {
+  specialist: string;
+  /** Count of findings the author did not acknowledge as fixed (`authorReply !== 'agree'`). */
+  findingsKept: number;
+  /** Count of findings the author agreed with and acted on (`authorReply === 'agree'`). */
+  findingsDismissed: number;
+}
+
+/** Compact summary of a prior review round fed back to the planner for budget allocation. */
+export interface PlannerRoundHint {
+  round: number;
+  specialistOutcomes: SpecialistOutcome[];
+}
+
 export type ReviewLevel = 'auto' | 'small' | 'medium' | 'large';
 
 export interface ReviewThresholds {


### PR DESCRIPTION
## Summary

Closes [#551](https://github.com/manki-review/manki/issues/551). Part of [#545](https://github.com/manki-review/manki/issues/545).

Feeds per-specialist outcomes from the last two review rounds back into the planner so it can calibrate agent selection and effort levels on re-reviews. A finding counts as "dismissed" when the author agreed with it and acted on it (`authorReply === 'agree'`); all other replies count as "kept".

### What changed

- `HandoverFinding.specialist?: string` — carries `Finding.reviewers[0]` into per-round handover state, populated in `appendHandoverRound`. Optional for backward compatibility.
- New types `SpecialistOutcome` and `PlannerRoundHint` in `src/types.ts`.
- `buildPlannerHints(rounds)` in `src/review.ts` — groups the last two rounds' findings by specialist, skipping legacy entries without `specialist`.
- `buildPlannerSystemPrompt(agents, hints?)` — when hints are non-empty, prepends a compact "Prior Round Outcomes (most recent first)" block ordered newest round first.
- `runPlanner` and `runReview` gain an optional trailing `priorRoundHints` parameter. `runReview` signature order: `(..., priorRounds, priorRoundHints)`.
- Deterministic effort-downgrade guard in `runReview` — if the most recent round's hint shows a specialist with `findingsDismissed >= 2`, `findingsKept === 0`, and the planner kept it at `'high'` effort, the pick is clamped to `'low'` and logged via `core.info`.
- `runFullReview` wires it up: after loading the handover, it computes `buildPlannerHints(handover?.rounds)` and passes it to `runReview`.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 1217 tests, 14 suites, all pass
- [x] `npm run build`
- [x] `buildPlannerHints` covers: empty/undefined, per-specialist split, legacy entries skipped, window trimmed to last 2, disagree/partial/none all count as kept
- [x] `buildPlannerSystemPrompt` covers: outcomes block rendered when hints non-empty, identical to no-hint call when hints empty, block precedes the `Decide:` section, most-recent-round-first ordering
- [x] `runPlanner` hints propagation verified via `sendMessage` system-prompt assertion
- [x] `runReview` hint-clamp test: 100% dismiss rate with sample 3 clamps `'high'` to `'low'`; below threshold does not fire
- [x] `runReview` forwards `priorRoundHints` into the planner prompt
- [x] `runFullReview` test verifies `buildPlannerHints` output is passed through from loaded handover; memory-disabled path yields `[]`
- [x] `appendHandoverRound` populates `specialist` from `reviewers[0]`; omits the field when the finding has no reviewers