### PR TITLE
feat: reviewer factual provenance note for prior-suggestion diff regions

### DIFF
--- a/src/judge.ts
+++ b/src/judge.ts
@@ -34,8 +34,8 @@ const OWN_PROPOSAL_MIN_MATCH_LENGTH = 30;
 
 /**
  * Maximum normalized `suggestedFix` length allowed in a provenance scan.
- * Legacy handover files may contain unsanitized oversized fixes; skipping
- * entries above this cap prevents unbounded substring scans.
+ * Legacy handover files may contain unsanitized oversized fixes.
+ * Skipping entries above this cap prevents unbounded substring scans.
  */
 const MAX_PROVENANCE_FIX_LEN = 4000;
 

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -216,6 +216,7 @@ export interface JudgeInput {
   openThreads?: Array<{ threadId: string; title: string; file: string; line: number; severity: string }>;
   priorRounds?: HandoverRound[];
   effort?: 'low' | 'medium' | 'high';
+  provenanceMap?: ProvenanceEntry[];
 }
 
 export interface JudgedFinding {
@@ -715,7 +716,7 @@ export async function runJudgeAgent(
   crossRoundDemoted?: number;
 }> {
   const { findings, diff, rawDiff, memory, prContext, linkedIssues, agentCount, isFollowUp, openThreads, priorRounds } = input;
-  const provenanceMap = rawDiff ? computeProvenanceMap(priorRounds, rawDiff) : [];
+  const provenanceMap = input.provenanceMap ?? (rawDiff ? computeProvenanceMap(priorRounds, rawDiff) : []);
 
   const hasOpenThreads = (openThreads?.length ?? 0) > 0;
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -620,7 +620,7 @@ export interface HandoverPreviousFinding {
  * Prior rounds' findings are backfilled with fresh `authorReply` classifications
  * drawn from the latest recap state, matched by thread ID.
  *
- * Pass the already-loaded `handover` to avoid a redundant fetch; if omitted,
+ * Pass the already-loaded `handover` to avoid a redundant fetch. If omitted,
  * the function loads it from the memory repo.
  */
 export async function appendHandoverRound(

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2872,13 +2872,50 @@ describe('runReview', () => {
       expect(userMessage).toContain('// [manki: added in round 2]');
     }
 
-    // computeProvenanceMap must be called exactly once per review cycle
+    // computeProvenanceMap must be called exactly once per review cycle, with the
+    // priorRounds and rawDiff supplied to runReview (priorRounds is undefined here)
     expect(mockedComputeProvenanceMap).toHaveBeenCalledTimes(1);
+    expect(mockedComputeProvenanceMap).toHaveBeenCalledWith(undefined, 'raw diff');
 
     // Judge should receive the same computed map through JudgeInput, not recompute it
     expect(mockedRunJudgeAgent).toHaveBeenCalledTimes(1);
     const judgeInput = mockedRunJudgeAgent.mock.calls[0][2];
     expect(judgeInput.provenanceMap).toEqual(provenance);
+  });
+
+  it('does not inject annotations or explanation when provenance entries reference files absent from fileContents', async () => {
+    const mockedComputeProvenanceMap = jest.mocked(computeProvenanceMap);
+    // Provenance entry references a file that is NOT among the loaded fileContents.
+    const provenance: ProvenanceEntry[] = [{
+      file: 'src/other.ts',
+      lineStart: 2,
+      lineEnd: 3,
+      originatingRound: 2,
+      originatingTitle: 'Prior finding',
+    }];
+    mockedComputeProvenanceMap.mockReturnValueOnce(provenance);
+
+    const reviewerSendMessage = jest.fn().mockResolvedValue({ content: '[]' });
+    const clients: ReviewClients = {
+      reviewer: { sendMessage: reviewerSendMessage } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '{"summary":"ok","findings":[]}' }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const fileContents = new Map([
+      ['src/foo.ts', 'const a = 1;\nconst b = 2;\nconst c = 3;'],
+    ]);
+
+    await runReview(clients, config, diff, 'raw diff', 'repo context', undefined, fileContents);
+
+    expect(reviewerSendMessage).toHaveBeenCalled();
+    for (const call of reviewerSendMessage.mock.calls) {
+      const userMessage = call[1] as string;
+      expect(userMessage).not.toContain('[manki:');
+      expect(userMessage).not.toContain('factual note');
+    }
   });
 
   it('does not inject annotations or explanation when provenance is empty', async () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2871,6 +2871,33 @@ describe('runReview', () => {
     const judgeInput = mockedRunJudgeAgent.mock.calls[0][2];
     expect(judgeInput.provenanceMap).toEqual(provenance);
   });
+
+  it('does not inject annotations or explanation when provenance is empty', async () => {
+    const mockedComputeProvenanceMap = jest.mocked(computeProvenanceMap);
+    mockedComputeProvenanceMap.mockReturnValueOnce([]);
+
+    const reviewerSendMessage = jest.fn().mockResolvedValue({ content: '[]' });
+    const clients: ReviewClients = {
+      reviewer: { sendMessage: reviewerSendMessage } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '{"summary":"ok","findings":[]}' }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const fileContents = new Map([
+      ['src/foo.ts', 'const a = 1;\nconst b = 2;\nconst c = 3;'],
+    ]);
+
+    await runReview(clients, config, diff, 'raw diff', 'repo context', undefined, fileContents);
+
+    expect(reviewerSendMessage).toHaveBeenCalled();
+    for (const call of reviewerSendMessage.mock.calls) {
+      const userMessage = call[1] as string;
+      expect(userMessage).not.toContain('[manki:');
+      expect(userMessage).not.toContain('factual note');
+    }
+  });
 });
 
 describe('runPlanner', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -24,7 +24,7 @@ import {
 } from './review';
 import * as core from '@actions/core';
 import { LinkedIssue, titleToSlug } from './github';
-import { Finding, HandoverFinding, HandoverRound, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, MAX_AGENT_RETRIES } from './types';
+import { Finding, HandoverFinding, HandoverRound, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
 import { runJudgeAgent } from './judge';
 import { applySuppressions } from './memory';
 
@@ -889,6 +889,100 @@ describe('buildReviewerUserMessage with linked issues', () => {
   });
 });
 
+describe('buildReviewerUserMessage with provenance map', () => {
+  const makeEntry = (overrides: Partial<ProvenanceEntry> = {}): ProvenanceEntry => ({
+    file: 'src/foo.ts',
+    lineStart: 2,
+    lineEnd: 3,
+    originatingRound: 1,
+    originatingTitle: 'Prior finding',
+    ...overrides,
+  });
+
+  it('annotates matched file regions with a factual round note', () => {
+    const fileContents = new Map([
+      ['src/foo.ts', 'const a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;'],
+    ]);
+    const provenance = [makeEntry({ lineStart: 2, lineEnd: 3, originatingRound: 2 })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    expect(message).toContain('// [manki: added in round 2]');
+    const annotationIdx = message.indexOf('// [manki: added in round 2]');
+    const bIdx = message.indexOf('const b = 2;');
+    expect(annotationIdx).toBeLessThan(bIdx);
+    expect(message).toContain('const a = 1;');
+    expect(message).toContain('const d = 4;');
+  });
+
+  it('does not inject finding text, severity, or resolution', () => {
+    const fileContents = new Map([['src/foo.ts', 'line1\nline2\nline3']]);
+    const provenance = [makeEntry({
+      lineStart: 2,
+      lineEnd: 2,
+      originatingRound: 3,
+      originatingTitle: 'Missing null check could crash the app',
+    })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    expect(message).toContain('// [manki: added in round 3]');
+    expect(message).not.toContain('Missing null check');
+    expect(message).not.toContain('required');
+    expect(message).not.toContain('suggestion');
+    expect(message).not.toContain('agree');
+    expect(message).not.toContain('disagree');
+  });
+
+  it('skips annotation when provenance map is empty', () => {
+    const fileContents = new Map([['src/foo.ts', 'const a = 1;\nconst b = 2;']]);
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, []);
+    expect(message).not.toContain('// [manki:');
+    expect(message).not.toContain('added by manki');
+  });
+
+  it('skips annotation when provenance map is undefined', () => {
+    const fileContents = new Map([['src/foo.ts', 'const a = 1;\nconst b = 2;']]);
+    const message = buildReviewerUserMessage('diff', '', fileContents);
+    expect(message).not.toContain('// [manki:');
+  });
+
+  it('only annotates the matching file', () => {
+    const fileContents = new Map([
+      ['src/foo.ts', 'foo1\nfoo2\nfoo3'],
+      ['src/bar.ts', 'bar1\nbar2\nbar3'],
+    ]);
+    const provenance = [makeEntry({ file: 'src/foo.ts', lineStart: 2, lineEnd: 2, originatingRound: 1 })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    const fooSection = message.slice(message.indexOf('### File: src/foo.ts'), message.indexOf('### File: src/bar.ts'));
+    const barSection = message.slice(message.indexOf('### File: src/bar.ts'));
+    expect(fooSection).toContain('// [manki: added in round 1]');
+    expect(barSection).not.toContain('// [manki:');
+  });
+
+  it('handles multiple annotations in one file in original order', () => {
+    const fileContents = new Map([
+      ['src/foo.ts', 'a\nb\nc\nd\ne\nf'],
+    ]);
+    const provenance = [
+      makeEntry({ lineStart: 2, lineEnd: 2, originatingRound: 1 }),
+      makeEntry({ lineStart: 5, lineEnd: 5, originatingRound: 2 }),
+    ];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    const firstIdx = message.indexOf('// [manki: added in round 1]');
+    const secondIdx = message.indexOf('// [manki: added in round 2]');
+    const lineBIdx = message.indexOf('\nb\n');
+    const lineEIdx = message.indexOf('\ne\n');
+    expect(firstIdx).toBeLessThan(lineBIdx);
+    expect(lineBIdx).toBeLessThan(secondIdx);
+    expect(secondIdx).toBeLessThan(lineEIdx);
+  });
+
+  it('includes a short explanation of the annotation when provenance is present', () => {
+    const fileContents = new Map([['src/foo.ts', 'a\nb']]);
+    const provenance = [makeEntry({ lineStart: 2, lineEnd: 2 })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    expect(message).toMatch(/\[manki: added in round N\]/);
+    expect(message).toContain('factual note');
+  });
+});
+
 describe('shuffleDiffFiles', () => {
   const makeFiles = (count: number): DiffFile[] =>
     Array.from({ length: count }, (_, i) => ({
@@ -1097,6 +1191,7 @@ describe('selectTeam maintainability scoring', () => {
 jest.mock('./judge', () => ({
   runJudgeAgent: jest.fn(),
   JudgeInput: {},
+  computeProvenanceMap: jest.fn().mockReturnValue([]),
 }));
 
 jest.mock('./memory', () => ({

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -984,6 +984,21 @@ describe('buildReviewerUserMessage with provenance map', () => {
     expect(message).toContain('[manki: added in round N]');
     expect(message).toContain('factual note');
   });
+
+  it('skips annotation when lineStart is out of bounds', () => {
+    const fileContents = new Map([['src/foo.ts', 'line1\nline2']]);
+    const provenance = [makeEntry({ lineStart: 10, lineEnd: 10, originatingRound: 1 })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    expect(message).not.toContain('[manki: added in round 1]');
+  });
+
+  it('uses # comment prefix for Python files', () => {
+    const fileContents = new Map([['src/script.py', 'x = 1\ny = 2\nz = 3']]);
+    const provenance = [makeEntry({ file: 'src/script.py', lineStart: 2, lineEnd: 2, originatingRound: 1 })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    expect(message).toContain('# [manki: added in round 1]');
+    expect(message).not.toContain('// [manki: added in round 1]');
+  });
 });
 
 describe('shuffleDiffFiles', () => {
@@ -2847,6 +2862,9 @@ describe('runReview', () => {
       const userMessage = call[1] as string;
       expect(userMessage).toContain('// [manki: added in round 2]');
     }
+
+    // computeProvenanceMap must be called exactly once per review cycle
+    expect(mockedComputeProvenanceMap).toHaveBeenCalledTimes(1);
 
     // Judge should receive the same computed map through JudgeInput, not recompute it
     expect(mockedRunJudgeAgent).toHaveBeenCalledTimes(1);

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -976,9 +976,12 @@ describe('buildReviewerUserMessage with provenance map', () => {
 
   it('includes a short explanation of the annotation when provenance is present', () => {
     const fileContents = new Map([['src/foo.ts', 'a\nb']]);
-    const provenance = [makeEntry({ lineStart: 2, lineEnd: 2 })];
+    const provenance = [makeEntry({ lineStart: 2, lineEnd: 2, originatingRound: 1 })];
     const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
-    expect(message).toMatch(/\[manki: added in round N\]/);
+    // Annotation uses the numeric round
+    expect(message).toContain('// [manki: added in round 1]');
+    // Explanation text uses the literal `N` placeholder and the `factual note` phrase
+    expect(message).toContain('[manki: added in round N]');
     expect(message).toContain('factual note');
   });
 });

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -999,6 +999,15 @@ describe('buildReviewerUserMessage with provenance map', () => {
     expect(message).toContain('# [manki: added in round 1]');
     expect(message).not.toContain('// [manki: added in round 1]');
   });
+
+  it('skips annotation and explanation for HTML files with no comment syntax', () => {
+    const fileContents = new Map([['src/template.html', '<div>\n<span>hi</span>\n</div>']]);
+    const provenance = [makeEntry({ file: 'src/template.html', lineStart: 2, lineEnd: 2, originatingRound: 1 })];
+    const message = buildReviewerUserMessage('diff', '', fileContents, undefined, undefined, undefined, provenance);
+    expect(message).not.toContain('[manki:');
+    expect(message).not.toContain('factual note');
+    expect(message).toContain('<span>hi</span>');
+  });
 });
 
 describe('shuffleDiffFiles', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -25,7 +25,7 @@ import {
 import * as core from '@actions/core';
 import { LinkedIssue, titleToSlug } from './github';
 import { Finding, HandoverFinding, HandoverRound, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
-import { runJudgeAgent } from './judge';
+import { runJudgeAgent, computeProvenanceMap } from './judge';
 import { applySuppressions } from './memory';
 
 const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
@@ -2813,6 +2813,45 @@ describe('runReview', () => {
     // Other agents produced no findings — only the retry contributed
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0].title).toBe('SQL injection');
+  });
+
+  it('threads a non-empty provenance map to reviewer agents and judge', async () => {
+    const mockedComputeProvenanceMap = jest.mocked(computeProvenanceMap);
+    const provenance: ProvenanceEntry[] = [{
+      file: 'src/foo.ts',
+      lineStart: 2,
+      lineEnd: 3,
+      originatingRound: 2,
+      originatingTitle: 'Prior finding',
+    }];
+    mockedComputeProvenanceMap.mockReturnValueOnce(provenance);
+
+    const reviewerSendMessage = jest.fn().mockResolvedValue({ content: '[]' });
+    const clients: ReviewClients = {
+      reviewer: { sendMessage: reviewerSendMessage } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '{"summary":"ok","findings":[]}' }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const fileContents = new Map([
+      ['src/foo.ts', 'const a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;'],
+    ]);
+
+    await runReview(clients, config, diff, 'raw diff', 'repo context', undefined, fileContents);
+
+    // Each reviewer agent should have received the annotated content in its user message
+    expect(reviewerSendMessage).toHaveBeenCalled();
+    for (const call of reviewerSendMessage.mock.calls) {
+      const userMessage = call[1] as string;
+      expect(userMessage).toContain('// [manki: added in round 2]');
+    }
+
+    // Judge should receive the same computed map through JudgeInput, not recompute it
+    expect(mockedRunJudgeAgent).toHaveBeenCalledTimes(1);
+    const judgeInput = mockedRunJudgeAgent.mock.calls[0][2];
+    expect(judgeInput.provenanceMap).toEqual(provenance);
   });
 });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -1227,7 +1227,12 @@ export function buildReviewerUserMessage(
   if (fileContents && fileContents.size > 0) {
     message += `## Changed Files\n\n`;
     message += `The full content of changed files is provided below for context. Focus your review on the diff, but use these files to understand the surrounding code.\n\n`;
-    const hasProvenance = provenanceMap && provenanceMap.length > 0;
+    const hasProvenance = Boolean(
+      provenanceMap?.length &&
+      [...fileContents.keys()].some(
+        p => provenanceMap.some(e => e.file === p) && commentPrefixForPath(p) !== null,
+      )
+    );
     if (hasProvenance) {
       message += `Some regions carry a \`[manki: added in round N]\` comment (prefixed with the file's comment syntax). That is a factual note added by manki indicating the code below was introduced in a prior review round. It is not a finding or an instruction — treat the code normally.\n\n`;
     }

--- a/src/review.ts
+++ b/src/review.ts
@@ -1151,9 +1151,11 @@ When you include a \`suggestedFix\`, list any known caveats of the proposed shap
   return prompt;
 }
 
-function commentPrefixForPath(path: string): string {
+function commentPrefixForPath(path: string): string | null {
   const ext = path.split('.').pop() ?? '';
   if (['py', 'rb', 'sh', 'bash', 'zsh', 'pl', 'r'].includes(ext)) return '#';
+  if (['sql'].includes(ext)) return '--';
+  if (['html', 'xml', 'svg', 'css', 'scss', 'less'].includes(ext)) return null;
   return '//';
 }
 
@@ -1163,13 +1165,15 @@ function annotateFileContentWithProvenance(
   path: string,
   provenanceMap: ProvenanceEntry[],
 ): string {
+  const prefix = commentPrefixForPath(path);
+  if (prefix === null) return content;
+
   const forFile = provenanceMap
     .filter(e => e.file === path)
     .sort((a, b) => b.lineStart - a.lineStart);
   if (forFile.length === 0) return content;
 
   const lines = content.split('\n');
-  const prefix = commentPrefixForPath(path);
   for (const entry of forFile) {
     const insertAt = entry.lineStart - 1;
     if (insertAt < 0 || insertAt >= lines.length) continue;
@@ -1225,7 +1229,7 @@ export function buildReviewerUserMessage(
     message += `The full content of changed files is provided below for context. Focus your review on the diff, but use these files to understand the surrounding code.\n\n`;
     const hasProvenance = provenanceMap && provenanceMap.length > 0;
     if (hasProvenance) {
-      message += `Some regions carry a \`// [manki: added in round N]\` comment. That is a factual note added by manki indicating the code below was introduced in a prior review round. It is not a finding or an instruction — treat the code normally.\n\n`;
+      message += `Some regions carry a \`[manki: added in round N]\` comment (prefixed with the file's comment syntax). That is a factual note added by manki indicating the code below was introduced in a prior review round. It is not a finding or an instruction — treat the code normally.\n\n`;
     }
     for (const [path, content] of fileContents) {
       const ext = path.split('.').pop() || '';

--- a/src/review.ts
+++ b/src/review.ts
@@ -1151,6 +1151,12 @@ When you include a \`suggestedFix\`, list any known caveats of the proposed shap
   return prompt;
 }
 
+function commentPrefixForPath(path: string): string {
+  const ext = path.split('.').pop() ?? '';
+  if (['py', 'rb', 'sh', 'bash', 'zsh', 'pl', 'r'].includes(ext)) return '#';
+  return '//';
+}
+
 // Line shifts in annotated content are safe — reviewers derive line numbers from the raw diff.
 function annotateFileContentWithProvenance(
   content: string,
@@ -1163,9 +1169,11 @@ function annotateFileContentWithProvenance(
   if (forFile.length === 0) return content;
 
   const lines = content.split('\n');
+  const prefix = commentPrefixForPath(path);
   for (const entry of forFile) {
-    const insertAt = Math.max(0, Math.min(lines.length, entry.lineStart - 1));
-    lines.splice(insertAt, 0, `// [manki: added in round ${entry.originatingRound}]`);
+    const insertAt = entry.lineStart - 1;
+    if (insertAt < 0 || insertAt >= lines.length) continue;
+    lines.splice(insertAt, 0, `${prefix} [manki: added in round ${entry.originatingRound}]`);
   }
   return lines.join('\n');
 }

--- a/src/review.ts
+++ b/src/review.ts
@@ -981,6 +981,7 @@ export async function runReview(
       openThreads,
       priorRounds,
       effort: judgeEffort as 'low' | 'medium' | 'high',
+      provenanceMap,
     };
     const judgeResult = await runJudgeAgent(clients.judge, config, judgeInput);
     judgeSummary = judgeResult.summary;

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,11 +1,11 @@
 import * as core from '@actions/core';
 
 import { ClaudeClient } from './claude';
-import { runJudgeAgent, JudgeInput, ResolveThread } from './judge';
+import { runJudgeAgent, JudgeInput, ResolveThread, computeProvenanceMap } from './judge';
 import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
 import { LinkedIssue, titleToSlug } from './github';
 import { deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
-import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, SpecialistOutcome, EffortLevel, AgentPick, MAX_AGENT_RETRIES } from './types';
+import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, SpecialistOutcome, EffortLevel, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
 import { extractJSON } from './json';
 
 const DISMISSED_LINE_TOLERANCE = 5;
@@ -543,6 +543,7 @@ export async function runReview(
   priorRounds?: HandoverRound[],
 ): Promise<ReviewResult> {
   const priorRoundHints = buildPlannerHints(priorRounds);
+  const provenanceMap = computeProvenanceMap(priorRounds, rawDiff);
   let team: TeamRoster;
   let plannerResult: PlannerResult | null = null;
 
@@ -602,7 +603,7 @@ export async function runReview(
         Array.from({ length: passes }, () => {
           const shuffledDiff = shuffleDiffFiles(diff);
           const shuffledRawDiff = rebuildRawDiff(shuffledDiff);
-          return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, agentEffort, plannerResult?.language, plannerResult?.context);
+          return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, agentEffort, plannerResult?.language, plannerResult?.context, provenanceMap);
         })
       );
 
@@ -692,7 +693,7 @@ export async function runReview(
             const shuffledDiff = shuffleDiffFiles(diff);
             const shuffledRawDiff = rebuildRawDiff(shuffledDiff);
             const retryEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-            return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, retryEffort, plannerResult?.language, plannerResult?.context);
+            return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, retryEffort, plannerResult?.language, plannerResult?.context, provenanceMap);
           })
         );
 
@@ -754,7 +755,7 @@ export async function runReview(
     const agentPromises = team.agents.map(agent => {
       const startTime = Date.now();
       const agentEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-      return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, agentEffort, plannerResult?.language, plannerResult?.context)
+      return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, agentEffort, plannerResult?.language, plannerResult?.context, provenanceMap)
         .then(agentResult => {
           completedCount++;
           agentResponseLengths.set(agent.name, agentResult.responseLength);
@@ -835,7 +836,7 @@ export async function runReview(
       const retryPromises = agentsToRetry.map(agent => {
         const startTime = Date.now();
         const retryEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-        return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, retryEffort, plannerResult?.language, plannerResult?.context)
+        return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, retryEffort, plannerResult?.language, plannerResult?.context, provenanceMap)
           .then(agentResult => ({ agent, agentResult, durationMs: Date.now() - startTime }))
           .catch(() => ({ agent, agentResult: null as AgentResult | null, durationMs: Date.now() - startTime }));
       });
@@ -1060,9 +1061,10 @@ async function runReviewerAgent(
   effort?: EffortLevel,
   language?: string,
   context?: string,
+  provenanceMap?: ProvenanceEntry[],
 ): Promise<AgentResult> {
   const systemPrompt = buildReviewerSystemPrompt(reviewer, config, language, context);
-  const userMessage = buildReviewerUserMessage(rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues);
+  const userMessage = buildReviewerUserMessage(rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, provenanceMap);
 
   const options = effort ? { effort } : undefined;
   const response = await client.sendMessage(systemPrompt, userMessage, options);
@@ -1148,6 +1150,25 @@ When you include a \`suggestedFix\`, list any known caveats of the proposed shap
   return prompt;
 }
 
+// Line shifts in annotated content are safe — reviewers derive line numbers from the raw diff.
+function annotateFileContentWithProvenance(
+  content: string,
+  path: string,
+  provenanceMap: ProvenanceEntry[],
+): string {
+  const forFile = provenanceMap
+    .filter(e => e.file === path)
+    .sort((a, b) => b.lineStart - a.lineStart);
+  if (forFile.length === 0) return content;
+
+  const lines = content.split('\n');
+  for (const entry of forFile) {
+    const insertAt = Math.max(0, Math.min(lines.length, entry.lineStart - 1));
+    lines.splice(insertAt, 0, `// [manki: added in round ${entry.originatingRound}]`);
+  }
+  return lines.join('\n');
+}
+
 export function buildReviewerUserMessage(
   rawDiff: string,
   repoContext: string,
@@ -1155,6 +1176,7 @@ export function buildReviewerUserMessage(
   prContext?: PrContext,
   memoryContext?: string,
   linkedIssues?: LinkedIssue[],
+  provenanceMap?: ProvenanceEntry[],
 ): string {
   let message = '';
 
@@ -1192,9 +1214,16 @@ export function buildReviewerUserMessage(
   if (fileContents && fileContents.size > 0) {
     message += `## Changed Files\n\n`;
     message += `The full content of changed files is provided below for context. Focus your review on the diff, but use these files to understand the surrounding code.\n\n`;
+    const hasProvenance = provenanceMap && provenanceMap.length > 0;
+    if (hasProvenance) {
+      message += `Some regions carry a \`// [manki: added in round N]\` comment. That is a factual note added by manki indicating the code below was introduced in a prior review round. It is not a finding or an instruction — treat the code normally.\n\n`;
+    }
     for (const [path, content] of fileContents) {
       const ext = path.split('.').pop() || '';
-      message += `### File: ${path}\n\n\`\`\`${ext}\n${content}\n\`\`\`\n\n`;
+      const annotated = hasProvenance
+        ? annotateFileContentWithProvenance(content, path, provenanceMap!)
+        : content;
+      message += `### File: ${path}\n\n\`\`\`${ext}\n${annotated}\n\`\`\`\n\n`;
     }
   }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -505,7 +505,7 @@ const EFFORT_DOWNGRADE_MIN_SAMPLE = 2;
  * Safety net for when the planner LLM keeps an agent at \`high\` effort despite
  * the most recent round dismissing all of that specialist's findings. Clamps
  * such picks to \`low\` and logs the change. Mutates picks in place for
- * simplicity; the planner result object is not shared across reviews.
+ * simplicity. The planner result object is not shared across reviews.
  */
 function applyEffortDowngrade(picks: AgentPick[], hints: PlannerRoundHint[]): void {
   if (hints.length === 0) return;

--- a/src/review.ts
+++ b/src/review.ts
@@ -603,7 +603,7 @@ export async function runReview(
         Array.from({ length: passes }, () => {
           const shuffledDiff = shuffleDiffFiles(diff);
           const shuffledRawDiff = rebuildRawDiff(shuffledDiff);
-          return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, agentEffort, plannerResult?.language, plannerResult?.context, provenanceMap);
+          return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: agentEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap });
         })
       );
 
@@ -693,7 +693,7 @@ export async function runReview(
             const shuffledDiff = shuffleDiffFiles(diff);
             const shuffledRawDiff = rebuildRawDiff(shuffledDiff);
             const retryEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-            return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, retryEffort, plannerResult?.language, plannerResult?.context, provenanceMap);
+            return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: retryEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap });
           })
         );
 
@@ -755,7 +755,7 @@ export async function runReview(
     const agentPromises = team.agents.map(agent => {
       const startTime = Date.now();
       const agentEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-      return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, agentEffort, plannerResult?.language, plannerResult?.context, provenanceMap)
+      return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: agentEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap })
         .then(agentResult => {
           completedCount++;
           agentResponseLengths.set(agent.name, agentResult.responseLength);
@@ -836,7 +836,7 @@ export async function runReview(
       const retryPromises = agentsToRetry.map(agent => {
         const startTime = Date.now();
         const retryEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-        return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, retryEffort, plannerResult?.language, plannerResult?.context, provenanceMap)
+        return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: retryEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap })
           .then(agentResult => ({ agent, agentResult, durationMs: Date.now() - startTime }))
           .catch(() => ({ agent, agentResult: null as AgentResult | null, durationMs: Date.now() - startTime }));
       });
@@ -1049,6 +1049,13 @@ interface AgentResult {
   responseLength: number;
 }
 
+interface RunReviewerAgentOptions {
+  effort?: EffortLevel;
+  language?: string;
+  context?: string;
+  provenanceMap?: ProvenanceEntry[];
+}
+
 async function runReviewerAgent(
   client: ClaudeClient,
   config: ReviewConfig,
@@ -1059,16 +1066,14 @@ async function runReviewerAgent(
   prContext?: PrContext,
   memoryContext?: string,
   linkedIssues?: LinkedIssue[],
-  effort?: EffortLevel,
-  language?: string,
-  context?: string,
-  provenanceMap?: ProvenanceEntry[],
+  options: RunReviewerAgentOptions = {},
 ): Promise<AgentResult> {
+  const { effort, language, context, provenanceMap } = options;
   const systemPrompt = buildReviewerSystemPrompt(reviewer, config, language, context);
   const userMessage = buildReviewerUserMessage(rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, provenanceMap);
 
-  const options = effort ? { effort } : undefined;
-  const response = await client.sendMessage(systemPrompt, userMessage, options);
+  const sendOptions = effort ? { effort } : undefined;
+  const response = await client.sendMessage(systemPrompt, userMessage, sendOptions);
   const findings = parseFindings(response.content, reviewer.name);
   return { findings, responseLength: response.content.length };
 }


### PR DESCRIPTION
## Summary
- Adds `computeProvenanceMap` to `src/judge.ts` (already existed) and threads a `ProvenanceEntry[]` through `runReview` to all reviewer agent calls
- Adds `annotateFileContentWithProvenance` helper in `src/review.ts` that inserts `// [manki: added in round N]` comments above matched line ranges in the reviewer's file context
- Reviewers now see which diff regions were introduced by which prior round, reducing false re-raises

Closes #552