### PR TITLE
refactor: rename severity tiers to blocker/warning/suggestion/nitpick; add confidence dot prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Manki will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed (BREAKING)
+
+- Renamed severity tiers from `required`/`suggestion`/`nit` to `blocker`/`warning`/`suggestion`/`nitpick` (#593). The `severity` field of every entry in the `findings_json` action output now uses the new values, and the `severity_counts` action output is now `{blocker, warning, suggestion, nitpick}`. Downstream workflow steps that switch on these values must be updated. Persisted handover and review markers from older versions are migrated automatically on read (`required` → `warning`, `nit` → `nitpick`).
+- Replaced `<sub>[high confidence]</sub>` text with a traffic-light dot prefix in review comment headers: 🔴 (high), 🟠 (medium), 🟡 (low).
+- Updated `determineVerdict` so only `blocker` and `warning` trigger `REQUEST_CHANGES`; `suggestion` and `nitpick` produce `APPROVE`.
+
 ## [4.5.3] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (BREAKING)
 
-- Renamed severity tiers from `required`/`suggestion`/`nit` to `blocker`/`warning`/`suggestion`/`nitpick` (#593). The `severity` field of every entry in the `findings_json` action output now uses the new values, and the `severity_counts` action output is now `{blocker, warning, suggestion, nitpick}`. Downstream workflow steps that switch on these values must be updated. Persisted handover and review markers from older versions are migrated automatically on read (`required` → `warning`, `nit` → `nitpick`).
+- Renamed severity tiers from `required`/`suggestion`/`nit` to `blocker`/`warning`/`suggestion`/`nitpick` (#593). The `severity` field of every entry in the `findings_json` action output now uses the new values, and the `severity_counts` action output is now `{blocker, warning, suggestion, nitpick}`. Downstream workflow steps that switch on these values must be updated. Persisted handover and review markers from older versions are migrated automatically on read (`required` → `blocker`, `nit` → `nitpick`).
 - Replaced `<sub>[high confidence]</sub>` text with a traffic-light dot prefix in review comment headers: 🔴 (high), 🟠 (medium), 🟡 (low).
 - Updated `determineVerdict` so only `blocker` and `warning` trigger `REQUEST_CHANGES`; `suggestion` and `nitpick` produce `APPROVE`.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -283,8 +283,8 @@ Manki reviews run in these stages:
 
 1. **Planner** (pre-review, `review_level: auto` only) -- A fast Haiku pass analyzes the diff and picks team size (1/3/5/7), reviewer/judge effort, and PR type. teamSize=1 routes trivial changes (docs, renames, comment-only edits) to a single **Trivial Change Verifier** agent. Falls back to the heuristic team selector if the planner fails or is disabled.
 2. **Reviewer agents** -- The chosen team of specialist agents (security, architecture, correctness, etc.) review the diff in parallel. Each produces raw findings.
-3. **Dedup** -- A two-tier dedup pass filters findings already posted on the PR before judge evaluation. A static matcher handles exact/near-exact matches, then an LLM dedup pass (Haiku) catches semantic duplicates.
-4. **Judge agent** -- A single agent evaluates the deduplicated reviewer findings for accuracy, actionability, and severity. It filters out noise, merges any remaining overlap, and assigns a 4-tier severity to each surviving finding.
+3. **Dedup**: A two-tier dedup pass filters findings already posted on the PR before judge evaluation. A static matcher handles exact/near-exact matches, then an LLM dedup pass (Haiku) catches semantic duplicates.
+4. **Judge agent**: A single agent evaluates the deduplicated reviewer findings for accuracy, actionability, and severity. It filters out noise, merges any remaining overlap, and assigns a 4-tier severity to each surviving finding.
 5. **Recap** -- Surviving findings are posted as inline PR comments with a summary review.
 
 ### Severity tiers

--- a/SETUP.md
+++ b/SETUP.md
@@ -189,9 +189,9 @@ The action exposes outputs you can chain into later workflow steps: `review_id`,
 ```
 
 ```yaml
-# Label PRs that have any required-severity findings
+# Label PRs that have any blocker-severity findings
 - name: Label blocking PRs
-  if: fromJSON(steps.manki.outputs.severity_counts).required > 0
+  if: fromJSON(steps.manki.outputs.severity_counts).blocker > 0
   run: gh pr edit ${{ github.event.number }} --add-label blocking-findings
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ outputs:
   findings_json:
     description: 'JSON array of all findings (for downstream processing)'
   severity_counts:
-    description: 'JSON object with severity counts: {required, suggestion, nit, ignore}'
+    description: 'JSON object with severity counts: {blocker, warning, suggestion, nitpick}'
   judge_model:
     description: 'Model used for the judge agent'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "claude-review",
-  "version": "0.1.0",
+  "name": "manki",
+  "version": "4.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-review",
-      "version": "0.1.0",
-      "license": "MIT",
+      "name": "manki",
+      "version": "4.5.3",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -334,10 +334,20 @@ describe('buildNitIssueBody', () => {
     reviewers: ['Security'],
   };
 
+  const warning: Finding = {
+    severity: 'warning',
+    title: 'Race condition in cache',
+    file: 'src/cache.ts',
+    line: 5,
+    description: 'Concurrent reads may observe stale state.',
+    reviewers: ['Concurrency'],
+  };
+
   it('filters to only nit findings', () => {
-    const body = buildNitIssueBody(42, [required, nit, suggestion], 'testowner', 'testrepo', 'abc123');
+    const body = buildNitIssueBody(42, [required, warning, nit, suggestion], 'testowner', 'testrepo', 'abc123');
     expect(body).toContain('Use const instead of let');
     expect(body).not.toContain('Null dereference');
+    expect(body).not.toContain('Race condition in cache');
     expect(body).not.toContain('Is this timeout intentional?');
   });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -24,6 +24,12 @@ describe('formatFindingComment', () => {
     expect(comment).toContain('✨ **Suggestion**');
   });
 
+  it('formats a warning finding with correct emoji and label', () => {
+    const finding: Finding = { ...baseFinding, severity: 'warning' };
+    const comment = formatFindingComment(finding);
+    expect(comment).toContain('⚠️ **Warning**');
+  });
+
   it('formats a nit finding with correct emoji and label', () => {
     const finding: Finding = { ...baseFinding, severity: 'nitpick' };
     const comment = formatFindingComment(finding);
@@ -616,7 +622,7 @@ describe('formatStatsOneLiner', () => {
     findingsRaw: 10,
     findingsKept: 4,
     findingsDropped: 6,
-    severity: { required: 1, suggestion: 2, nit: 1 },
+    severity: { blocker: 1, warning: 0, suggestion: 2, nitpick: 1 },
     verdict: 'REQUEST_CHANGES',
     prNumber: 42,
     commitSha: 'abc123',
@@ -624,11 +630,11 @@ describe('formatStatsOneLiner', () => {
 
   it('formats a one-liner with severity breakdown', () => {
     const result = formatStatsOneLiner(baseStats);
-    expect(result).toBe('\u{1F4CA} 4 findings (1 required, 2 suggestion, 1 nit) \u00B7 120 lines \u00B7 45s');
+    expect(result).toBe('\u{1F4CA} 4 findings (1 blocker, 2 suggestion, 1 nitpick) \u00B7 120 lines \u00B7 45s');
   });
 
   it('omits zero-count severities', () => {
-    const stats = { ...baseStats, severity: { required: 0, suggestion: 3, nit: 0 }, findingsKept: 3 };
+    const stats = { ...baseStats, severity: { blocker: 0, warning: 0, suggestion: 3, nitpick: 0 }, findingsKept: 3 };
     const result = formatStatsOneLiner(stats);
     expect(result).toContain('(3 suggestion)');
     expect(result).not.toContain('blocker');
@@ -636,7 +642,7 @@ describe('formatStatsOneLiner', () => {
   });
 
   it('shows none when all severities are zero', () => {
-    const stats = { ...baseStats, severity: { required: 0, suggestion: 0, nit: 0 }, findingsKept: 0 };
+    const stats = { ...baseStats, severity: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, findingsKept: 0 };
     const result = formatStatsOneLiner(stats);
     expect(result).toContain('(none)');
   });
@@ -661,7 +667,7 @@ describe('formatStatsJson', () => {
       findingsRaw: 5,
       findingsKept: 2,
       findingsDropped: 3,
-      severity: { required: 1, suggestion: 1, nit: 0 },
+      severity: { blocker: 1, warning: 0, suggestion: 1, nitpick: 0 },
       verdict: 'APPROVE',
       prNumber: 10,
       commitSha: 'def456',
@@ -709,7 +715,7 @@ describe('postReview with stats', () => {
       findingsRaw: 6,
       findingsKept: 3,
       findingsDropped: 3,
-      severity: { required: 0, suggestion: 2, nit: 1 },
+      severity: { blocker: 0, warning: 0, suggestion: 2, nitpick: 1 },
       verdict: 'APPROVE',
       prNumber: 99,
       commitSha: 'abc',

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -654,6 +654,15 @@ describe('formatStatsOneLiner', () => {
     expect(result).toContain('(none)');
   });
 
+  it('includes non-zero warning count in output', () => {
+    const stats = { ...baseStats, severity: { blocker: 0, warning: 2, suggestion: 1, nitpick: 0 }, findingsKept: 3 };
+    const result = formatStatsOneLiner(stats);
+    expect(result).toContain('2 warning');
+    expect(result).toContain('1 suggestion');
+    expect(result).not.toContain('blocker');
+    expect(result).not.toContain('nitpick');
+  });
+
   it('rounds review time to nearest second', () => {
     const stats = { ...baseStats, reviewTimeMs: 1500 };
     const result = formatStatsOneLiner(stats);
@@ -1680,6 +1689,18 @@ describe('buildDashboard', () => {
     expect(md).toContain('**Judge** — 2 kept · 6 dropped');
     expect(md).toContain(`${INDENT}kept: 1 blocker · 1 suggestion`);
     expect(md).toContain(`${INDENT}dropped: 2 suggestion · 3 nitpick · 1 ignore`);
+  });
+
+  it('renders warning in severity breakdown when warning count is non-zero', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 200, agentCount: 3,
+      rawFindingCount: 5, keptCount: 3, droppedCount: 2,
+      keptSeverities: { blocker: 1, warning: 2 },
+      droppedSeverities: { warning: 1, nitpick: 1 },
+    };
+    const md = buildDashboard(data);
+    expect(md).toContain(`${INDENT}kept: 1 blocker · 2 warning`);
+    expect(md).toContain(`${INDENT}dropped: 1 warning · 1 nitpick`);
   });
 
   it('renders plannerInfo in complete phase', () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -3,7 +3,7 @@ import { DashboardData, Finding, ParsedDiff, ReviewMetadata, ReviewResult, Revie
 
 describe('formatFindingComment', () => {
   const baseFinding: Finding = {
-    severity: 'required',
+    severity: 'blocker',
     title: 'Null pointer dereference',
     file: 'src/main.ts',
     line: 42,
@@ -13,7 +13,7 @@ describe('formatFindingComment', () => {
 
   it('formats a required finding with correct emoji and label', () => {
     const comment = formatFindingComment(baseFinding);
-    expect(comment).toContain('🚫 **Required**');
+    expect(comment).toContain('🚫 **Blocker**');
     expect(comment).toContain(baseFinding.title);
     expect(comment).toContain(baseFinding.description);
   });
@@ -21,13 +21,13 @@ describe('formatFindingComment', () => {
   it('formats a suggestion finding with correct emoji and label', () => {
     const finding: Finding = { ...baseFinding, severity: 'suggestion' };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('💡 **Suggestion**');
+    expect(comment).toContain('✨ **Suggestion**');
   });
 
   it('formats a nit finding with correct emoji and label', () => {
-    const finding: Finding = { ...baseFinding, severity: 'nit' };
+    const finding: Finding = { ...baseFinding, severity: 'nitpick' };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('📝 **Nit**');
+    expect(comment).toContain('📝 **Nitpick**');
   });
 
   it('formats an ignore finding with correct emoji and label', () => {
@@ -76,13 +76,13 @@ describe('formatFindingComment', () => {
     expect(parsed.fix).toBeUndefined();
   });
 
-  it('includes fix and confidence in AI context JSON when present', () => {
+  it('includes fix in AI context JSON when present and omits confidence', () => {
     const finding: Finding = { ...baseFinding, suggestedFix: 'if (value != null) { use(value); }', judgeConfidence: 'high' };
     const comment = formatFindingComment(finding);
     const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
     const parsed = JSON.parse(jsonMatch![1]);
     expect(parsed.fix).toBe('if (value != null) { use(value); }');
-    expect(parsed.confidence).toBe('high');
+    expect(parsed.confidence).toBeUndefined();
   });
 
   it('truncates long suggestedFix in AI context JSON to 200 chars', () => {
@@ -122,49 +122,57 @@ describe('formatFindingComment', () => {
 
   it('includes metadata marker with severity and sanitized title', () => {
     const comment = formatFindingComment(baseFinding);
-    expect(comment).toContain('<!-- manki:required:Null-pointer-dereference -->');
+    expect(comment).toContain('<!-- manki:blocker:Null-pointer-dereference -->');
   });
 
   it('sanitizes special characters in metadata marker title', () => {
     const finding: Finding = { ...baseFinding, title: 'Bug: foo() returns "bar"!' };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('<!-- manki:required:Bug--foo---returns--bar-- -->');
+    expect(comment).toContain('<!-- manki:blocker:Bug--foo---returns--bar-- -->');
   });
 
-  it('shows judge confidence when present', () => {
+  it('shows judge confidence as a red dot when high', () => {
     const finding: Finding = { ...baseFinding, judgeConfidence: 'high' };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('<sub>[high confidence]</sub>');
+    expect(comment).toContain('🔴 🚫 **Blocker**');
   });
 
-  it('shows medium judge confidence', () => {
+  it('shows judge confidence as an orange dot when medium', () => {
     const finding: Finding = { ...baseFinding, judgeConfidence: 'medium' };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('<sub>[medium confidence]</sub>');
+    expect(comment).toContain('🟠 🚫 **Blocker**');
   });
 
-  it('omits judge confidence when absent', () => {
+  it('shows judge confidence as a yellow dot when low', () => {
+    const finding: Finding = { ...baseFinding, judgeConfidence: 'low' };
+    const comment = formatFindingComment(finding);
+    expect(comment).toContain('🟡 🚫 **Blocker**');
+  });
+
+  it('omits judge confidence dot when absent', () => {
     const comment = formatFindingComment(baseFinding);
-    expect(comment).not.toContain('confidence]');
+    expect(comment).not.toContain('🔴');
+    expect(comment).not.toContain('🟠');
+    expect(comment).not.toContain('🟡');
   });
 
   it('renders defensive-hardening tag with original severity when tagged', () => {
     const finding: Finding = {
       ...baseFinding,
-      severity: 'nit',
+      severity: 'nitpick',
       tags: ['defensive-hardening'],
-      originalSeverity: 'required',
+      originalSeverity: 'blocker',
       reachability: 'hypothetical',
       reachabilityReasoning: 'no caller passes a negative value',
     };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('[defensive hardening — capped from required]');
+    expect(comment).toContain('[defensive hardening — capped from blocker]');
     const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
     const parsed = JSON.parse(jsonMatch![1]);
     expect(parsed.tags).toEqual(['defensive-hardening']);
     expect(parsed.reachability).toBe('hypothetical');
     expect(parsed.reachabilityReasoning).toBe('no caller passes a negative value');
-    expect(parsed.originalSeverity).toBe('required');
+    expect(parsed.originalSeverity).toBe('blocker');
   });
 
   it('omits defensive-hardening line when finding has no tags', () => {
@@ -178,7 +186,7 @@ describe('formatFindingComment', () => {
   });
 
   it('omits defensive-hardening line when tag is absent but originalSeverity is set', () => {
-    const finding: Finding = { ...baseFinding, originalSeverity: 'required' };
+    const finding: Finding = { ...baseFinding, originalSeverity: 'blocker' };
     const comment = formatFindingComment(finding);
     expect(comment).not.toContain('defensive hardening');
   });
@@ -186,22 +194,22 @@ describe('formatFindingComment', () => {
   it('renders own-proposal-followup tag with originalSeverity when present', () => {
     const finding: Finding = {
       ...baseFinding,
-      severity: 'nit',
+      severity: 'nitpick',
       tags: ['own-proposal-followup'],
-      originalSeverity: 'required',
+      originalSeverity: 'blocker',
     };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('[own-proposal followup — capped from required]');
+    expect(comment).toContain('[own-proposal followup — capped from blocker]');
     const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
     const parsed = JSON.parse(jsonMatch![1]);
     expect(parsed.tags).toEqual(['own-proposal-followup']);
-    expect(parsed.originalSeverity).toBe('required');
+    expect(parsed.originalSeverity).toBe('blocker');
   });
 
   it('renders own-proposal-followup without "capped from" when originalSeverity is absent', () => {
     const finding: Finding = {
       ...baseFinding,
-      severity: 'nit',
+      severity: 'nitpick',
       tags: ['own-proposal-followup'],
     };
     const comment = formatFindingComment(finding);
@@ -212,8 +220,8 @@ describe('formatFindingComment', () => {
   it('renders own-proposal-followup without "capped from" when originalSeverity equals severity', () => {
     const finding: Finding = {
       ...baseFinding,
-      severity: 'nit',
-      originalSeverity: 'nit',
+      severity: 'nitpick',
+      originalSeverity: 'nitpick',
       tags: ['own-proposal-followup'],
     };
     const comment = formatFindingComment(finding);
@@ -224,14 +232,14 @@ describe('formatFindingComment', () => {
   it('renders both defensive-hardening and own-proposal-followup tags when both are present', () => {
     const finding: Finding = {
       ...baseFinding,
-      severity: 'nit',
+      severity: 'nitpick',
       tags: ['defensive-hardening', 'own-proposal-followup'],
-      originalSeverity: 'required',
+      originalSeverity: 'blocker',
       reachability: 'hypothetical',
     };
     const comment = formatFindingComment(finding);
-    expect(comment).toContain('[defensive hardening — capped from required]');
-    expect(comment).toContain('[own-proposal followup — capped from required]');
+    expect(comment).toContain('[defensive hardening — capped from blocker]');
+    expect(comment).toContain('[own-proposal followup — capped from blocker]');
   });
 
   it('omits own-proposal-followup line when tag is absent', () => {
@@ -287,7 +295,7 @@ describe('BOT_MARKER', () => {
 
 describe('buildNitIssueBody', () => {
   const nit: Finding = {
-    severity: 'nit',
+    severity: 'nitpick',
     title: 'Use const instead of let',
     file: 'src/utils.ts',
     line: 10,
@@ -305,7 +313,7 @@ describe('buildNitIssueBody', () => {
   };
 
   const required: Finding = {
-    severity: 'required',
+    severity: 'blocker',
     title: 'Null dereference',
     file: 'src/main.ts',
     line: 1,
@@ -623,8 +631,8 @@ describe('formatStatsOneLiner', () => {
     const stats = { ...baseStats, severity: { required: 0, suggestion: 3, nit: 0 }, findingsKept: 3 };
     const result = formatStatsOneLiner(stats);
     expect(result).toContain('(3 suggestion)');
-    expect(result).not.toContain('required');
-    expect(result).not.toContain('nit');
+    expect(result).not.toContain('blocker');
+    expect(result).not.toContain('nitpick');
   });
 
   it('shows none when all severities are zero', () => {
@@ -779,16 +787,20 @@ describe('postReview partialNote', () => {
 });
 
 describe('getSeverityLabel', () => {
-  it('returns Required for required severity', () => {
-    expect(getSeverityLabel('required')).toBe('Required');
+  it('returns Blocker for blocker severity', () => {
+    expect(getSeverityLabel('blocker')).toBe('Blocker');
+  });
+
+  it('returns Warning for warning severity', () => {
+    expect(getSeverityLabel('warning')).toBe('Warning');
   });
 
   it('returns Suggestion for suggestion severity', () => {
     expect(getSeverityLabel('suggestion')).toBe('Suggestion');
   });
 
-  it('returns Nit for nit severity', () => {
-    expect(getSeverityLabel('nit')).toBe('Nit');
+  it('returns Nitpick for nitpick severity', () => {
+    expect(getSeverityLabel('nitpick')).toBe('Nitpick');
   });
 
   it('returns Ignore for ignore severity', () => {
@@ -1648,13 +1660,13 @@ describe('buildDashboard', () => {
     const data: DashboardData = {
       phase: 'complete', lineCount: 400, agentCount: 5,
       rawFindingCount: 8, keptCount: 2, droppedCount: 6,
-      keptSeverities: { required: 1, suggestion: 1 },
-      droppedSeverities: { nit: 3, suggestion: 2, ignore: 1 },
+      keptSeverities: { blocker: 1, suggestion: 1 },
+      droppedSeverities: { nitpick: 3, suggestion: 2, ignore: 1 },
     };
     const md = buildDashboard(data);
     expect(md).toContain('**Judge** — 2 kept · 6 dropped');
-    expect(md).toContain(`${INDENT}kept: 1 required · 1 suggestion`);
-    expect(md).toContain(`${INDENT}dropped: 2 suggestion · 3 nit · 1 ignore`);
+    expect(md).toContain(`${INDENT}kept: 1 blocker · 1 suggestion`);
+    expect(md).toContain(`${INDENT}dropped: 2 suggestion · 3 nitpick · 1 ignore`);
   });
 
   it('renders plannerInfo in complete phase', () => {
@@ -1847,7 +1859,7 @@ describe('updateProgressComment', () => {
       nitHandling: 'issues',
     },
     judgeDecisions: [
-      { title: 'Null dereference', severity: 'required', reasoning: 'Valid bug', confidence: 'high', kept: true },
+      { title: 'Null dereference', severity: 'blocker', reasoning: 'Valid bug', confidence: 'high', kept: true },
       { title: 'Style nitpick', severity: 'ignore', reasoning: 'Intentional pattern', confidence: 'medium', kept: false },
     ],
     timing: {
@@ -1890,7 +1902,7 @@ describe('updateProgressComment', () => {
     const body = mockUpdateComment.mock.calls[0][0].body as string;
     expect(body).toContain('**Judge decisions:**');
     expect(body).toContain('\u2713 Kept: "Null dereference"');
-    expect(body).toContain('(required, high confidence)');
+    expect(body).toContain('(blocker, high confidence)');
     expect(body).toContain('\u2717 Dropped: "Style nitpick"');
     expect(body).toContain('(ignore, medium confidence)');
   });
@@ -2225,7 +2237,7 @@ describe('createNitIssue', () => {
   it('returns null when no nit findings exist', async () => {
     const mockOctokit = {} as unknown as Parameters<typeof createNitIssue>[0];
     const findings: Finding[] = [
-      { severity: 'required', title: 'Bug', file: 'a.ts', line: 1, description: 'Desc', reviewers: [] },
+      { severity: 'blocker', title: 'Bug', file: 'a.ts', line: 1, description: 'Desc', reviewers: [] },
     ];
 
     const result = await createNitIssue(mockOctokit, 'owner', 'repo', 1, findings, 'sha');
@@ -2244,7 +2256,7 @@ describe('createNitIssue', () => {
     } as unknown as Parameters<typeof createNitIssue>[0];
 
     const findings: Finding[] = [
-      { severity: 'nit', title: 'Style', file: 'a.ts', line: 1, description: 'Desc', reviewers: [] },
+      { severity: 'nitpick', title: 'Style', file: 'a.ts', line: 1, description: 'Desc', reviewers: [] },
     ];
 
     const result = await createNitIssue(mockOctokit, 'owner', 'repo', 1, findings, 'sha');
@@ -2266,7 +2278,7 @@ describe('createNitIssue', () => {
     } as unknown as Parameters<typeof createNitIssue>[0];
 
     const findings: Finding[] = [
-      { severity: 'nit', title: 'Style issue', file: 'a.ts', line: 5, description: 'Minor style.', reviewers: [] },
+      { severity: 'nitpick', title: 'Style issue', file: 'a.ts', line: 5, description: 'Minor style.', reviewers: [] },
     ];
 
     const result = await createNitIssue(mockOctokit, 'owner', 'repo', 42, findings, 'abc123');
@@ -2293,7 +2305,7 @@ describe('createNitIssue', () => {
     } as unknown as Parameters<typeof createNitIssue>[0];
 
     const findings: Finding[] = [
-      { severity: 'nit', title: 'Nit', file: 'a.ts', line: 1, description: 'Desc', reviewers: [] },
+      { severity: 'nitpick', title: 'Nit', file: 'a.ts', line: 1, description: 'Desc', reviewers: [] },
     ];
 
     await createNitIssue(mockOctokit, 'owner', 'repo', 1, findings, 'sha');
@@ -2375,7 +2387,7 @@ describe('postReview fallback paths', () => {
       verdict: 'REQUEST_CHANGES',
       summary: 'Issues found.',
       findings: [{
-        severity: 'required',
+        severity: 'blocker',
         title: 'Critical bug here',
         file: 'src/a.ts',
         line: 10,
@@ -2489,9 +2501,10 @@ describe('postReview fallback paths', () => {
 
 describe('getSeverityEmoji', () => {
   it('returns correct emoji for each severity', () => {
-    expect(getSeverityEmoji('required')).toBe('\u{1F6AB}');
-    expect(getSeverityEmoji('suggestion')).toBe('\u{1F4A1}');
-    expect(getSeverityEmoji('nit')).toBe('\u{1F4DD}');
+    expect(getSeverityEmoji('blocker')).toBe('\u{1F6AB}');
+    expect(getSeverityEmoji('warning')).toBe('\u26A0\uFE0F');
+    expect(getSeverityEmoji('suggestion')).toBe('\u2728');
+    expect(getSeverityEmoji('nitpick')).toBe('\u{1F4DD}');
     expect(getSeverityEmoji('ignore')).toBe('\u26AA');
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -82,12 +82,19 @@ describe('formatFindingComment', () => {
     expect(parsed.fix).toBeUndefined();
   });
 
-  it('includes fix in AI context JSON when present and omits confidence', () => {
+  it('includes fix and confidence in AI context JSON when present', () => {
     const finding: Finding = { ...baseFinding, suggestedFix: 'if (value != null) { use(value); }', judgeConfidence: 'high' };
     const comment = formatFindingComment(finding);
     const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
     const parsed = JSON.parse(jsonMatch![1]);
     expect(parsed.fix).toBe('if (value != null) { use(value); }');
+    expect(parsed.confidence).toBe('high');
+  });
+
+  it('omits confidence from AI context JSON when judgeConfidence is absent', () => {
+    const comment = formatFindingComment(baseFinding);
+    const jsonMatch = comment.match(/```json\n([\s\S]*?)\n```/);
+    const parsed = JSON.parse(jsonMatch![1]);
     expect(parsed.confidence).toBeUndefined();
   });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -235,7 +235,7 @@ function sanitizeEffort(v: string): string {
   return VALID_EFFORTS.has(v) ? v : 'unknown';
 }
 
-const SEVERITY_ORDER = ['required', 'suggestion', 'nit', 'ignore'];
+const SEVERITY_ORDER = ['blocker', 'warning', 'suggestion', 'nitpick', 'ignore'];
 
 function renderSeverityBreakdown(severities: Record<string, number>): string {
   return SEVERITY_ORDER
@@ -663,16 +663,18 @@ function mapVerdictToEvent(verdict: ReviewVerdict): 'APPROVE' | 'COMMENT' | 'REQ
 }
 
 const severityLabels: Record<FindingSeverity, string> = {
-  required: 'Required',
+  blocker: 'Blocker',
+  warning: 'Warning',
   suggestion: 'Suggestion',
-  nit: 'Nit',
+  nitpick: 'Nitpick',
   ignore: 'Ignore',
 };
 
 const severityEmojis: Record<FindingSeverity, string> = {
-  required: '🚫',
-  suggestion: '💡',
-  nit: '📝',
+  blocker: '🚫',
+  warning: '⚠️',
+  suggestion: '✨',
+  nitpick: '📝',
   ignore: '⚪',
 };
 
@@ -733,8 +735,13 @@ function formatFindingComment(finding: Finding): string {
   const safeTitle = sanitizeMarkdown(finding.title);
   const safeDescription = sanitizeMarkdown(finding.description);
 
-  const confidence = finding.judgeConfidence ? ` <sub>[${finding.judgeConfidence} confidence]</sub>` : '';
-  let comment = `${severityEmoji} **${severityLabel}**${confidence}: ${safeTitle}`;
+  const confidenceDots: Record<'high' | 'medium' | 'low', string> = {
+    high: '🔴',
+    medium: '🟠',
+    low: '🟡',
+  };
+  const confidenceDot = finding.judgeConfidence ? `${confidenceDots[finding.judgeConfidence]} ` : '';
+  let comment = `${confidenceDot}${severityEmoji} **${severityLabel}**: ${safeTitle}`;
   if (finding.tags?.includes(DEFENSIVE_HARDENING_TAG) && finding.originalSeverity) {
     comment += `\n<sub>[defensive hardening — capped from ${finding.originalSeverity}]</sub>`;
   }
@@ -764,7 +771,6 @@ function formatFindingComment(finding: Finding): string {
     file: finding.file,
     line: finding.line,
     severity: finding.severity,
-    ...(finding.judgeConfidence && { confidence: finding.judgeConfidence }),
     flaggedBy: finding.reviewers,
     title: finding.title,
     ...(finding.suggestedFix && { fix: finding.suggestedFix.slice(0, 200) }),
@@ -791,7 +797,7 @@ export function buildNitIssueBody(
   repo: string,
   commitSha: string,
 ): string {
-  const nits = findings.filter(f => f.severity === 'nit');
+  const nits = findings.filter(f => f.severity === 'nitpick');
 
   const checklist = nits.map(f => {
     const icon = '\u{1F4DD}';
@@ -840,7 +846,7 @@ export async function createNitIssue(
   findings: Finding[],
   commitSha: string,
 ): Promise<number | null> {
-  const nits = findings.filter(f => f.severity === 'nit');
+  const nits = findings.filter(f => f.severity === 'nitpick');
   if (nits.length === 0) return null;
 
   const searchQuery = `repo:${owner}/${repo} is:issue "triage: findings from PR #${prNumber}" label:needs-human`;

--- a/src/github.ts
+++ b/src/github.ts
@@ -772,6 +772,7 @@ function formatFindingComment(finding: Finding): string {
     file: finding.file,
     line: finding.line,
     severity: finding.severity,
+    ...(finding.judgeConfidence && { confidence: finding.judgeConfidence }),
     flaggedBy: finding.reviewers,
     title: finding.title,
     ...(finding.suggestedFix && { fix: finding.suggestedFix.slice(0, 200) }),

--- a/src/github.ts
+++ b/src/github.ts
@@ -235,7 +235,7 @@ function sanitizeEffort(v: string): string {
   return VALID_EFFORTS.has(v) ? v : 'unknown';
 }
 
-const SEVERITY_ORDER = ['blocker', 'warning', 'suggestion', 'nitpick', 'ignore'];
+const SEVERITY_ORDER: readonly FindingSeverity[] = ['blocker', 'warning', 'suggestion', 'nitpick', 'ignore'];
 
 function renderSeverityBreakdown(severities: Record<string, number>): string {
   return SEVERITY_ORDER

--- a/src/github.ts
+++ b/src/github.ts
@@ -679,6 +679,12 @@ const severityEmojis: Record<FindingSeverity, string> = {
   ignore: '⚪',
 };
 
+const confidenceDots: Record<'high' | 'medium' | 'low', string> = {
+  high: '🔴',
+  medium: '🟠',
+  low: '🟡',
+};
+
 function getSeverityLabel(severity: FindingSeverity): string {
   return severityLabels[severity];
 }
@@ -736,11 +742,6 @@ function formatFindingComment(finding: Finding): string {
   const safeTitle = sanitizeMarkdown(finding.title);
   const safeDescription = sanitizeMarkdown(finding.description);
 
-  const confidenceDots: Record<'high' | 'medium' | 'low', string> = {
-    high: '🔴',
-    medium: '🟠',
-    low: '🟡',
-  };
   const confidenceDot = finding.judgeConfidence ? `${confidenceDots[finding.judgeConfidence]} ` : '';
   let comment = `${confidenceDot}${severityEmoji} **${severityLabel}**: ${safeTitle}`;
   if (finding.tags?.includes(DEFENSIVE_HARDENING_TAG) && finding.originalSeverity) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -457,9 +457,10 @@ export async function dismissPreviousReviews(
 
 function formatStatsOneLiner(stats: ReviewStats): string {
   const parts: string[] = [];
-  if (stats.severity.required) parts.push(`${stats.severity.required} required`);
+  if (stats.severity.blocker) parts.push(`${stats.severity.blocker} blocker`);
+  if (stats.severity.warning) parts.push(`${stats.severity.warning} warning`);
   if (stats.severity.suggestion) parts.push(`${stats.severity.suggestion} suggestion`);
-  if (stats.severity.nit) parts.push(`${stats.severity.nit} nit`);
+  if (stats.severity.nitpick) parts.push(`${stats.severity.nitpick} nitpick`);
   const breakdown = parts.length > 0 ? parts.join(', ') : 'none';
   const total = stats.findingsKept;
   const time = Math.round(stats.reviewTimeMs / 1000);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1509,6 +1509,14 @@ describe('runFullReview orchestration', () => {
     // Outputs set
     expect(jest.mocked(core.setOutput)).toHaveBeenCalledWith('verdict', 'REQUEST_CHANGES');
     expect(jest.mocked(core.setOutput)).toHaveBeenCalledWith('findings_count', '1');
+    // `severity_counts` uses the new key shape (#593): blocker/warning/suggestion/nitpick.
+    const setOutputCalls = jest.mocked(core.setOutput).mock.calls;
+    const severityCountsCall = setOutputCalls.find(c => c[0] === 'severity_counts');
+    expect(severityCountsCall).toBeTruthy();
+    const counts = JSON.parse(severityCountsCall![1] as string);
+    expect(counts).toEqual({ blocker: 1, warning: 0, suggestion: 0, nitpick: 0 });
+    expect(counts).not.toHaveProperty('required');
+    expect(counts).not.toHaveProperty('nit');
   });
 
   it('populates enriched stats fields (agentMetrics, judgeMetrics, fileMetrics, model split)', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,7 +112,7 @@ jest.mock('./review', () => {
       highlights: [],
       reviewComplete: true,
     }),
-    determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' }),
+    determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' }),
     selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
     buildPlannerHints: actual.buildPlannerHints,
   };
@@ -1343,7 +1343,7 @@ describe('runFullReview orchestration', () => {
       verdict: 'APPROVE', summary: 'Looks good',
       findings: [], highlights: [], reviewComplete: true,
     });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
     jest.mocked(reviewModule.selectTeam).mockReturnValue({ level: 'standard' as 'small', agents: [{ name: 'general', focus: '' }], lineCount: 0 });
     jest.mocked(ghUtils.postProgressComment).mockResolvedValue(1);
     jest.mocked(ghUtils.postReview).mockResolvedValue(123);
@@ -1483,7 +1483,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
 
     const findings = [
-      { severity: 'required' as const, title: 'Bug found', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['general'] },
+      { severity: 'blocker' as const, title: 'Bug found', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['general'] },
     ];
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'REQUEST_CHANGES',
@@ -1523,9 +1523,9 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
 
     const findings = [
-      { severity: 'required' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, judgeNotes: 'confirmed' },
+      { severity: 'blocker' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, judgeNotes: 'confirmed' },
       { severity: 'suggestion' as const, title: 'Style', file: 'src/app.ts', line: 8, description: 'desc', reviewers: ['general'], judgeConfidence: 'medium' as const },
-      { severity: 'nit' as const, title: 'Nit', file: 'src/utils.js', line: 1, description: 'desc', reviewers: ['general', 'security'], judgeConfidence: 'low' as const },
+      { severity: 'nitpick' as const, title: 'Nit', file: 'src/utils.js', line: 1, description: 'desc', reviewers: ['general', 'security'], judgeConfidence: 'low' as const },
     ];
     const allJudged = [
       ...findings,
@@ -1533,7 +1533,7 @@ describe('runFullReview orchestration', () => {
     ];
     const rawFindings = [
       ...findings,
-      { severity: 'nit' as const, title: 'Dropped', file: 'src/app.ts', line: 2, description: 'dropped', reviewers: ['security'] },
+      { severity: 'nitpick' as const, title: 'Dropped', file: 'src/app.ts', line: 2, description: 'dropped', reviewers: ['security'] },
     ];
 
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -1583,8 +1583,8 @@ describe('runFullReview orchestration', () => {
 
     // keptSeverities/droppedSeverities passed to dashboard use original severity for dropped findings
     const dashboardArg = jest.mocked(ghUtils.updateProgressComment).mock.calls.at(-1)?.[4];
-    expect(dashboardArg?.keptSeverities).toEqual({ required: 1, suggestion: 1, nit: 1 });
-    expect(dashboardArg?.droppedSeverities).toEqual({ nit: 1 });
+    expect(dashboardArg?.keptSeverities).toEqual({ blocker: 1, suggestion: 1, nitpick: 1 });
+    expect(dashboardArg?.droppedSeverities).toEqual({ nitpick: 1 });
     expect(dashboardArg?.droppedCount).toBe(1);
     expect(dashboardArg?.keptCount).toBe(3);
   });
@@ -1600,14 +1600,14 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
 
     const findings = [
-      { severity: 'required' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
+      { severity: 'blocker' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
     ];
     const allJudged = [...findings];
     // rawFindings: 5 findings from agents (pre-suppression, pre-dedup)
     const rawFindings = [
-      { severity: 'required' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'] },
-      { severity: 'required' as const, title: 'Dup1', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'] },
-      { severity: 'required' as const, title: 'Dup2', file: 'src/app.ts', line: 7, description: 'desc', reviewers: ['general'] },
+      { severity: 'blocker' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'] },
+      { severity: 'blocker' as const, title: 'Dup1', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'] },
+      { severity: 'blocker' as const, title: 'Dup2', file: 'src/app.ts', line: 7, description: 'desc', reviewers: ['general'] },
       { severity: 'suggestion' as const, title: 'Judge-merged', file: 'src/app.ts', line: 8, description: 'desc', reviewers: ['general'] },
       { severity: 'suggestion' as const, title: 'Judge-merged-2', file: 'src/app.ts', line: 9, description: 'desc', reviewers: ['general'] },
     ];
@@ -1653,13 +1653,13 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
 
     const findings = [
-      { severity: 'required' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
+      { severity: 'blocker' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
     ];
     const allJudged = [...findings];
     const rawFindings = [
-      { severity: 'required' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'] },
-      { severity: 'nit' as const, title: 'Suppressed1', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'] },
-      { severity: 'nit' as const, title: 'Suppressed2', file: 'src/app.ts', line: 7, description: 'desc', reviewers: ['general'] },
+      { severity: 'blocker' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'] },
+      { severity: 'nitpick' as const, title: 'Suppressed1', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'] },
+      { severity: 'nitpick' as const, title: 'Suppressed2', file: 'src/app.ts', line: 7, description: 'desc', reviewers: ['general'] },
       { severity: 'suggestion' as const, title: 'Judge-merged', file: 'src/app.ts', line: 8, description: 'desc', reviewers: ['general'] },
     ];
 
@@ -1699,8 +1699,8 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
 
     const findings = [
-      { severity: 'nit' as const, title: 'Guard', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, tags: ['defensive-hardening'], originalSeverity: 'required' as const, reachability: 'hypothetical' as const },
-      { severity: 'required' as const, title: 'Real', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, reachability: 'reachable' as const },
+      { severity: 'nitpick' as const, title: 'Guard', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, tags: ['defensive-hardening'], originalSeverity: 'blocker' as const, reachability: 'hypothetical' as const },
+      { severity: 'blocker' as const, title: 'Real', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const, reachability: 'reachable' as const },
     ];
     const allJudged = [...findings];
 
@@ -1734,7 +1734,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
 
     const findings = [
-      { severity: 'required' as const, title: 'Real', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
+      { severity: 'blocker' as const, title: 'Real', file: 'src/app.ts', line: 6, description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const },
     ];
 
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -1779,7 +1779,7 @@ describe('runFullReview orchestration', () => {
     });
 
     const nitFinding = {
-      severity: 'nit' as const, title: 'Style nit', file: 'src/app.ts',
+      severity: 'nitpick' as const, title: 'Style nit', file: 'src/app.ts',
       line: 3, description: 'nit desc', reviewers: ['general'],
     };
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -1789,13 +1789,13 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
     });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_nit_or_suggestion' });
 
     await callRunFullReview();
 
     expect(jest.mocked(ghUtils.createNitIssue)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 42,
-      [expect.objectContaining({ severity: 'nit' })], 'abc123',
+      [expect.objectContaining({ severity: 'nitpick' })], 'abc123',
     );
   });
 
@@ -1819,7 +1819,7 @@ describe('runFullReview orchestration', () => {
     });
 
     const nitFinding = {
-      severity: 'nit' as const, title: 'Style nit', file: 'src/app.ts',
+      severity: 'nitpick' as const, title: 'Style nit', file: 'src/app.ts',
       line: 3, description: 'nit desc', reviewers: ['general'],
     };
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -1829,7 +1829,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
     });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_nit_or_suggestion' });
 
     await callRunFullReview();
 
@@ -1839,7 +1839,7 @@ describe('runFullReview orchestration', () => {
     expect(jest.mocked(ghUtils.postReview)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 42, 'abc123',
       expect.objectContaining({
-        findings: [expect.objectContaining({ severity: 'nit' })],
+        findings: [expect.objectContaining({ severity: 'nitpick' })],
       }),
       expect.anything(), expect.anything(),
     );
@@ -1904,14 +1904,14 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
 
     const previousFindings = [
-      { title: 'Bug', file: 'src/app.ts', line: 5, severity: 'required' as const, status: 'resolved' as const },
+      { title: 'Bug', file: 'src/app.ts', line: 5, severity: 'blocker' as const, status: 'resolved' as const },
     ];
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings,
       recapContext: 'previous context',
     });
 
-    const finding2 = { severity: 'nit' as const, title: 'Style', file: 'src/app.ts', line: 8, description: 'desc', reviewers: ['general'] };
+    const finding2 = { severity: 'nitpick' as const, title: 'Style', file: 'src/app.ts', line: 8, description: 'desc', reviewers: ['general'] };
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Issues',
       findings: [finding2], highlights: [], reviewComplete: true,
@@ -1954,14 +1954,14 @@ describe('runFullReview orchestration', () => {
       findings: [
         {
           fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's' },
-          severity: 'required' as const,
+          severity: 'blocker' as const,
           title: 't',
           authorReply: 'agree' as const,
           specialist: 'Security & Safety',
         },
         {
           fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' },
-          severity: 'required' as const,
+          severity: 'blocker' as const,
           title: 't2',
           authorReply: 'agree' as const,
           specialist: 'Security & Safety',
@@ -2034,8 +2034,8 @@ describe('runFullReview orchestration', () => {
     };
     jest.mocked(memoryModule.loadMemory).mockResolvedValue(memory);
 
-    const finding = { severity: 'nit' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['general'] };
-    const escalated = { ...finding, severity: 'required' as const };
+    const finding = { severity: 'nitpick' as const, title: 'Bug', file: 'src/app.ts', line: 5, description: 'desc', reviewers: ['general'] };
+    const escalated = { ...finding, severity: 'blocker' as const };
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Nits',
       findings: [finding], highlights: [], reviewComplete: true,
@@ -2074,12 +2074,12 @@ describe('runFullReview orchestration', () => {
       findings: [], highlights: [], reviewComplete: true,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [], duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
 
     await callRunFullReview();
 
     const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
-    expect(statsArg?.judgeMetrics?.verdictReason).toBe('only_dismissed_or_nit');
+    expect(statsArg?.judgeMetrics?.verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('enriches findings with code context from diff hunks', async () => {
@@ -2103,7 +2103,7 @@ describe('runFullReview orchestration', () => {
       findings: [finding], highlights: [], reviewComplete: true,
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_nit_or_suggestion' });
 
     await callRunFullReview();
 
@@ -2354,7 +2354,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(memoryModule.loadMemory).mockResolvedValue(memory);
 
     const finding1 = { severity: 'suggestion' as const, title: 'Real issue', file: 'src/app.ts', line: 3, description: 'desc', reviewers: ['general'] };
-    const finding2 = { severity: 'nit' as const, title: 'Noise', file: 'src/app.ts', line: 7, description: 'desc', reviewers: ['general'] };
+    const finding2 = { severity: 'nitpick' as const, title: 'Noise', file: 'src/app.ts', line: 7, description: 'desc', reviewers: ['general'] };
 
     jest.mocked(reviewModule.runReview).mockImplementation(
       async (_clients, _config, _diff, _rawDiff, _repoContext, _memory, _fileContents, _prContext, _linkedIssues, onProgress) => {
@@ -2371,7 +2371,7 @@ describe('runFullReview orchestration', () => {
         };
       },
     );
-    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_dismissed_or_nit' });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_nit_or_suggestion' });
 
     await callRunFullReview();
 
@@ -2396,7 +2396,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
 
     const previousFindings = [
-      { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'required' as const, status: 'resolved' as const },
+      { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'resolved' as const },
       { title: 'Bug B', file: 'src/app.ts', line: 2, severity: 'suggestion' as const, status: 'open' as const, threadId: 'PRRT_123' },
     ];
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
@@ -2472,7 +2472,7 @@ describe('runFullReview orchestration', () => {
 
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings: [
-        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'required' as const, status: 'open' as const, threadId: 'PRRT_abc' },
+        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_abc' },
         { title: 'Bug B', file: 'src/app.ts', line: 2, severity: 'suggestion' as const, status: 'open' as const, threadId: 'PRRT_def' },
       ],
       recapContext: 'previous context',
@@ -2515,7 +2515,7 @@ describe('runFullReview orchestration', () => {
 
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings: [
-        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'required' as const, status: 'open' as const, threadId: 'PRRT_known' },
+        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_known' },
       ],
       recapContext: 'previous context',
     });
@@ -2557,9 +2557,9 @@ describe('runFullReview orchestration', () => {
 
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings: [
-        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'required' as const, status: 'open' as const, threadId: 'PRRT_open' },
+        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_open' },
         { title: 'Bug B', file: 'src/app.ts', line: 2, severity: 'suggestion' as const, status: 'replied' as const, threadId: 'PRRT_replied' },
-        { title: 'Bug C', file: 'src/app.ts', line: 3, severity: 'nit' as const, status: 'resolved' as const, threadId: 'PRRT_resolved' },
+        { title: 'Bug C', file: 'src/app.ts', line: 3, severity: 'nitpick' as const, status: 'resolved' as const, threadId: 'PRRT_resolved' },
       ],
       recapContext: 'previous context',
     });
@@ -2588,7 +2588,7 @@ describe('runFullReview orchestration', () => {
 
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings: [
-        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'required' as const, status: 'open' as const, threadId: 'PRRT_fail' },
+        { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_fail' },
       ],
       recapContext: 'previous context',
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -860,16 +860,14 @@ async function runFullReview(
     core.setOutput('findings_count', result.findings.length.toString());
     core.setOutput('findings_json', JSON.stringify(result.findings));
 
-    const severityCounts = { blocker: 0, warning: 0, suggestion: 0, nitpick: 0, ignore: 0 };
-    for (const f of result.findings) {
-      severityCounts[f.severity]++;
-    }
-    core.setOutput('severity_counts', JSON.stringify(severityCounts));
+    // `result.findings` excludes 'ignore' severity (filtered in review.ts), so
+    // the counts here mirror `severityMap` above and the `stats.severity` output.
+    core.setOutput('severity_counts', JSON.stringify(severityMap));
 
     core.setOutput('judge_model', judgeModel);
 
     core.info(`Review complete: ${result.verdict} with ${result.findings.length} findings`);
-    core.info(`Severity breakdown: ${severityCounts.blocker} blocker, ${severityCounts.warning} warning, ${severityCounts.suggestion} suggestion, ${severityCounts.nitpick} nitpick, ${severityCounts.ignore} ignore`);
+    core.info(`Severity breakdown: ${severityMap.blocker} blocker, ${severityMap.warning} warning, ${severityMap.suggestion} suggestion, ${severityMap.nitpick} nitpick`);
   } catch (error) {
     if (dashboardFlushTimer) {
       clearTimeout(dashboardFlushTimer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -626,16 +626,16 @@ async function runFullReview(
     }
 
     // Route findings based on nit_handling config:
-    // - required + suggestion: always go to inline PR comments
-    // - nit: inline comments if nit_handling === 'comments', nit issue if 'issues'
+    // - blocker + warning + suggestion: always go to inline PR comments
+    // - nitpick: inline comments if nit_handling === 'comments', nit issue if 'issues'
     const nitHandling = config.nit_handling ?? 'issues';
-    const nitFindings = result.findings.filter(f => f.severity === 'nit');
+    const nitFindings = result.findings.filter(f => f.severity === 'nitpick');
     const inlineFindings = nitHandling === 'comments'
       ? result.findings
-      : result.findings.filter(f => f.severity !== 'nit');
+      : result.findings.filter(f => f.severity !== 'nitpick');
 
     const reviewTimeMs = Date.now() - startTime;
-    const severityMap: Record<string, number> = { required: 0, suggestion: 0, nit: 0 };
+    const severityMap: Record<string, number> = { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 };
     for (const f of result.findings) {
       if (f.severity in severityMap) severityMap[f.severity]++;
     }
@@ -860,7 +860,7 @@ async function runFullReview(
     core.setOutput('findings_count', result.findings.length.toString());
     core.setOutput('findings_json', JSON.stringify(result.findings));
 
-    const severityCounts = { required: 0, suggestion: 0, nit: 0, ignore: 0 };
+    const severityCounts = { blocker: 0, warning: 0, suggestion: 0, nitpick: 0, ignore: 0 };
     for (const f of result.findings) {
       severityCounts[f.severity]++;
     }
@@ -869,7 +869,7 @@ async function runFullReview(
     core.setOutput('judge_model', judgeModel);
 
     core.info(`Review complete: ${result.verdict} with ${result.findings.length} findings`);
-    core.info(`Severity breakdown: ${severityCounts.required} required, ${severityCounts.suggestion} suggestion, ${severityCounts.nit} nit, ${severityCounts.ignore} ignore`);
+    core.info(`Severity breakdown: ${severityCounts.blocker} blocker, ${severityCounts.warning} warning, ${severityCounts.suggestion} suggestion, ${severityCounts.nitpick} nitpick, ${severityCounts.ignore} ignore`);
   } catch (error) {
     if (dashboardFlushTimer) {
       clearTimeout(dashboardFlushTimer);

--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -656,7 +656,7 @@ describe('handlePRComment', () => {
   it('dispatches triage command', async () => {
     setContext({ comment: { id: 42, body: '@manki triage', user: { type: 'User' }, author_association: 'COLLABORATOR' } });
     const octokit = createMockOctokit();
-    octokit.rest.issues.get.mockResolvedValue({ data: { body: '- [x] 💡 **Fix bug** — `src/a.ts:1`\n- [ ] 💡 **Nit** — `src/b.ts:2`' } });
+    octokit.rest.issues.get.mockResolvedValue({ data: { body: '- [x] 💡 **Fix bug** — `src/a.ts:1`\n- [ ] 💡 **Nitpick** — `src/b.ts:2`' } });
     await handlePRComment(octokit, null, 'test-owner', 'test-repo', 1);
     expect(ghUtils.reactToIssueComment).toHaveBeenCalledWith(octokit, 'test-owner', 'test-repo', 42, 'eyes');
     expect(octokit.rest.issues.create).toHaveBeenCalled();

--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -245,6 +245,20 @@ describe('parseTriageBody', () => {
     expect(result.accepted).toEqual([]);
     expect(result.rejected).toEqual([]);
   });
+
+  it('still parses legacy 💡 suggestion emoji from pre-rename triage comments', () => {
+    const body = [
+      '- [x] 💡 **Legacy accepted** — `src/legacy.ts:1`',
+      '- [ ] 💡 **Legacy rejected** — `src/legacy.ts:2`',
+    ].join('\n');
+    const result = parseTriageBody(body);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.accepted[0].title).toBe('Legacy accepted');
+    expect(result.accepted[0].ref).toBe('src/legacy.ts:1');
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].title).toBe('Legacy rejected');
+    expect(result.rejected[0].ref).toBe('src/legacy.ts:2');
+  });
 });
 
 describe('extractFindingContent', () => {

--- a/src/interaction.test.ts
+++ b/src/interaction.test.ts
@@ -656,7 +656,7 @@ describe('handlePRComment', () => {
   it('dispatches triage command', async () => {
     setContext({ comment: { id: 42, body: '@manki triage', user: { type: 'User' }, author_association: 'COLLABORATOR' } });
     const octokit = createMockOctokit();
-    octokit.rest.issues.get.mockResolvedValue({ data: { body: '- [x] 💡 **Fix bug** — `src/a.ts:1`\n- [ ] 💡 **Nitpick** — `src/b.ts:2`' } });
+    octokit.rest.issues.get.mockResolvedValue({ data: { body: '- [x] ✨ **Fix bug** — `src/a.ts:1`\n- [ ] 📝 **Nitpick** — `src/b.ts:2`' } });
     await handlePRComment(octokit, null, 'test-owner', 'test-repo', 1);
     expect(ghUtils.reactToIssueComment).toHaveBeenCalledWith(octokit, 'test-owner', 'test-repo', 42, 'eyes');
     expect(octokit.rest.issues.create).toHaveBeenCalled();

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -854,7 +854,7 @@ interface FindingContent {
 }
 
 function parseTriageBody(body: string): TriageResult {
-  const headerRegex = /^- \[([ x])\] (?:<details><summary>)?[📝💡❓🚫] \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmiu;
+  const headerRegex = /^- \[([ x])\] (?:<details><summary>)?(?:📝|💡|✨|⚠️|❓|🚫|⚪) \*\*(.+?)\*\* — (?:`|<code>)(.+?)(?:`|<\/code>)/gmiu;
 
   const accepted: TriageFinding[] = [];
   const rejected: TriageFinding[] = [];

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -91,9 +91,9 @@ const makeMemory = (overrides: Partial<RepoMemory> = {}): RepoMemory => ({
 describe('buildJudgeSystemPrompt', () => {
   it('contains severity definitions', () => {
     const prompt = buildJudgeSystemPrompt(makeConfig(), 5);
-    expect(prompt).toContain('required');
+    expect(prompt).toContain('blocker');
     expect(prompt).toContain('suggestion');
-    expect(prompt).toContain('nit');
+    expect(prompt).toContain('nitpick');
     expect(prompt).toContain('ignore');
   });
 
@@ -183,7 +183,7 @@ describe('buildJudgeSystemPrompt', () => {
     expect(prompt).toContain('**Impact**');
     expect(prompt).toContain('**Likelihood**');
     expect(prompt).toContain('**Severity mapping:**');
-    expect(prompt).toContain('Critical/High impact + Certain/Probable likelihood');
+    expect(prompt).toContain('correctness bug, data loss risk, or security issue');
   });
 
   it('uses follow-up summary instruction when isFollowUp is true', () => {
@@ -358,7 +358,7 @@ describe('buildJudgeUserMessage', () => {
   it('includes open threads section when openThreads provided', () => {
     const findings = [makeFinding()];
     const openThreads = [
-      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'required' },
+      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'blocker' },
       { threadId: 'PRRT_def', title: 'Unused import', file: 'src/bar.ts', line: 20, severity: 'suggestion' },
     ];
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
@@ -393,14 +393,14 @@ describe('buildJudgeUserMessage', () => {
       findings: [
         {
           fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Null check') },
-          severity: 'required',
+          severity: 'blocker',
           title: 'Null check',
           authorReply: 'agree',
           threadId: 'PRRT_1',
         },
         {
           fingerprint: { file: 'src/b.ts', lineStart: 20, lineEnd: 20, slug: titleToSlug('Unused import') },
-          severity: 'nit',
+          severity: 'nitpick',
           title: 'Unused import',
           authorReply: 'disagree',
         },
@@ -451,7 +451,7 @@ describe('buildJudgeUserMessage', () => {
       findings: [
         {
           fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug('Real') },
-          severity: 'required',
+          severity: 'blocker',
           title: 'Real',
           authorReply: 'none',
         },
@@ -492,7 +492,7 @@ describe('buildJudgeUserMessage', () => {
         findings: [
           {
             fingerprint: { file: 'b.ts', lineStart: 5, lineEnd: 5, slug: 'Real' },
-            severity: 'required',
+            severity: 'blocker',
             title: 'Real finding',
             authorReply: 'none',
           },
@@ -534,7 +534,7 @@ describe('buildJudgeUserMessage', () => {
         round: 2,
         commitSha: 'b',
         timestamp: 't',
-        findings: [{ fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 'y' }, severity: 'required', title: 'RealFinding', authorReply: 'none' }],
+        findings: [{ fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 'y' }, severity: 'blocker', title: 'RealFinding', authorReply: 'none' }],
       },
     ];
     const msg = buildJudgeUserMessage([makeFinding()], new Map(), '', undefined, undefined, undefined, undefined, priorRounds);
@@ -551,7 +551,7 @@ describe('buildJudgeUserMessage', () => {
       timestamp: 't',
       findings: [{
         fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug('Finding') },
-        severity: 'required',
+        severity: 'blocker',
         title: 'Finding',
         authorReply: 'none',
       }],
@@ -571,7 +571,7 @@ describe('buildJudgeUserMessage', () => {
       timestamp: 't',
       findings: [{
         fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: titleToSlug('Long') },
-        severity: 'required',
+        severity: 'blocker',
         title: longTitle,
         authorReply: 'none',
       }],
@@ -636,7 +636,7 @@ describe('parseJudgeResponse', () => {
     const json = JSON.stringify({
       summary: 'Clean PR with one minor issue.',
       findings: [
-        { title: 'Bug found', severity: 'required', reasoning: 'This is a real bug.', confidence: 'high' },
+        { title: 'Bug found', severity: 'blocker', reasoning: 'This is a real bug.', confidence: 'high' },
       ],
     });
 
@@ -644,14 +644,14 @@ describe('parseJudgeResponse', () => {
     expect(result.summary).toBe('Clean PR with one minor issue.');
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0].title).toBe('Bug found');
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].reasoning).toBe('This is a real bug.');
     expect(result.findings[0].confidence).toBe('high');
   });
 
   it('falls back to default summary when plain array is returned', () => {
     const json = JSON.stringify([
-      { title: 'Bug found', severity: 'required', reasoning: 'This is a real bug.', confidence: 'high' },
+      { title: 'Bug found', severity: 'blocker', reasoning: 'This is a real bug.', confidence: 'high' },
     ]);
 
     const result = parseJudgeResponse(json);
@@ -758,7 +758,7 @@ describe('parseJudgeResponse', () => {
   });
 
   it('handles missing title and reasoning gracefully', () => {
-    const json = JSON.stringify([{ severity: 'nit' }]);
+    const json = JSON.stringify([{ severity: 'nitpick' }]);
 
     const result = parseJudgeResponse(json);
     expect(result.findings).toHaveLength(1);
@@ -768,13 +768,13 @@ describe('parseJudgeResponse', () => {
 
   it('parses multiple findings', () => {
     const json = JSON.stringify([
-      { title: 'A', severity: 'required', reasoning: 'Bug.', confidence: 'high' },
+      { title: 'A', severity: 'blocker', reasoning: 'Bug.', confidence: 'high' },
       { title: 'B', severity: 'ignore', reasoning: 'False positive.', confidence: 'low' },
     ]);
 
     const result = parseJudgeResponse(json);
     expect(result.findings).toHaveLength(2);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[1].severity).toBe('ignore');
   });
 
@@ -956,7 +956,7 @@ describe('runJudgeAgent', () => {
   it('returns originals when judge response is empty', async () => {
     mockSendMessage.mockResolvedValue({ content: '' });
 
-    const finding = makeFinding({ severity: 'required' });
+    const finding = makeFinding({ severity: 'blocker' });
     const input: JudgeInput = {
       findings: [finding],
       diff: makeDiff(),
@@ -967,7 +967,7 @@ describe('runJudgeAgent', () => {
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].judgeNotes).toBeUndefined();
   });
 
@@ -975,7 +975,7 @@ describe('runJudgeAgent', () => {
     const judgedResponse = JSON.stringify({
       summary: 'Mixed findings.',
       findings: [
-        { title: 'Different title', severity: 'nit', reasoning: 'Minor.', confidence: 'low' },
+        { title: 'Different title', severity: 'nitpick', reasoning: 'Minor.', confidence: 'low' },
         { title: 'Unused variable cleanup', severity: 'ignore', reasoning: 'Not real.', confidence: 'high' },
       ],
     });
@@ -1000,8 +1000,8 @@ describe('runJudgeAgent', () => {
     // "Unused variable" should fuzzy-match "Unused variable cleanup" => severity 'ignore'
     expect(result.findings[0].severity).toBe('ignore');
     expect(result.findings[0].judgeNotes).toBe('Not real.');
-    // "Something completely different" matches "Different title" by position => severity 'nit'
-    expect(result.findings[1].severity).toBe('nit');
+    // "Something completely different" matches "Different title" by position => severity 'nitpick'
+    expect(result.findings[1].severity).toBe('nitpick');
     expect(result.findings[1].judgeNotes).toBe('Minor.');
   });
 
@@ -1048,7 +1048,7 @@ describe('runJudgeAgent', () => {
       repoContext: '',
       agentCount: 3,
       openThreads: [
-        { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'required' },
+        { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'blocker' },
       ],
     };
 
@@ -1069,7 +1069,7 @@ describe('runJudgeAgent', () => {
       findings: [
         {
           title: 'Unused variable',
-          severity: 'required',
+          severity: 'blocker',
           reasoning: 'Technically a bug.',
           confidence: 'high',
           reachability: 'hypothetical',
@@ -1089,8 +1089,8 @@ describe('runJudgeAgent', () => {
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].severity).toBe('nit');
-    expect(result.findings[0].originalSeverity).toBe('required');
+    expect(result.findings[0].severity).toBe('nitpick');
+    expect(result.findings[0].originalSeverity).toBe('blocker');
     expect(result.findings[0].tags).toEqual(['defensive-hardening']);
     expect(result.findings[0].reachability).toBe('hypothetical');
   });
@@ -1120,7 +1120,7 @@ describe('runJudgeAgent', () => {
     };
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].originalSeverity).toBe('suggestion');
     expect(result.findings[0].tags).toEqual(['defensive-hardening']);
   });
@@ -1131,7 +1131,7 @@ describe('runJudgeAgent', () => {
       findings: [
         {
           title: 'Unused variable',
-          severity: 'required',
+          severity: 'blocker',
           reasoning: 'Null deref on every call.',
           confidence: 'high',
           reachability: 'reachable',
@@ -1149,7 +1149,7 @@ describe('runJudgeAgent', () => {
     };
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].tags).toBeUndefined();
     expect(result.findings[0].reachability).toBe('reachable');
   });
@@ -1234,7 +1234,7 @@ describe('runJudgeAgent', () => {
       summary: 'Two findings, one prior match.',
       findings: [
         { title: 'Null check', severity: 'suggestion', reasoning: 'Prior agreed.', confidence: 'high' },
-        { title: 'Missing error handler', severity: 'required', reasoning: 'Real bug.', confidence: 'high' },
+        { title: 'Missing error handler', severity: 'blocker', reasoning: 'Real bug.', confidence: 'high' },
       ],
     });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
@@ -1254,7 +1254,7 @@ describe('runJudgeAgent', () => {
     const input: JudgeInput = {
       findings: [
         makeFinding({ title: 'Null check', severity: 'suggestion', line: 10 }),
-        makeFinding({ title: 'Missing error handler', severity: 'required', line: 50, file: 'src/other.ts' }),
+        makeFinding({ title: 'Missing error handler', severity: 'blocker', line: 50, file: 'src/other.ts' }),
       ],
       diff: makeDiff([
         makeDiffFile(),
@@ -1278,7 +1278,7 @@ describe('runJudgeAgent', () => {
 
     // Non-matching finding must be returned with judge-assigned severity unchanged.
     expect(errorHandler).toBeDefined();
-    expect(errorHandler!.severity).toBe('required');
+    expect(errorHandler!.severity).toBe('blocker');
     expect(errorHandler!.tags).toBeUndefined();
   });
 
@@ -1343,7 +1343,7 @@ describe('runJudgeAgent', () => {
         findings: [
           {
             fingerprint: { file: diffFile, lineStart: 10, lineEnd: 10, slug: 'clamp-value' },
-            severity: 'required',
+            severity: 'blocker',
             title: 'Clamp value to safe integer',
             authorReply: 'none',
             suggestedFix,
@@ -1374,7 +1374,7 @@ describe('runJudgeAgent', () => {
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].originalSeverity).toBe('suggestion');
     expect(result.findings[0].tags).toContain('own-proposal-followup');
     expect(result.findings[0].judgeNotes).toContain('Own-proposal follow-up: implements round 1 finding "Clamp value to safe integer"');
@@ -1477,38 +1477,38 @@ describe('mapJudgedToFindings', () => {
       makeFinding({ title: 'Bug B', severity: 'suggestion', reviewers: ['R2'], file: 'b.ts' }),
     ];
     const judged: JudgedFinding[] = [
-      { title: 'Bug A', severity: 'required', reasoning: 'Real bug.', confidence: 'high' },
-      { title: 'Bug B', severity: 'nit', reasoning: 'Minor.', confidence: 'low' },
+      { title: 'Bug A', severity: 'blocker', reasoning: 'Real bug.', confidence: 'high' },
+      { title: 'Bug B', severity: 'nitpick', reasoning: 'Minor.', confidence: 'low' },
     ];
 
     const result = mapJudgedToFindings(originals, judged);
     expect(result).toHaveLength(2);
-    expect(result[0].severity).toBe('required');
-    expect(result[1].severity).toBe('nit');
+    expect(result[0].severity).toBe('blocker');
+    expect(result[1].severity).toBe('nitpick');
   });
 
   it('handles fewer judge results by merging duplicates', () => {
     const originals = [
       makeFinding({ title: 'Null check missing', severity: 'suggestion', reviewers: ['SecurityReviewer'] }),
-      makeFinding({ title: 'Missing null check', severity: 'required', reviewers: ['BugReviewer'] }),
-      makeFinding({ title: 'Unused import', severity: 'nit', reviewers: ['StyleReviewer'] }),
+      makeFinding({ title: 'Missing null check', severity: 'blocker', reviewers: ['BugReviewer'] }),
+      makeFinding({ title: 'Unused import', severity: 'nitpick', reviewers: ['StyleReviewer'] }),
     ];
     const judged: JudgedFinding[] = [
-      { title: 'Null check missing', severity: 'required', reasoning: 'Merged findings 1 and 2 — same issue.', confidence: 'high' },
-      { title: 'Unused import', severity: 'nit', reasoning: 'Minor style issue.', confidence: 'medium' },
+      { title: 'Null check missing', severity: 'blocker', reasoning: 'Merged findings 1 and 2 — same issue.', confidence: 'high' },
+      { title: 'Unused import', severity: 'nitpick', reasoning: 'Minor style issue.', confidence: 'medium' },
     ];
 
     const result = mapJudgedToFindings(originals, judged);
     expect(result).toHaveLength(2);
 
     // First result should have merged reviewers from both null-check findings
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].reviewers).toContain('SecurityReviewer');
     expect(result[0].reviewers).toContain('BugReviewer');
     expect(result[0].judgeNotes).toContain('Merged findings 1 and 2');
 
     // Second result maps normally
-    expect(result[1].severity).toBe('nit');
+    expect(result[1].severity).toBe('nitpick');
     expect(result[1].reviewers).toEqual(['StyleReviewer']);
   });
 
@@ -1535,7 +1535,7 @@ describe('mapJudgedToFindings', () => {
       makeFinding({ title: 'Null check missing', description: 'This is a much more detailed description of the null check issue.' }),
     ];
     const judged: JudgedFinding[] = [
-      { title: 'Null check', severity: 'required', reasoning: 'Merged.', confidence: 'high' },
+      { title: 'Null check', severity: 'blocker', reasoning: 'Merged.', confidence: 'high' },
     ];
 
     const result = mapJudgedToFindings(originals, judged);
@@ -1544,7 +1544,7 @@ describe('mapJudgedToFindings', () => {
   });
 
   it.each([
-    ['required' as const],
+    ['blocker' as const],
     ['suggestion' as const],
   ])('demotes hypothetical %s findings to nit and tags defensive-hardening', (severity) => {
     const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
@@ -1560,7 +1560,7 @@ describe('mapJudgedToFindings', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].originalSeverity).toBe(severity);
     expect(result[0].tags).toEqual(['defensive-hardening']);
     expect(result[0].reachability).toBe('hypothetical');
@@ -1568,11 +1568,11 @@ describe('mapJudgedToFindings', () => {
   });
 
   it('appends defensive-hardening without dropping pre-existing tags', () => {
-    const originals = [makeFinding({ title: 'Bug', severity: 'required', tags: ['security'] })];
+    const originals = [makeFinding({ title: 'Bug', severity: 'blocker', tags: ['security'] })];
     const judged: JudgedFinding[] = [
       {
         title: 'Bug',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Correct but unreachable.',
         confidence: 'high',
         reachability: 'hypothetical',
@@ -1590,7 +1590,7 @@ describe('mapJudgedToFindings', () => {
     const judged: JudgedFinding[] = [
       {
         title: 'Bug',
-        severity: 'nit',
+        severity: 'nitpick',
         reasoning: 'Minor.',
         confidence: 'low',
         reachability: 'hypothetical',
@@ -1598,14 +1598,14 @@ describe('mapJudgedToFindings', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
     expect(result[0].reachability).toBe('hypothetical');
   });
 
   it('leaves hypothetical ignore findings unchanged and does not tag', () => {
-    const originals = [makeFinding({ title: 'Bug', severity: 'required' })];
+    const originals = [makeFinding({ title: 'Bug', severity: 'blocker' })];
     const judged: JudgedFinding[] = [
       {
         title: 'Bug',
@@ -1628,7 +1628,7 @@ describe('mapJudgedToFindings', () => {
     const judged: JudgedFinding[] = [
       {
         title: 'Bug',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Real bug.',
         confidence: 'high',
         reachability: 'reachable',
@@ -1636,7 +1636,7 @@ describe('mapJudgedToFindings', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
     expect(result[0].reachability).toBe('reachable');
@@ -1647,7 +1647,7 @@ describe('mapJudgedToFindings', () => {
     const judged: JudgedFinding[] = [
       {
         title: 'Bug',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Callers outside diff.',
         confidence: 'medium',
         reachability: 'unknown',
@@ -1655,7 +1655,7 @@ describe('mapJudgedToFindings', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
     expect(result[0].reachability).toBe('unknown');
@@ -1664,11 +1664,11 @@ describe('mapJudgedToFindings', () => {
   it('does not demote when reachability is absent', () => {
     const originals = [makeFinding({ title: 'Bug', severity: 'suggestion' })];
     const judged: JudgedFinding[] = [
-      { title: 'Bug', severity: 'required', reasoning: 'Real bug.', confidence: 'high' },
+      { title: 'Bug', severity: 'blocker', reasoning: 'Real bug.', confidence: 'high' },
     ];
 
     const result = mapJudgedToFindings(originals, judged);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
     expect(result[0].reachability).toBeUndefined();
@@ -1676,13 +1676,13 @@ describe('mapJudgedToFindings', () => {
 
   it('demotes hypothetical findings when merging duplicates', () => {
     const originals = [
-      makeFinding({ title: 'Defensive guard', severity: 'required', reviewers: ['R1'] }),
+      makeFinding({ title: 'Defensive guard', severity: 'blocker', reviewers: ['R1'] }),
       makeFinding({ title: 'Defensive guard missing', severity: 'suggestion', reviewers: ['R2'] }),
     ];
     const judged: JudgedFinding[] = [
       {
         title: 'Defensive guard',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Merged.',
         confidence: 'high',
         reachability: 'hypothetical',
@@ -1692,8 +1692,8 @@ describe('mapJudgedToFindings', () => {
 
     const result = mapJudgedToFindings(originals, judged);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('nit');
-    expect(result[0].originalSeverity).toBe('required');
+    expect(result[0].severity).toBe('nitpick');
+    expect(result[0].originalSeverity).toBe('blocker');
     expect(result[0].tags).toEqual(['defensive-hardening']);
     expect(result[0].reachability).toBe('hypothetical');
   });
@@ -1704,12 +1704,12 @@ describe('mapJudgedToFindings', () => {
   ])('preserves severity when merging duplicates with reachability %s', (reachability) => {
     const originals = [
       makeFinding({ title: 'Null check', severity: 'suggestion', reviewers: ['R1'] }),
-      makeFinding({ title: 'Null check missing', severity: 'required', reviewers: ['R2'] }),
+      makeFinding({ title: 'Null check missing', severity: 'blocker', reviewers: ['R2'] }),
     ];
     const judged: JudgedFinding[] = [
       {
         title: 'Null check',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Merged.',
         confidence: 'high',
         reachability,
@@ -1718,7 +1718,7 @@ describe('mapJudgedToFindings', () => {
 
     const result = mapJudgedToFindings(originals, judged);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
     expect(result[0].reachability).toBe(reachability);
@@ -1742,7 +1742,7 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].originalSeverity).toBe('suggestion');
     expect(result[0].tags).toEqual(['own-proposal-followup']);
     expect(result[0].judgeNotes).toContain('Own-proposal follow-up: implements round 2 finding "Clamp future time"');
@@ -1755,7 +1755,7 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].originalSeverity).toBe('suggestion');
     expect(result[0].tags).toEqual(['own-proposal-followup']);
   });
@@ -1763,11 +1763,11 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
   it('tags a nit finding without setting originalSeverity', () => {
     const originals = [makeFinding({ title: 'Style nit', severity: 'suggestion', line: 12 })];
     const judged: JudgedFinding[] = [
-      { title: 'Style nit', severity: 'nit', reasoning: 'Tiny.', confidence: 'low' },
+      { title: 'Style nit', severity: 'nitpick', reasoning: 'Tiny.', confidence: 'low' },
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toEqual(['own-proposal-followup']);
   });
@@ -1789,7 +1789,7 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     const judged: JudgedFinding[] = [
       {
         title: 'Real bug',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Triggered by caller X.',
         confidence: 'high',
         reachability: 'reachable',
@@ -1797,24 +1797,24 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].reachability).toBe('reachable');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
   });
 
   it('does not demote a required finding when judge omits reachability annotation', () => {
-    // Guard must fire on severity alone: when the judge says 'required' but provides
+    // Guard must fire on severity alone: when the judge says 'blocker' but provides
     // no reachability, applyReachability leaves finding.reachability undefined.
-    // The old compound guard (reachability === 'reachable' && severity === 'required')
+    // The old compound guard (reachability === 'reachable' && severity === 'blocker')
     // would be false here, incorrectly demoting the finding to nit.
     const originals = [makeFinding({ title: 'Confirmed bug', severity: 'suggestion', line: 10 })];
     const judged: JudgedFinding[] = [
-      { title: 'Confirmed bug', severity: 'required', reasoning: 'Real.', confidence: 'high' },
+      { title: 'Confirmed bug', severity: 'blocker', reasoning: 'Real.', confidence: 'high' },
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].originalSeverity).toBeUndefined();
     expect(result[0].tags).toBeUndefined();
   });
@@ -1846,18 +1846,18 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].tags).toContain('own-proposal-followup');
   });
 
   it('leaves findings outside the provenance range unchanged', () => {
     const originals = [makeFinding({ title: 'Elsewhere', severity: 'suggestion', line: 50 })];
     const judged: JudgedFinding[] = [
-      { title: 'Elsewhere', severity: 'required', reasoning: 'Different spot.', confidence: 'high' },
+      { title: 'Elsewhere', severity: 'blocker', reasoning: 'Different spot.', confidence: 'high' },
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].tags).toBeUndefined();
     expect(result[0].originalSeverity).toBeUndefined();
   });
@@ -1881,7 +1881,7 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     const judged: JudgedFinding[] = [
       {
         title: 'Guard',
-        severity: 'required',
+        severity: 'blocker',
         reasoning: 'Unreachable.',
         confidence: 'high',
         reachability: 'hypothetical',
@@ -1890,15 +1890,15 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
     ];
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
-    expect(result[0].severity).toBe('nit');
-    expect(result[0].originalSeverity).toBe('required');
+    expect(result[0].severity).toBe('nitpick');
+    expect(result[0].originalSeverity).toBe('blocker');
     expect(result[0].tags).toContain('defensive-hardening');
     expect(result[0].tags).toContain('own-proposal-followup');
   });
 
   it('demotes through mapMergedFindings when judge merges duplicates', () => {
     const originals = [
-      makeFinding({ title: 'Clamp A', severity: 'required', line: 10, reviewers: ['R1'] }),
+      makeFinding({ title: 'Clamp A', severity: 'blocker', line: 10, reviewers: ['R1'] }),
       makeFinding({ title: 'Clamp A missing', severity: 'suggestion', line: 10, reviewers: ['R2'] }),
     ];
     const judged: JudgedFinding[] = [
@@ -1907,7 +1907,7 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
 
     const result = mapJudgedToFindings(originals, judged, [makeProvenance()]);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('nit');
+    expect(result[0].severity).toBe('nitpick');
     expect(result[0].originalSeverity).toBe('suggestion');
     expect(result[0].tags).toEqual(['own-proposal-followup']);
   });
@@ -1915,11 +1915,11 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
   it('is a no-op when provenanceMap is undefined or empty', () => {
     const originals = [makeFinding({ title: 'Bug', severity: 'suggestion', line: 10 })];
     const judged: JudgedFinding[] = [
-      { title: 'Bug', severity: 'required', reasoning: 'Real.', confidence: 'high' },
+      { title: 'Bug', severity: 'blocker', reasoning: 'Real.', confidence: 'high' },
     ];
 
-    expect(mapJudgedToFindings(originals, judged)[0].severity).toBe('required');
-    expect(mapJudgedToFindings(originals, judged, [])[0].severity).toBe('required');
+    expect(mapJudgedToFindings(originals, judged)[0].severity).toBe('blocker');
+    expect(mapJudgedToFindings(originals, judged, [])[0].severity).toBe('blocker');
   });
 
   it('sanitizes newlines and backticks in originatingTitle embedded in judgeNotes', () => {
@@ -1941,7 +1941,7 @@ describe('mapJudgedToFindings own-proposal demotion', () => {
 describe('computeProvenanceMap', () => {
   const makeHandoverFinding = (overrides: Partial<HandoverFinding> = {}): HandoverFinding => ({
     fingerprint: { file: 'src/a.ts', lineStart: 1, lineEnd: 1, slug: 'Clamp-future-time' },
-    severity: 'required',
+    severity: 'blocker',
     title: 'Clamp future time',
     authorReply: 'none',
     ...overrides,
@@ -2153,14 +2153,14 @@ describe('deduplicateFindings', () => {
 
   it('preserves the first occurrence and drops subsequent duplicates', () => {
     const findings = [
-      makeFinding({ title: 'Bug', file: 'x.ts', severity: 'required', description: 'First' }),
-      makeFinding({ title: 'Bug', file: 'x.ts', severity: 'nit', description: 'Second' }),
+      makeFinding({ title: 'Bug', file: 'x.ts', severity: 'blocker', description: 'First' }),
+      makeFinding({ title: 'Bug', file: 'x.ts', severity: 'nitpick', description: 'Second' }),
       makeFinding({ title: 'Bug', file: 'x.ts', severity: 'suggestion', description: 'Third' }),
     ];
 
     const result = deduplicateFindings(findings);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
     expect(result[0].description).toBe('First');
   });
 
@@ -2205,17 +2205,17 @@ describe('applyCrossRoundSuppression', () => {
   });
 
   it('does not suppress required findings even when prior agreed match exists', () => {
-    const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'required' })];
+    const findings = [makeFinding({ title: 'Unused variable', file: 'src/a.ts', line: 10, severity: 'blocker' })];
     const prior = [makePriorRound([{
       fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Unused variable') },
-      severity: 'required',
+      severity: 'blocker',
       title: 'Unused variable',
       authorReply: 'agree',
     }])];
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.suppressedCount).toBe(0);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].tags).toBeUndefined();
   });
 
@@ -2280,7 +2280,7 @@ describe('applyCrossRoundSuppression', () => {
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 12,
-      severity: 'required',
+      severity: 'blocker',
       description: 'Replace the old helper and avoid the previous pattern instead.',
     })];
     const prior = [makePriorRound([{
@@ -2293,7 +2293,7 @@ describe('applyCrossRoundSuppression', () => {
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.suppressedCount).toBe(0);
     expect(result.demotedCount).toBe(0);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].originalSeverity).toBeUndefined();
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
@@ -2326,7 +2326,7 @@ describe('applyCrossRoundSuppression', () => {
       title: 'Null pointer dereference',
       file: 'src/a.ts',
       line: 20,
-      severity: 'required',
+      severity: 'blocker',
       description: 'Remove the null check — avoid dereferencing here instead.',
     })];
     const prior = [makePriorRound([{
@@ -2339,7 +2339,7 @@ describe('applyCrossRoundSuppression', () => {
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(0);
     expect(result.suppressedCount).toBe(0);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].originalSeverity).toBeUndefined();
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
@@ -2362,7 +2362,7 @@ describe('applyCrossRoundSuppression', () => {
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.suppressedCount).toBe(0);
     expect(result.demotedCount).toBe(1);
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].originalSeverity).toBe('suggestion');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
     expect(result.findings[0].tags).not.toContain('suppressed-by-ratchet');
@@ -2386,7 +2386,7 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(1);
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
 
@@ -2395,7 +2395,7 @@ describe('applyCrossRoundSuppression', () => {
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 12,
-      severity: 'nit',
+      severity: 'nitpick',
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
@@ -2416,7 +2416,7 @@ describe('applyCrossRoundSuppression', () => {
 
   it('does not tag or count findings already marked ignore by the judge', () => {
     // The judge may return findings with severity `ignore` (explicitly dropped). The ratchet
-    // condition `current.severity !== 'required'` is true for `ignore`, so without an early
+    // condition `current.severity !== 'blocker'` is true for `ignore`, so without an early
     // return the ratchet would fire, add a tag, and inflate suppressedCount.
     const findings = [makeFinding({
       title: 'Naming convention',
@@ -2482,7 +2482,7 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(1);
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].originalSeverity).toBe('suggestion');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
@@ -2505,7 +2505,7 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(0);
-    expect(result.findings[0].severity).not.toBe('nit');
+    expect(result.findings[0].severity).not.toBe('nitpick');
     expect(result.findings[0].tags ?? []).not.toContain('contradicts-prior-round');
   });
 
@@ -2526,19 +2526,19 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(1);
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
 
   it('does not overwrite pre-existing originalSeverity when contradiction fires', () => {
-    // Simulates a finding that was already demoted by applyReachability (originalSeverity='required')
+    // Simulates a finding that was already demoted by applyReachability (originalSeverity='blocker')
     // before applyCrossRoundSuppression runs. The contradiction path must preserve it.
     const findings = [makeFinding({
       title: 'Naming convention',
       file: 'src/a.ts',
       line: 12,
       severity: 'suggestion',
-      originalSeverity: 'required',
+      originalSeverity: 'blocker',
       description: 'Replace the old helper instead.',
     })];
     const prior = [makePriorRound([{
@@ -2550,8 +2550,8 @@ describe('applyCrossRoundSuppression', () => {
 
     const result = applyCrossRoundSuppression(findings, prior);
     expect(result.demotedCount).toBe(1);
-    expect(result.findings[0].severity).toBe('nit');
-    expect(result.findings[0].originalSeverity).toBe('required');
+    expect(result.findings[0].severity).toBe('nitpick');
+    expect(result.findings[0].originalSeverity).toBe('blocker');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
 
@@ -2699,7 +2699,7 @@ describe('runJudgeAgent cross-round suppression', () => {
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
     expect(result.crossRoundDemoted).toBe(1);
     expect(result.crossRoundSuppressed).toBeUndefined();
-    expect(result.findings[0].severity).toBe('nit');
+    expect(result.findings[0].severity).toBe('nitpick');
     expect(result.findings[0].tags).toContain('contradicts-prior-round');
   });
 

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -673,7 +673,7 @@ describe('parseJudgeResponse', () => {
   });
 
   it('parses JSON wrapped in markdown code fences', () => {
-    const json = '```json\n[{"title":"Bug","severity":"required","reasoning":"Real bug.","confidence":"high"}]\n```';
+    const json = '```json\n[{"title":"Bug","severity":"blocker","reasoning":"Real bug.","confidence":"high"}]\n```';
 
     const result = parseJudgeResponse(json);
     expect(result.findings).toHaveLength(1);
@@ -1380,7 +1380,7 @@ describe('runJudgeAgent', () => {
     expect(result.findings[0].judgeNotes).toContain('Own-proposal follow-up: implements round 1 finding "Clamp value to safe integer"');
   });
 
-  it('does not demote a required finding when priorRounds contain matching suggestedFix in rawDiff', async () => {
+  it('does not demote a blocker finding when priorRounds contain matching suggestedFix in rawDiff', async () => {
     const suggestedFix = 'const clamped = Math.min(value, Number.MAX_SAFE_INTEGER);';
     const diffFile = 'src/utils.ts';
     const diffStartLine = 10;
@@ -1396,7 +1396,7 @@ describe('runJudgeAgent', () => {
         findings: [
           {
             fingerprint: { file: diffFile, lineStart: 10, lineEnd: 10, slug: 'clamp-value' },
-            severity: 'required',
+            severity: 'blocker',
             title: 'Clamp value to safe integer',
             authorReply: 'none',
             suggestedFix,
@@ -1408,13 +1408,13 @@ describe('runJudgeAgent', () => {
     const judgedResponse = JSON.stringify({
       summary: 'One finding.',
       findings: [
-        { title: 'Clamp value to safe integer', severity: 'required', reasoning: 'Real bug.', confidence: 'high' },
+        { title: 'Clamp value to safe integer', severity: 'blocker', reasoning: 'Real bug.', confidence: 'high' },
       ],
     });
     mockSendMessage.mockResolvedValue({ content: judgedResponse });
 
     const parsedDiff = makeDiff([makeDiffFile({ path: diffFile })]);
-    const finding = makeFinding({ title: 'Clamp value to safe integer', file: diffFile, line: diffStartLine, severity: 'required' });
+    const finding = makeFinding({ title: 'Clamp value to safe integer', file: diffFile, line: diffStartLine, severity: 'blocker' });
 
     const input: JudgeInput = {
       findings: [finding],
@@ -1427,7 +1427,7 @@ describe('runJudgeAgent', () => {
 
     const result = await runJudgeAgent(mockClient, makeConfig(), input);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].severity).toBe('required');
+    expect(result.findings[0].severity).toBe('blocker');
     expect(result.findings[0].originalSeverity).toBeUndefined();
     expect(result.findings[0].tags ?? []).not.toContain('own-proposal-followup');
     expect(result.findings[0].judgeNotes ?? '').not.toContain('Own-proposal follow-up');

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -303,19 +303,20 @@ Evaluate each finding on two dimensions:
 - Unlikely: requires unusual circumstances or rare conditions
 
 **Severity mapping:**
-- **required**: Critical/High impact + Certain/Probable likelihood, OR any Critical impact, OR patterns flagged as important in project memory
-- **suggestion**: High impact + Possible likelihood, OR Medium impact + Certain/Probable likelihood
-- **nit**: Low impact regardless of likelihood, or Medium impact + Unlikely likelihood
-- **ignore**: False positives, intentional patterns, style preferences, reviewer misunderstandings
+- **blocker**: correctness bug, data loss risk, or security issue. Must be fixed.
+- **warning**: real behavioral concern — e.g., an edge case that will fail, a misuse of an API that will produce wrong output, a race condition. Not catastrophic but shouldn't ship.
+- **suggestion**: improvement open to discussion — refactoring, deduplication, API clarity, code style. The code works today but could be cleaner.
+- **nitpick**: minor cosmetic — wording, formatting, tiny naming tweaks. Purely optional.
+- **ignore**: False positives, intentional patterns, style preferences, reviewer misunderstandings.
 
 **Calibration note**: LLMs tend toward leniency when judging code review findings. Counteract this bias:
 - When a finding is borderline between two severities, choose the higher one
-- A finding that "could cause problems" under realistic conditions is \`required\`, not \`suggestion\`
+- A finding that "could cause problems" under realistic conditions is \`blocker\`, not \`warning\`
 - Only downgrade a finding if you can articulate a specific reason the issue won't manifest
 
-Include your impact and likelihood assessment in the reasoning field (e.g., "Impact: High (silent data loss), Likelihood: Probable (happens on every error path) → required").
+Include your impact and likelihood assessment in the reasoning field (e.g., "Impact: High (silent data loss), Likelihood: Probable (happens on every error path) → blocker").
 
-Examples of **required** (high impact, certain/probable):
+Examples of **blocker** (correctness bug, data loss, or security):
   - SQL injection or unsanitized user input passed to any external system
   - Null/undefined dereference that will crash at runtime
   - Missing error handling that silently swallows failures
@@ -323,15 +324,22 @@ Examples of **required** (high impact, certain/probable):
   - Breaking API change without migration path
   - Unchecked return value where the error is silently discarded
   - Resource leak (file handle, connection, listener) not cleaned up on error path
-  - Race condition in concurrent code (shared mutable state without synchronization)
   - Missing input validation at a trust boundary (API endpoint, user input, external data)
 
-Examples of **suggestion** (medium impact, or high impact with lower likelihood):
-  - Error message lacks context that would help debugging (impact: medium, likelihood: certain)
-  - Function could be split to improve testability (impact: medium, likelihood: N/A)
-  - Missing timeout on HTTP request that could hang indefinitely (impact: high, likelihood: possible)
+Examples of **warning** (real behavioral concern, not catastrophic):
+  - Edge case that will produce wrong output under specific input
+  - Race condition in concurrent code (shared mutable state without synchronization)
+  - Missing timeout on HTTP request that could hang indefinitely
+  - Misuse of an API that will return stale or incorrect data
+  - Error message lacks context that would help debugging when a real failure occurs
 
-Examples of **nit**:
+Examples of **suggestion** (improvement open to discussion):
+  - Function could be split to improve testability
+  - Duplicate logic that could be deduplicated into a helper
+  - API could be clarified with better parameter names or return types
+  - Code style inconsistency within the module
+
+Examples of **nitpick** (minor cosmetic):
   - Variable name could be more descriptive
   - Inconsistent import ordering
   - Missing JSDoc on an exported function
@@ -351,7 +359,7 @@ For every finding, decide whether the failure mode it describes is **practically
 
 Populate \`reachability\` on every finding. When you choose \`hypothetical\`, also give a one-sentence \`reachabilityReasoning\` explaining why no current caller triggers the failure — this is how the author audits a demotion.
 
-Reachability is independent of severity. A finding can be \`required\` and \`hypothetical\`, or \`nit\` and \`reachable\`. Severity captures how bad the failure is; reachability captures whether it can actually happen today.
+Reachability is independent of severity. A finding can be \`blocker\` and \`hypothetical\`, or \`nitpick\` and \`reachable\`. Severity captures how bad the failure is; reachability captures whether it can actually happen today.
 
 ## Evaluation Criteria
 
@@ -384,8 +392,8 @@ Multiple independent reviewers reaching the same conclusion is strong evidence t
 
 If the PR description or linked issues contain acceptance criteria (checkbox items like "- [ ] criterion"):
 - Check if each criterion is addressed by the changes in this PR
-- An unmet acceptance criterion that the PR claims to implement should be flagged as \`required\`
-- A partially met criterion should be flagged as \`suggestion\` with details on what's missing
+- An unmet acceptance criterion that the PR claims to implement should be flagged as \`blocker\`
+- A partially met criterion should be flagged as \`warning\` with details on what's missing
 - Acceptance criteria from the issue that are clearly out of scope for this specific PR can be ignored
 
 ## Duplicate Detection
@@ -414,7 +422,7 @@ Respond with ONLY a JSON object (no markdown fences, no explanation):
   "findings": [
     {
       "title": "Short title matching or close to the original finding title",
-      "severity": "required" | "suggestion" | "nit" | "ignore",
+      "severity": "blocker" | "warning" | "suggestion" | "nitpick" | "ignore",
       "reasoning": "1-2 sentences explaining your judgment",
       "confidence": "high" | "medium" | "low",
       "reachability": "reachable" | "hypothetical" | "unknown",
@@ -817,16 +825,16 @@ function applyReachability(finding: Finding, judged: JudgedFinding): void {
     finding.reachabilityReasoning = judged.reachabilityReasoning;
   }
   if (judged.reachability !== 'hypothetical') return;
-  if (judged.severity !== 'required' && judged.severity !== 'suggestion') return;
+  if (judged.severity !== 'blocker' && judged.severity !== 'warning' && judged.severity !== 'suggestion') return;
   finding.originalSeverity = judged.severity;
-  finding.severity = 'nit';
+  finding.severity = 'nitpick';
   finding.tags = addTag(finding.tags, DEFENSIVE_HARDENING_TAG);
 }
 
 /**
  * Demote findings that flag code implementing a prior-round `suggestedFix`.
- * A reachable required bug introduced by the fix itself is preserved — only
- * caveat-level concerns are capped to nit.
+ * A reachable blocker bug introduced by the fix itself is preserved — only
+ * caveat-level concerns are capped to nitpick.
  */
 function applyOwnProposal(finding: Finding, provenanceMap?: ProvenanceEntry[]): void {
   if (!provenanceMap || provenanceMap.length === 0) return;
@@ -839,11 +847,11 @@ function applyOwnProposal(finding: Finding, provenanceMap?: ProvenanceEntry[]): 
   if (!match) return;
 
   if (finding.severity === 'ignore') return;
-  if (finding.severity === 'required') return;
+  if (finding.severity === 'blocker') return;
 
-  if (finding.severity !== 'nit') {
+  if (finding.severity !== 'nitpick') {
     finding.originalSeverity ??= finding.severity;
-    finding.severity = 'nit';
+    finding.severity = 'nitpick';
   }
 
   finding.tags = addTag(finding.tags, OWN_PROPOSAL_TAG);
@@ -909,13 +917,13 @@ function mapMergedFindings(
  * Apply cross-round suppression rules using prior-round handover state.
  *
  * Ratchet: if a prior finding with the same slug + file exists and the author
- * agreed, suppress the current finding unless it is `required`.
+ * agreed, suppress the current finding unless it is `blocker`.
  *
  * Contradiction: if a prior finding with the same slug + file + line proximity
  * exists, the author agreed, and the current finding uses a reversal word,
- * demote `suggestion` to `nit` and annotate `judgeNotes`. `required` findings
- * are intentionally excluded from contradiction demotion to prevent prompt
- * injection attacks where adversarial PR content could silently hide real bugs.
+ * demote `suggestion`/`warning` to `nitpick` and annotate `judgeNotes`. `blocker`
+ * findings are intentionally excluded from contradiction demotion to prevent
+ * prompt injection attacks where adversarial PR content could silently hide real bugs.
  */
 export function applyCrossRoundSuppression(
   findings: Finding[],
@@ -950,9 +958,9 @@ export function applyCrossRoundSuppression(
 
     const slug = titleToSlug(current.title);
 
-    // Contradiction is checked before ratchet for `suggestion` findings only.
-    // `required` and `nit` skip this branch: required is protected from any
-    // silent demotion (prompt-injection guard); nit falls through to ratchet.
+    // Contradiction is checked before ratchet for `warning`/`suggestion` findings only.
+    // `blocker` and `nitpick` skip this branch: blocker is protected from any
+    // silent demotion (prompt-injection guard); nitpick falls through to ratchet.
     const contradictionMatch = acceptedPriors.find(({ finding: prior }) =>
       prior.fingerprint.file === current.file
       && prior.fingerprint.slug === slug
@@ -961,9 +969,9 @@ export function applyCrossRoundSuppression(
         && current.line <= prior.fingerprint.lineEnd + LINE_WINDOW
       ),
     );
-    if (contradictionMatch && hasReversalWord(current) && current.severity === 'suggestion') {
+    if (contradictionMatch && hasReversalWord(current) && (current.severity === 'warning' || current.severity === 'suggestion')) {
       current.originalSeverity ??= current.severity;
-      current.severity = 'nit';
+      current.severity = 'nitpick';
       current.tags = addTag(current.tags, CONTRADICTION_TAG);
       const note = `Contradicts round ${contradictionMatch.round} guidance accepted by author`;
       current.judgeNotes = current.judgeNotes ? `${current.judgeNotes} ${note}` : note;
@@ -974,7 +982,7 @@ export function applyCrossRoundSuppression(
     const ratchetMatch = acceptedPriors.find(({ finding: prior }) =>
       prior.fingerprint.file === current.file && prior.fingerprint.slug === slug,
     );
-    if (ratchetMatch && current.severity !== 'required') {
+    if (ratchetMatch && current.severity !== 'blocker') {
       current.severity = 'ignore';
       current.tags = addTag(current.tags, RATCHET_SUPPRESSED_TAG);
       suppressedCount++;

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -833,7 +833,7 @@ function applyReachability(finding: Finding, judged: JudgedFinding): void {
 
 /**
  * Demote findings that flag code implementing a prior-round `suggestedFix`.
- * A reachable blocker bug introduced by the fix itself is preserved — only
+ * A reachable blocker bug introduced by the fix itself is preserved. Only
  * caveat-level concerns are capped to nitpick.
  */
 function applyOwnProposal(finding: Finding, provenanceMap?: ProvenanceEntry[]): void {

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -902,6 +902,46 @@ describe('loadHandover', () => {
     const result = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
     expect(result).toEqual(handover);
   });
+
+  it('migrates legacy severity values (`required` -> `blocker`, `nit` -> `nitpick`)', async () => {
+    const persisted = {
+      prNumber: 106,
+      repo: 'rust-dashcore',
+      rounds: [
+        {
+          round: 1,
+          commitSha: 'abc123',
+          timestamp: '2025-01-01T00:00:00Z',
+          findings: [
+            {
+              fingerprint: { file: 'src/a.rs', lineStart: 10, lineEnd: 10, slug: 'Old-blocker' },
+              severity: 'required',
+              title: 'Old blocker',
+              authorReply: 'agree',
+            },
+            {
+              fingerprint: { file: 'src/b.rs', lineStart: 20, lineEnd: 20, slug: 'Old-nit' },
+              severity: 'nit',
+              title: 'Old nit',
+              authorReply: 'none',
+            },
+            {
+              fingerprint: { file: 'src/c.rs', lineStart: 30, lineEnd: 30, slug: 'Current' },
+              severity: 'suggestion',
+              title: 'Current suggestion',
+              authorReply: 'none',
+            },
+          ],
+        },
+      ],
+    };
+    const octokit = mockJsonOctokit({ 'rust-dashcore/prs/106/handover.json': persisted });
+
+    const result = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
+    expect(result!.rounds[0].findings[0].severity).toBe('blocker');
+    expect(result!.rounds[0].findings[1].severity).toBe('nitpick');
+    expect(result!.rounds[0].findings[2].severity).toBe('suggestion');
+  });
 });
 
 describe('writeHandover', () => {

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -103,14 +103,14 @@ describe('applySuppressions', () => {
 
   it('never suppresses required-severity findings', () => {
     const findings = [
-      makeFinding({ severity: 'required', title: 'Unused variable in auth' }),
+      makeFinding({ severity: 'blocker', title: 'Unused variable in auth' }),
     ];
     const suppressions = [makeSuppression({ pattern: 'unused variable' })];
 
     const { kept, suppressed } = applySuppressions(findings, suppressions);
     expect(kept).toHaveLength(1);
     expect(suppressed).toHaveLength(0);
-    expect(kept[0].severity).toBe('required');
+    expect(kept[0].severity).toBe('blocker');
   });
 
   it('never suppresses ignore-severity findings', () => {
@@ -127,15 +127,15 @@ describe('applySuppressions', () => {
 
   it('suppresses suggestion and nit but keeps required with same pattern', () => {
     const findings = [
-      makeFinding({ severity: 'required', title: 'Unused variable causes crash' }),
+      makeFinding({ severity: 'blocker', title: 'Unused variable causes crash' }),
       makeFinding({ severity: 'suggestion', title: 'Unused variable cleanup' }),
-      makeFinding({ severity: 'nit', title: 'Unused variable — rename?' }),
+      makeFinding({ severity: 'nitpick', title: 'Unused variable — rename?' }),
     ];
     const suppressions = [makeSuppression({ pattern: 'unused variable' })];
 
     const { kept, suppressed } = applySuppressions(findings, suppressions);
     expect(kept).toHaveLength(1);
-    expect(kept[0].severity).toBe('required');
+    expect(kept[0].severity).toBe('blocker');
     expect(suppressed).toHaveLength(2);
   });
 });
@@ -352,16 +352,16 @@ describe('applyEscalations', () => {
 
     const result = applyEscalations(findings, patterns);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
   });
 
   it('does not escalate required findings', () => {
-    const findings = [makeFinding({ severity: 'required', title: 'Unused variable' })];
+    const findings = [makeFinding({ severity: 'blocker', title: 'Unused variable' })];
     const patterns = [makePattern({ finding_title: 'unused variable', escalated: true })];
 
     const result = applyEscalations(findings, patterns);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
   });
 
   it('does not escalate non-matching patterns', () => {
@@ -383,16 +383,16 @@ describe('applyEscalations', () => {
 
     const result = applyEscalations(findings, patterns);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
   });
 
   it('escalates nit severity findings', () => {
-    const findings = [makeFinding({ severity: 'nit', title: 'Unused variable' })];
+    const findings = [makeFinding({ severity: 'nitpick', title: 'Unused variable' })];
     const patterns = [makePattern({ finding_title: 'unused variable', escalated: true })];
 
     const result = applyEscalations(findings, patterns);
     expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('required');
+    expect(result[0].severity).toBe('blocker');
   });
 
   it('does not escalate when pattern is not escalated', () => {
@@ -887,7 +887,7 @@ describe('loadHandover', () => {
           findings: [
             {
               fingerprint: { file: 'src/a.rs', lineStart: 10, lineEnd: 10, slug: 'Null-check' },
-              severity: 'required',
+              severity: 'blocker',
               title: 'Null check',
               authorReply: 'agree',
               threadId: 'PRRT_1',
@@ -990,7 +990,7 @@ describe('appendHandoverRound', () => {
         timestamp: '2025-01-01T00:00:00Z',
         findings: [{
           fingerprint: { file: 'src/a.ts', lineStart: 5, lineEnd: 5, slug: 'Null-check' },
-          severity: 'required',
+          severity: 'blocker',
           title: 'Null check',
           authorReply: 'none',
           threadId: 't1',
@@ -1020,7 +1020,7 @@ describe('appendHandoverRound', () => {
         timestamp: '2025-01-01T00:00:00Z',
         findings: [{
           fingerprint: { file: 'src/a.ts', lineStart: 5, lineEnd: 5, slug: 'Null-check' },
-          severity: 'required',
+          severity: 'blocker',
           title: 'Null check',
           authorReply: 'none',
           // no threadId yet
@@ -1053,7 +1053,7 @@ describe('appendHandoverRound', () => {
         timestamp: '2025-01-01T00:00:00Z',
         findings: [{
           fingerprint: { file: 'src/a.ts', lineStart: 40, lineEnd: 44, slug: 'Range-check' },
-          severity: 'required',
+          severity: 'blocker',
           title: 'Range check',
           authorReply: 'none',
           // no threadId yet
@@ -1192,7 +1192,7 @@ describe('appendHandoverRound', () => {
         findings: [
           {
             fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: 'Null-check' },
-            severity: 'required',
+            severity: 'blocker',
             title: 'Null check',
             authorReply: 'none',
           },
@@ -1235,7 +1235,7 @@ describe('appendHandoverRound', () => {
         timestamp: '2025-01-01T00:00:00Z',
         findings: [{
           fingerprint: { file: 'src/a.ts', lineStart: 5, lineEnd: 5, slug: 'Null-check' },
-          severity: 'required',
+          severity: 'blocker',
           title: 'Null check',
           authorReply: 'none',
         }],

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -119,7 +119,7 @@ async function fetchTextFile(
 }
 
 /** Severities that are allowed to be suppressed by stored suppressions. */
-const SUPPRESSIBLE_SEVERITIES: ReadonlySet<FindingSeverity> = new Set<FindingSeverity>(['suggestion', 'nit']);
+const SUPPRESSIBLE_SEVERITIES: ReadonlySet<FindingSeverity> = new Set<FindingSeverity>(['warning', 'suggestion', 'nitpick']);
 
 /**
  * Filter findings against stored suppressions.
@@ -475,7 +475,7 @@ export function applyEscalations(
   patterns: Pattern[],
 ): Finding[] {
   return findings.map(f => {
-    if (f.severity !== 'suggestion' && f.severity !== 'nit') return f;
+    if (f.severity !== 'warning' && f.severity !== 'suggestion' && f.severity !== 'nitpick') return f;
 
     const normalized = f.title.toLowerCase().trim();
     const pattern = patterns.find(p =>
@@ -483,8 +483,8 @@ export function applyEscalations(
     );
 
     if (pattern) {
-      core.info(`Escalating "${f.title}" from ${f.severity} to required (pattern accepted ${pattern.accepted_count || 0} times)`);
-      return { ...f, severity: 'required' as const };
+      core.info(`Escalating "${f.title}" from ${f.severity} to blocker (pattern accepted ${pattern.accepted_count || 0} times)`);
+      return { ...f, severity: 'blocker' as const };
     }
 
     return f;

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { minimatch } from 'minimatch';
 
-import { AuthorReplyClass, Finding, FindingSeverity, HandoverFinding, HandoverRound, PrHandover } from './types';
+import { AuthorReplyClass, Finding, FindingSeverity, HandoverFinding, HandoverRound, PrHandover, migrateLegacySeverity } from './types';
 import { titleToSlug } from './github';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
@@ -575,6 +575,10 @@ async function fetchJsonFile<T>(
 
 /**
  * Load the per-PR handover file, or null if it does not yet exist.
+ *
+ * Legacy severity values written by older versions (`'required'`, `'nit'`)
+ * are migrated to the current vocabulary on read so downstream code only ever
+ * sees `FindingSeverity` values it recognizes.
  */
 export async function loadHandover(
   octokit: Octokit,
@@ -583,7 +587,22 @@ export async function loadHandover(
   prNumber: number,
 ): Promise<PrHandover | null> {
   const [owner, repo] = memoryRepo.split('/');
-  return fetchJsonFile<PrHandover>(octokit, owner, repo, handoverPath(targetRepo, prNumber));
+  const loaded = await fetchJsonFile<PrHandover>(octokit, owner, repo, handoverPath(targetRepo, prNumber));
+  return loaded ? migrateHandover(loaded) : null;
+}
+
+/** Apply `migrateLegacySeverity` to every finding's severity in a loaded handover. */
+function migrateHandover(handover: PrHandover): PrHandover {
+  return {
+    ...handover,
+    rounds: handover.rounds.map(round => ({
+      ...round,
+      findings: round.findings.map(f => ({
+        ...f,
+        severity: migrateLegacySeverity(f.severity) as HandoverFinding['severity'],
+      })),
+    })),
+  };
 }
 
 /**

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -496,7 +496,7 @@ describe('fetchRecapState', () => {
       line: 10,
       comments: {
         nodes: [{
-          body: '<!-- manki:required:Null-check --> \u{1F6AB} **Required**: Missing null check\n\nDescription here.',
+          body: '<!-- manki:blocker:Null-check --> \u{1F6AB} **Blocker**: Missing null check\n\nDescription here.',
           author: { login: 'github-actions[bot]' },
         }],
       },
@@ -570,7 +570,7 @@ describe('fetchRecapState', () => {
         comments: {
           nodes: [
             {
-              body: '<!-- manki:required:Bug --> \u{1F6AB} **Required**: Bug found\n\nDesc.',
+              body: '<!-- manki:blocker:Bug --> \u{1F6AB} **Blocker**: Bug found\n\nDesc.',
               author: { login: 'github-actions[bot]' },
             },
             {
@@ -604,7 +604,7 @@ describe('fetchRecapState', () => {
         isResolved: false,
         comments: {
           nodes: [{
-            body: '<!-- manki:nit:Style-issue --> \u{1F4DD} **Nit**: Style issue\n\nMinor.',
+            body: '<!-- manki:nitpick:Style-issue --> \u{1F4DD} **Nitpick**: Style issue\n\nMinor.',
             author: { login: 'github-actions[bot]' },
           }],
         },
@@ -612,7 +612,7 @@ describe('fetchRecapState', () => {
     ]);
 
     const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
-    expect(state.previousFindings[0].severity).toBe('nit');
+    expect(state.previousFindings[0].severity).toBe('nitpick');
   });
 
   it('returns unknown severity when marker is missing', async () => {
@@ -639,7 +639,7 @@ describe('fetchRecapState', () => {
         isResolved: false,
         comments: {
           nodes: [{
-            body: '<!-- manki:required:Prompt-injection --> 🚫 **Required** <sub>[high confidence]</sub>: Prompt injection via unsanitized file paths\n\nDescription.',
+            body: '<!-- manki:blocker:Prompt-injection --> 🚫 **Blocker** <sub>[high confidence]</sub>: Prompt injection via unsanitized file paths\n\nDescription.',
             author: { login: 'github-actions[bot]' },
           }],
         },
@@ -680,7 +680,7 @@ describe('fetchRecapState', () => {
         comments: {
           nodes: [
             {
-              body: '<!-- manki:required:Bug --> \u{1F6AB} **Required**: Bug found\n\nDesc.',
+              body: '<!-- manki:blocker:Bug --> \u{1F6AB} **Blocker**: Bug found\n\nDesc.',
               author: { login: 'github-actions[bot]' },
             },
             {

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -632,6 +632,33 @@ describe('fetchRecapState', () => {
     expect(state.previousFindings[0].severity).toBe('unknown');
   });
 
+  it('migrates legacy severity markers (`required`, `nit`) on read', async () => {
+    const octokit = mockOctokit([
+      makeThread({
+        id: 't1',
+        comments: {
+          nodes: [{
+            body: '<!-- manki:required:Old-blocker --> **Required**: legacy blocker',
+            author: { login: 'github-actions[bot]' },
+          }],
+        },
+      }),
+      makeThread({
+        id: 't2',
+        comments: {
+          nodes: [{
+            body: '<!-- manki:nit:Old-nit --> **Nit**: legacy nitpick',
+            author: { login: 'github-actions[bot]' },
+          }],
+        },
+      }),
+    ]);
+
+    const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+    expect(state.previousFindings[0].severity).toBe('blocker');
+    expect(state.previousFindings[1].severity).toBe('nitpick');
+  });
+
   it('extracts title when confidence sub tag is present', async () => {
     const octokit = mockOctokit([
       makeThread({

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 import { ClaudeClient } from './claude';
 import { titleToSlug } from './github';
 import { matchesSuppression, Suppression } from './memory';
-import { AuthorReplyClass, Finding, FindingFingerprint, FindingSeverity } from './types';
+import { AuthorReplyClass, Finding, FindingFingerprint, FindingSeverity, migrateLegacySeverity, SEVERITY_TOKEN_PATTERN } from './types';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -248,8 +248,10 @@ async function fetchReviewThreads(
       const hasHumanReply = firstNonBotReply !== undefined;
       const authorReplyText = firstNonBotReply?.body;
 
-      const severityMatch = firstComment?.body?.match(/manki:(blocker|warning|suggestion|nitpick|ignore):/);
-      const severity = (severityMatch?.[1] ?? 'unknown') as FindingSeverity | 'unknown';
+      const severityMatch = firstComment?.body?.match(new RegExp(`manki:(${SEVERITY_TOKEN_PATTERN}):`));
+      const severity = (severityMatch?.[1]
+        ? migrateLegacySeverity(severityMatch[1])
+        : 'unknown') as FindingSeverity | 'unknown';
 
       const titleMatch = firstComment?.body?.match(/\*\*(?:Blocker|Warning|Suggestion|Nitpick|Ignore)\*\*(?:\s*<sub>\[[^\]]*\]<\/sub>)?\s*:\s*(.+?)(?:\n|$)/);
       const findingTitle = titleMatch?.[1]?.trim() ?? '';

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -248,10 +248,10 @@ async function fetchReviewThreads(
       const hasHumanReply = firstNonBotReply !== undefined;
       const authorReplyText = firstNonBotReply?.body;
 
-      const severityMatch = firstComment?.body?.match(/manki:(required|suggestion|nit|ignore):/);
+      const severityMatch = firstComment?.body?.match(/manki:(blocker|warning|suggestion|nitpick|ignore):/);
       const severity = (severityMatch?.[1] ?? 'unknown') as FindingSeverity | 'unknown';
 
-      const titleMatch = firstComment?.body?.match(/\*\*(?:Required|Suggestion|Nit|Ignore)\*\*(?:\s*<sub>\[[^\]]*\]<\/sub>)?\s*:\s*(.+?)(?:\n|$)/);
+      const titleMatch = firstComment?.body?.match(/\*\*(?:Blocker|Warning|Suggestion|Nitpick|Ignore)\*\*(?:\s*<sub>\[[^\]]*\]<\/sub>)?\s*:\s*(.+?)(?:\n|$)/);
       const findingTitle = titleMatch?.[1]?.trim() ?? '';
 
       const line = thread.line ?? 0;

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -62,7 +62,7 @@ describe('parseFindings', () => {
   it('parses valid JSON array', () => {
     const json = JSON.stringify([
       {
-        severity: 'required',
+        severity: 'blocker',
         title: 'Bug found',
         file: 'src/index.ts',
         line: 10,
@@ -73,7 +73,7 @@ describe('parseFindings', () => {
 
     const findings = parseFindings(json, 'TestReviewer');
     expect(findings).toHaveLength(1);
-    expect(findings[0].severity).toBe('required');
+    expect(findings[0].severity).toBe('blocker');
     expect(findings[0].title).toBe('Bug found');
     expect(findings[0].file).toBe('src/index.ts');
     expect(findings[0].line).toBe(10);
@@ -91,11 +91,11 @@ describe('parseFindings', () => {
   });
 
   it('parses markdown-wrapped JSON without language tag', () => {
-    const json = '```\n[{"severity":"nit","title":"Why?","file":"b.ts","line":5,"description":"Unclear code."}]\n```';
+    const json = '```\n[{"severity":"nitpick","title":"Why?","file":"b.ts","line":5,"description":"Unclear code."}]\n```';
 
     const findings = parseFindings(json, 'Reviewer');
     expect(findings).toHaveLength(1);
-    expect(findings[0].severity).toBe('nit');
+    expect(findings[0].severity).toBe('nitpick');
   });
 
   it('returns empty array for invalid JSON', () => {
@@ -184,7 +184,7 @@ describe('parseFindings', () => {
   });
 
   it('handles missing fields gracefully', () => {
-    const json = JSON.stringify([{ severity: 'required' }]);
+    const json = JSON.stringify([{ severity: 'blocker' }]);
 
     const findings = parseFindings(json, 'Reviewer');
     expect(findings).toHaveLength(1);
@@ -211,7 +211,7 @@ describe('parseFindings', () => {
 
 describe('validateSeverity', () => {
   it('accepts required', () => {
-    expect(validateSeverity('required')).toBe('required');
+    expect(validateSeverity('blocker')).toBe('blocker');
   });
 
   it('accepts suggestion', () => {
@@ -219,7 +219,7 @@ describe('validateSeverity', () => {
   });
 
   it('accepts nit', () => {
-    expect(validateSeverity('nit')).toBe('nit');
+    expect(validateSeverity('nitpick')).toBe('nitpick');
   });
 
   it('accepts ignore', () => {
@@ -239,39 +239,39 @@ describe('validateSeverity', () => {
 describe('determineVerdict', () => {
   it('returns REQUEST_CHANGES when any finding is required', () => {
     const findings: Finding[] = [
-      makeFinding({ severity: 'suggestion' }),
-      makeFinding({ severity: 'required' }),
+      makeFinding({ severity: 'warning' }),
+      makeFinding({ severity: 'blocker' }),
     ];
     expect(determineVerdict(findings).verdict).toBe('REQUEST_CHANGES');
     expect(determineVerdict(findings).verdictReason).toBe('required_present');
   });
 
   it('returns REQUEST_CHANGES when a novel suggestion exists', () => {
-    const findings: Finding[] = [makeFinding({ severity: 'suggestion' })];
+    const findings: Finding[] = [makeFinding({ severity: 'warning' })];
     expect(determineVerdict(findings).verdict).toBe('REQUEST_CHANGES');
     expect(determineVerdict(findings).verdictReason).toBe('novel_suggestion');
   });
 
-  it('returns APPROVE when there are only nits', () => {
-    const findings: Finding[] = [makeFinding({ severity: 'nit' })];
+  it('returns APPROVE when there are only nitpicks', () => {
+    const findings: Finding[] = [makeFinding({ severity: 'nitpick' })];
     expect(determineVerdict(findings).verdict).toBe('APPROVE');
-    expect(determineVerdict(findings).verdictReason).toBe('only_dismissed_or_nit');
+    expect(determineVerdict(findings).verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('returns APPROVE when there are only ignores', () => {
     const findings: Finding[] = [makeFinding({ severity: 'ignore' })];
     expect(determineVerdict(findings).verdict).toBe('APPROVE');
-    expect(determineVerdict(findings).verdictReason).toBe('only_dismissed_or_nit');
+    expect(determineVerdict(findings).verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('returns APPROVE when there are no findings', () => {
     expect(determineVerdict([]).verdict).toBe('APPROVE');
-    expect(determineVerdict([]).verdictReason).toBe('only_dismissed_or_nit');
+    expect(determineVerdict([]).verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('returns REQUEST_CHANGES when a suggestion has no matching prior-round dismissal', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 1, description: 'The return value should be checked for null', reviewers: ['reviewer-1'], judgeConfidence: 'high' },
+      { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 1, description: 'The return value should be checked for null', reviewers: ['reviewer-1'], judgeConfidence: 'high' },
     ];
     const result = determineVerdict(findings, []);
     expect(result.verdict).toBe('REQUEST_CHANGES');
@@ -280,43 +280,43 @@ describe('determineVerdict', () => {
 
   it('returns APPROVE when the only suggestion matches a prior-round agreement', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Missing null check',
       authorReply: 'agree',
     }];
     const result = determineVerdict(findings, priors);
     expect(result.verdict).toBe('APPROVE');
-    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
-  it('returns APPROVE for a mix of nits and dismissed suggestions', () => {
+  it('returns APPROVE for a mix of nitpicks and dismissed warnings', () => {
     const findings: Finding[] = [
-      makeFinding({ severity: 'nit' }),
-      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+      makeFinding({ severity: 'nitpick' }),
+      { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Missing null check',
       authorReply: 'agree',
     }];
     const result = determineVerdict(findings, priors);
     expect(result.verdict).toBe('APPROVE');
-    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('returns REQUEST_CHANGES when mixing dismissed and novel suggestions', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
-      { severity: 'suggestion', title: 'Unused import', file: 'src/handler.ts', line: 20, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'warning', title: 'Unused import', file: 'src/handler.ts', line: 20, description: 'desc', reviewers: ['reviewer-1'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Missing null check',
       authorReply: 'agree',
     }];
@@ -327,7 +327,7 @@ describe('determineVerdict', () => {
 
   it('treats undefined priorRounds as "all suggestions novel"', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'Something', file: 'a.ts', line: 3, description: 'desc', reviewers: ['r'] },
+      { severity: 'warning', title: 'Something', file: 'a.ts', line: 3, description: 'desc', reviewers: ['r'] },
     ];
     expect(determineVerdict(findings).verdict).toBe('REQUEST_CHANGES');
     expect(determineVerdict(findings).verdictReason).toBe('novel_suggestion');
@@ -336,11 +336,11 @@ describe('determineVerdict', () => {
   it('only dismisses when the prior authorReply is "agree"', () => {
     const title = 'T';
     const findings: Finding[] = [
-      { severity: 'suggestion', title, file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title, file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: titleToSlug(title) },
-      severity: 'suggestion',
+      severity: 'warning',
       title,
       authorReply: 'disagree',
     }];
@@ -350,11 +350,11 @@ describe('determineVerdict', () => {
   it.each(['partial', 'none'] as const)('does not dismiss when authorReply is "%s"', (reply) => {
     const title = 'T';
     const findings: Finding[] = [
-      { severity: 'suggestion', title, file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title, file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'f.ts', lineStart: 5, lineEnd: 5, slug: titleToSlug(title) },
-      severity: 'suggestion',
+      severity: 'warning',
       title,
       authorReply: reply,
     }];
@@ -364,11 +364,11 @@ describe('determineVerdict', () => {
 
   it('tolerates ±5 line drift when matching a prior dismissal', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'Drifted', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Drifted', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'Drifted' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Drifted',
       authorReply: 'agree',
     }];
@@ -377,11 +377,11 @@ describe('determineVerdict', () => {
 
   it('rejects matches outside the ±5 line tolerance', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'FarAway', file: 'f.ts', line: 100, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'FarAway', file: 'f.ts', line: 100, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'FarAway' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'FarAway',
       authorReply: 'agree',
     }];
@@ -391,27 +391,27 @@ describe('determineVerdict', () => {
   it('matches when finding.line equals lineStart + 5 (exact tolerance boundary)', () => {
     const prior: HandoverFinding = {
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'Boundary' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Boundary',
       authorReply: 'agree',
     };
     const atBoundary: Finding[] = [
-      { severity: 'suggestion', title: 'Boundary', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Boundary', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v1, verdictReason: vr1 } = determineVerdict(atBoundary, [prior]);
     expect(v1).toBe('APPROVE');
-    expect(vr1).toBe('only_dismissed_or_nit');
+    expect(vr1).toBe('only_nit_or_suggestion');
   });
 
   it('does not match when finding.line equals lineStart + 6 (one outside tolerance)', () => {
     const prior: HandoverFinding = {
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'Boundary' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Boundary',
       authorReply: 'agree',
     };
     const outsideBoundary: Finding[] = [
-      { severity: 'suggestion', title: 'Boundary', file: 'f.ts', line: 16, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Boundary', file: 'f.ts', line: 16, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v4, verdictReason: vr4 } = determineVerdict(outsideBoundary, [prior]);
     expect(v4).toBe('REQUEST_CHANGES');
@@ -421,27 +421,27 @@ describe('determineVerdict', () => {
   it('matches when finding.line equals lineEnd + 5 (exact tolerance on lineEnd endpoint)', () => {
     const prior: HandoverFinding = {
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 20, slug: 'Boundary2' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Boundary2',
       authorReply: 'agree',
     };
     const atEndBoundary: Finding[] = [
-      { severity: 'suggestion', title: 'Boundary2', file: 'f.ts', line: 25, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Boundary2', file: 'f.ts', line: 25, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v2, verdictReason: vr2 } = determineVerdict(atEndBoundary, [prior]);
     expect(v2).toBe('APPROVE');
-    expect(vr2).toBe('only_dismissed_or_nit');
+    expect(vr2).toBe('only_nit_or_suggestion');
   });
 
   it('does not match when finding.line equals lineEnd + 6 (one outside lineEnd tolerance)', () => {
     const prior: HandoverFinding = {
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 20, slug: 'Boundary2' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Boundary2',
       authorReply: 'agree',
     };
     const outsideEndBoundary: Finding[] = [
-      { severity: 'suggestion', title: 'Boundary2', file: 'f.ts', line: 26, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Boundary2', file: 'f.ts', line: 26, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v5, verdictReason: vr5 } = determineVerdict(outsideEndBoundary, [prior]);
     expect(v5).toBe('REQUEST_CHANGES');
@@ -451,27 +451,27 @@ describe('determineVerdict', () => {
   it('matches when finding.line equals lineStart - 5 (exact tolerance below lineStart)', () => {
     const prior: HandoverFinding = {
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'Boundary' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Boundary',
       authorReply: 'agree',
     };
     const atLowerBoundary: Finding[] = [
-      { severity: 'suggestion', title: 'Boundary', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Boundary', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v3, verdictReason: vr3 } = determineVerdict(atLowerBoundary, [prior]);
     expect(v3).toBe('APPROVE');
-    expect(vr3).toBe('only_dismissed_or_nit');
+    expect(vr3).toBe('only_nit_or_suggestion');
   });
 
   it('does not match when finding.line equals lineStart - 6 (one outside tolerance below lineStart)', () => {
     const prior: HandoverFinding = {
       fingerprint: { file: 'f.ts', lineStart: 10, lineEnd: 10, slug: 'Boundary' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Boundary',
       authorReply: 'agree',
     };
     const outsideLowerBoundary: Finding[] = [
-      { severity: 'suggestion', title: 'Boundary', file: 'f.ts', line: 4, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'Boundary', file: 'f.ts', line: 4, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v6, verdictReason: vr6 } = determineVerdict(outsideLowerBoundary, [prior]);
     expect(v6).toBe('REQUEST_CHANGES');
@@ -480,30 +480,30 @@ describe('determineVerdict', () => {
 
   it('returns APPROVE for a PR #106 R7 replay (4 suggestions all dismissed)', () => {
     const findings: Finding[] = [
-      { severity: 'suggestion', title: 'F1', file: 'src/a.ts', line: 10, description: 'd', reviewers: ['r'] },
-      { severity: 'suggestion', title: 'F2', file: 'src/b.ts', line: 20, description: 'd', reviewers: ['r'] },
-      { severity: 'suggestion', title: 'F3', file: 'src/c.ts', line: 30, description: 'd', reviewers: ['r'] },
-      { severity: 'suggestion', title: 'F4', file: 'src/d.ts', line: 40, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'F1', file: 'src/a.ts', line: 10, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'F2', file: 'src/b.ts', line: 20, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'F3', file: 'src/c.ts', line: 30, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title: 'F4', file: 'src/d.ts', line: 40, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = findings.map(f => ({
       fingerprint: { file: f.file, lineStart: f.line, lineEnd: f.line, slug: titleToSlug(f.title) },
-      severity: 'suggestion' as const,
+      severity: 'warning' as const,
       title: f.title,
       authorReply: 'agree' as const,
     }));
     const result = determineVerdict(findings, priors);
     expect(result.verdict).toBe('APPROVE');
-    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('does not dismiss a finding with line === 0 even when file and slug match', () => {
     const title = 'Null check';
     const findings: Finding[] = [
-      { severity: 'suggestion', title, file: 'f.ts', line: 0, description: 'd', reviewers: ['r'] },
+      { severity: 'warning', title, file: 'f.ts', line: 0, description: 'd', reviewers: ['r'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'f.ts', lineStart: 3, lineEnd: 3, slug: titleToSlug(title) },
-      severity: 'suggestion',
+      severity: 'warning',
       title,
       authorReply: 'agree',
     }];
@@ -548,15 +548,17 @@ describe('buildReviewerSystemPrompt', () => {
 
   it('includes severity examples for each level', () => {
     const prompt = buildReviewerSystemPrompt(reviewer, makeConfig());
-    // required examples
+    // blocker examples
     expect(prompt).toContain('SQL injection');
     expect(prompt).toContain('Null/undefined dereference');
     expect(prompt).toContain('Off-by-one');
+    // warning examples
+    expect(prompt).toContain('Race condition');
+    expect(prompt).toContain('Missing timeout');
     // suggestion examples
-    expect(prompt).toContain('logging "failed"');
     expect(prompt).toContain('const');
     expect(prompt).toContain('reusable helper');
-    // nit examples
+    // nitpick examples
     expect(prompt).toContain('connectionCount');
     expect(prompt).toContain('import ordering');
     expect(prompt).toContain('JSDoc');
@@ -1239,14 +1241,14 @@ describe('runReview', () => {
 
     const result = await runReview(clients, config, diff, 'raw diff', 'repo context');
     expect(result.verdict).toBe('APPROVE');
-    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
     expect(result.reviewComplete).toBe(true);
     expect(result.findings).toEqual([]);
   });
 
   it('collects findings from reviewer agents and passes to judge', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.' },
+      { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.' },
     ]);
     const clients = makeClients(findingJson);
     const config = makeConfig();
@@ -1254,7 +1256,7 @@ describe('runReview', () => {
 
     mockedRunJudgeAgent.mockResolvedValue({
       findings: [
-        { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
+        { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
       ],
       summary: 'One required finding.',
     });
@@ -1380,7 +1382,7 @@ describe('runReview', () => {
 
   it('fires onProgress per agent in multi-pass mode', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Consistent bug across passes', file: 'src/a.ts', line: 10, description: 'Bug.' },
+      { severity: 'blocker', title: 'Consistent bug across passes', file: 'src/a.ts', line: 10, description: 'Bug.' },
     ]);
     const clients = makeClients(findingJson);
     const config = makeConfig({ review_passes: 2 });
@@ -1479,7 +1481,7 @@ describe('runReview', () => {
 
   it('proceeds with quorum when one agent fails all retries in multi-pass mode', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Found a bug', file: 'src/a.ts', line: 10, description: 'Bug.' },
+      { severity: 'blocker', title: 'Found a bug', file: 'src/a.ts', line: 10, description: 'Bug.' },
     ]);
     const clients: ReviewClients = {
       reviewer: {
@@ -1540,13 +1542,13 @@ describe('runReview', () => {
 
   it('drops findings matching dismissed previous ones before judge sees them', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.' },
+      { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.' },
     ]);
     const clients = makeClients(findingJson);
     const config = makeConfig();
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const previousFindings = [
-      { title: 'Null dereference bug', file: 'src/a.ts', line: 10, severity: 'required' as const, status: 'resolved' as const },
+      { title: 'Null dereference bug', file: 'src/a.ts', line: 10, severity: 'blocker' as const, status: 'resolved' as const },
     ];
 
     // Judge should not be called (findings all deduped away before judge).
@@ -1566,7 +1568,7 @@ describe('runReview', () => {
 
   it('emits judgeInputCount in judging progress event reflecting post-suppression post-dedup count', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.' },
+      { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.' },
     ]);
     const clients = makeClients(findingJson);
     const config = makeConfig();
@@ -1579,15 +1581,15 @@ describe('runReview', () => {
     // Suppress 1 of the 3 identical raw findings, keep 2 for dedup to handle.
     mockedApplySuppressions.mockReturnValue({
       kept: [
-        { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
-        { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
+        { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
+        { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
       ],
       suppressed: [
-        { severity: 'required', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
+        { severity: 'blocker', title: 'Null dereference bug', file: 'src/a.ts', line: 10, description: 'Bug found.', reviewers: ['Security & Safety'] },
       ],
     });
     const previousFindings = [
-      { title: 'Null dereference bug', file: 'src/a.ts', line: 10, severity: 'required' as const, status: 'resolved' as const },
+      { title: 'Null dereference bug', file: 'src/a.ts', line: 10, severity: 'blocker' as const, status: 'resolved' as const },
     ];
 
     const onProgress = jest.fn();
@@ -1610,7 +1612,7 @@ describe('runReview', () => {
 
   it('runs LLM dedup after static dedup when a dedup client is provided', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Totally different wording of same bug', file: 'src/a.ts', line: 10, description: 'Bug.' },
+      { severity: 'blocker', title: 'Totally different wording of same bug', file: 'src/a.ts', line: 10, description: 'Bug.' },
     ]);
     const clients: ReviewClients = {
       ...makeClients(findingJson),
@@ -1627,7 +1629,7 @@ describe('runReview', () => {
     const config = makeConfig();
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const previousFindings = [
-      { title: 'Unrelated title that static wont match', file: 'src/a.ts', line: 10, severity: 'required' as const, status: 'resolved' as const },
+      { title: 'Unrelated title that static wont match', file: 'src/a.ts', line: 10, severity: 'blocker' as const, status: 'resolved' as const },
     ];
 
     const result = await runReview(
@@ -1645,13 +1647,13 @@ describe('runReview', () => {
 
   it('skips LLM dedup when no dedup client is provided', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Something brand new', file: 'src/a.ts', line: 10, description: 'Bug.' },
+      { severity: 'blocker', title: 'Something brand new', file: 'src/a.ts', line: 10, description: 'Bug.' },
     ]);
     const clients = makeClients(findingJson);
     const config = makeConfig();
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const previousFindings = [
-      { title: 'Unrelated dismissed thing', file: 'src/other.ts', line: 99, severity: 'required' as const, status: 'resolved' as const },
+      { title: 'Unrelated dismissed thing', file: 'src/other.ts', line: 99, severity: 'blocker' as const, status: 'resolved' as const },
     ];
 
     const result = await runReview(
@@ -1668,7 +1670,7 @@ describe('runReview', () => {
 
   it('leaves dedup counts at zero when no previous findings are supplied', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'A bug', file: 'src/a.ts', line: 10, description: 'Bug.' },
+      { severity: 'blocker', title: 'A bug', file: 'src/a.ts', line: 10, description: 'Bug.' },
     ]);
     const clients: ReviewClients = {
       ...makeClients(findingJson),
@@ -1704,7 +1706,7 @@ describe('runReview', () => {
 
   it('runs multi-pass review with review_passes > 1', async () => {
     const findingJson = JSON.stringify([
-      { severity: 'required', title: 'Consistent bug across passes', file: 'src/a.ts', line: 10, description: 'Bug.' },
+      { severity: 'blocker', title: 'Consistent bug across passes', file: 'src/a.ts', line: 10, description: 'Bug.' },
     ]);
     const clients = makeClients(findingJson);
     const config = makeConfig({ review_passes: 2 });
@@ -1712,7 +1714,7 @@ describe('runReview', () => {
 
     mockedRunJudgeAgent.mockResolvedValue({
       findings: [
-        { severity: 'required', title: 'Consistent bug across passes', file: 'src/a.ts', line: 10, description: 'Bug.', reviewers: ['Security & Safety'] },
+        { severity: 'blocker', title: 'Consistent bug across passes', file: 'src/a.ts', line: 10, description: 'Bug.', reviewers: ['Security & Safety'] },
       ],
       summary: 'One finding.',
     });
@@ -1819,7 +1821,7 @@ describe('runReview', () => {
     );
 
     expect(result.verdict).toBe('APPROVE');
-    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
     expect(result.reviewComplete).toBe(true);
   });
 
@@ -1938,7 +1940,7 @@ describe('runReview', () => {
     });
 
     const findingJson = JSON.stringify([{
-      severity: 'required', title: 'Bug', file: 'a.ts', line: 1,
+      severity: 'blocker', title: 'Bug', file: 'a.ts', line: 1,
       description: 'desc', suggestedFix: '', reviewers: [],
     }]);
 
@@ -1968,7 +1970,7 @@ describe('runReview', () => {
 
   it('uses default judgeEffort of high when planner is absent', async () => {
     const findingJson = JSON.stringify([{
-      severity: 'required', title: 'Bug', file: 'a.ts', line: 1,
+      severity: 'blocker', title: 'Bug', file: 'a.ts', line: 1,
       description: 'desc', suggestedFix: '', reviewers: [],
     }]);
 
@@ -2099,12 +2101,12 @@ describe('runReview', () => {
         commitSha: 'sha1',
         timestamp: '2024-01-01T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'required', title: 't4', authorReply: 'none', specialist: 'Correctness & Logic' },
-          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'required', title: 't5', authorReply: 'agree', specialist: 'Correctness & Logic' },
-          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'required', title: 't6', authorReply: 'agree', specialist: 'Correctness & Logic' },
+          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'blocker', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'blocker', title: 't4', authorReply: 'none', specialist: 'Correctness & Logic' },
+          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'blocker', title: 't5', authorReply: 'agree', specialist: 'Correctness & Logic' },
+          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'blocker', title: 't6', authorReply: 'agree', specialist: 'Correctness & Logic' },
         ],
       },
     ];
@@ -2166,7 +2168,7 @@ describe('runReview', () => {
         commitSha: 'sha1',
         timestamp: '2024-01-01T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
         ],
       },
     ];
@@ -2208,9 +2210,9 @@ describe('runReview', () => {
         commitSha: 'sha1',
         timestamp: '2024-01-01T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'blocker', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
         ],
       },
       {
@@ -2218,10 +2220,10 @@ describe('runReview', () => {
         commitSha: 'sha2',
         timestamp: '2024-01-02T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'required', title: 't4', authorReply: 'none', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'required', title: 't5', authorReply: 'none', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'required', title: 't6', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 7, lineEnd: 7, slug: 's7' }, severity: 'required', title: 't7', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'blocker', title: 't4', authorReply: 'none', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'blocker', title: 't5', authorReply: 'none', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'blocker', title: 't6', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 7, lineEnd: 7, slug: 's7' }, severity: 'blocker', title: 't7', authorReply: 'agree', specialist: 'Security & Safety' },
         ],
       },
     ];
@@ -2264,9 +2266,9 @@ describe('runReview', () => {
         commitSha: 'sha1',
         timestamp: '2024-01-01T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'none', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'none', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'none', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'none', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'blocker', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
         ],
       },
       {
@@ -2274,9 +2276,9 @@ describe('runReview', () => {
         commitSha: 'sha2',
         timestamp: '2024-01-02T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'required', title: 't4', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'required', title: 't5', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'required', title: 't6', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'blocker', title: 't4', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'blocker', title: 't5', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'blocker', title: 't6', authorReply: 'agree', specialist: 'Security & Safety' },
         ],
       },
     ];
@@ -2328,16 +2330,16 @@ describe('runReview', () => {
         commitSha: 'sha1',
         timestamp: '2024-01-01T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
-          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'required', title: 't4', authorReply: 'none', specialist: 'Correctness & Logic' },
-          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'required', title: 't5', authorReply: 'agree', specialist: 'Correctness & Logic' },
-          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'required', title: 't6', authorReply: 'agree', specialist: 'Correctness & Logic' },
-          { fingerprint: { file: 'a.ts', lineStart: 7, lineEnd: 7, slug: 's7' }, severity: 'required', title: 't7', authorReply: 'agree', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 8, lineEnd: 8, slug: 's8' }, severity: 'required', title: 't8', authorReply: 'agree', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 9, lineEnd: 9, slug: 's9' }, severity: 'required', title: 't9', authorReply: 'agree', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 10, lineEnd: 10, slug: 's10' }, severity: 'required', title: 't10', authorReply: 'agree', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'blocker', title: 't3', authorReply: 'agree', specialist: 'Security & Safety' },
+          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'blocker', title: 't4', authorReply: 'none', specialist: 'Correctness & Logic' },
+          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'blocker', title: 't5', authorReply: 'agree', specialist: 'Correctness & Logic' },
+          { fingerprint: { file: 'a.ts', lineStart: 6, lineEnd: 6, slug: 's6' }, severity: 'blocker', title: 't6', authorReply: 'agree', specialist: 'Correctness & Logic' },
+          { fingerprint: { file: 'a.ts', lineStart: 7, lineEnd: 7, slug: 's7' }, severity: 'blocker', title: 't7', authorReply: 'agree', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 8, lineEnd: 8, slug: 's8' }, severity: 'blocker', title: 't8', authorReply: 'agree', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 9, lineEnd: 9, slug: 's9' }, severity: 'blocker', title: 't9', authorReply: 'agree', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 10, lineEnd: 10, slug: 's10' }, severity: 'blocker', title: 't10', authorReply: 'agree', specialist: 'Architecture & Design' },
         ],
       },
     ];
@@ -2511,11 +2513,11 @@ describe('runReview', () => {
         commitSha: 'sha1',
         timestamp: '2024-01-01T00:00:00Z',
         findings: [
-          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'none', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'none', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'none', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'required', title: 't4', authorReply: 'agree', specialist: 'Architecture & Design' },
-          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'required', title: 't5', authorReply: 'agree', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'none', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'none', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'blocker', title: 't3', authorReply: 'none', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 4, lineEnd: 4, slug: 's4' }, severity: 'blocker', title: 't4', authorReply: 'agree', specialist: 'Architecture & Design' },
+          { fingerprint: { file: 'a.ts', lineStart: 5, lineEnd: 5, slug: 's5' }, severity: 'blocker', title: 't5', authorReply: 'agree', specialist: 'Architecture & Design' },
         ],
       },
     ];
@@ -2945,7 +2947,7 @@ describe('runReview', () => {
 
   it('retries failed agents in multi-pass mode and recovers on subsequent pass', async () => {
     const callsByAgent: Record<string, number> = {};
-    const securityFinding = { severity: 'required' as const, title: 'SQL injection', file: 'src/db.ts', line: 42, description: 'Unsanitized input.' };
+    const securityFinding = { severity: 'blocker' as const, title: 'SQL injection', file: 'src/db.ts', line: 42, description: 'Unsanitized input.' };
     const emptyFindings = JSON.stringify([]);
     const clients: ReviewClients = {
       reviewer: {
@@ -3419,8 +3421,8 @@ describe('buildPlannerHints', () => {
   it('groups findings by specialist with kept/dismissed counts', () => {
     const rounds = [
       makeRound(1, [
-        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
-        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'agree', specialist: 'Security & Safety' },
         { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'suggestion', title: 't3', authorReply: 'none', specialist: 'Testing & Coverage' },
       ]),
     ];
@@ -3436,8 +3438,8 @@ describe('buildPlannerHints', () => {
   it('skips findings without a specialist field (legacy handover entries)', () => {
     const rounds = [
       makeRound(1, [
-        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree' },
-        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'none', specialist: 'Correctness & Logic' },
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'none', specialist: 'Correctness & Logic' },
       ]),
     ];
     const hints = buildPlannerHints(rounds);
@@ -3448,7 +3450,7 @@ describe('buildPlannerHints', () => {
 
   it('consumes only the last two rounds when more are present', () => {
     const make = (n: number, spec: string): HandoverRound => makeRound(n, [
-      { fingerprint: { file: 'a.ts', lineStart: n, lineEnd: n, slug: `s${n}` }, severity: 'required', title: `t${n}`, authorReply: 'none', specialist: spec },
+      { fingerprint: { file: 'a.ts', lineStart: n, lineEnd: n, slug: `s${n}` }, severity: 'blocker', title: `t${n}`, authorReply: 'none', specialist: spec },
     ]);
     const rounds = [make(1, 'Security & Safety'), make(2, 'Architecture & Design'), make(3, 'Testing & Coverage')];
     const hints = buildPlannerHints(rounds);
@@ -3458,10 +3460,10 @@ describe('buildPlannerHints', () => {
   it('omits rounds whose findings all lack a specialist', () => {
     const rounds = [
       makeRound(1, [
-        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'agree' },
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'agree' },
       ]),
       makeRound(2, [
-        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'none', specialist: 'Correctness & Logic' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'none', specialist: 'Correctness & Logic' },
       ]),
     ];
     const hints = buildPlannerHints(rounds);
@@ -3471,9 +3473,9 @@ describe('buildPlannerHints', () => {
   it('treats disagree/partial/none replies as kept', () => {
     const rounds = [
       makeRound(1, [
-        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'required', title: 't1', authorReply: 'disagree', specialist: 'Security & Safety' },
-        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'required', title: 't2', authorReply: 'partial', specialist: 'Security & Safety' },
-        { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'required', title: 't3', authorReply: 'none', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 1, lineEnd: 1, slug: 's1' }, severity: 'blocker', title: 't1', authorReply: 'disagree', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 2, lineEnd: 2, slug: 's2' }, severity: 'blocker', title: 't2', authorReply: 'partial', specialist: 'Security & Safety' },
+        { fingerprint: { file: 'a.ts', lineStart: 3, lineEnd: 3, slug: 's3' }, severity: 'blocker', title: 't3', authorReply: 'none', specialist: 'Security & Safety' },
       ]),
     ];
     const hints = buildPlannerHints(rounds);

--- a/src/review.ts
+++ b/src/review.ts
@@ -1011,7 +1011,7 @@ export async function runReview(
   core.info(`Verdict: ${verdict}`);
   core.info(`Findings: ${finalFindings.length}`);
   for (const f of finalFindings) {
-    const icon = f.severity === 'required' ? '\u2717' : f.severity === 'suggestion' ? '\u25CB' : f.severity === 'nit' ? '\u00B7' : '\u2205';
+    const icon = f.severity === 'blocker' ? '\u2717' : f.severity === 'warning' ? '\u26A0' : f.severity === 'suggestion' ? '\u25CB' : f.severity === 'nitpick' ? '\u00B7' : '\u2205';
     core.info(`  ${icon} [${f.severity}] ${f.title}`);
     core.info(`    ${f.file}:${f.line}`);
   }
@@ -1101,7 +1101,7 @@ Respond with ONLY a JSON array (no markdown fences, no explanation). Each findin
 \`\`\`
 [
   {
-    "severity": "required" | "suggestion" | "nit" | "ignore",
+    "severity": "blocker" | "warning" | "suggestion" | "nitpick" | "ignore",
     "title": "Short descriptive title",
     "file": "path/to/file.ext",
     "line": <line number in the NEW file>,
@@ -1115,15 +1115,19 @@ When you include a \`suggestedFix\`, list any known caveats of the proposed shap
 
 ## Severity Guidelines
 
-- **required**: Bugs, security vulnerabilities, data corruption risks, crashes, incorrect behavior. These MUST be fixed before merge.
+- **blocker**: Correctness bug, data loss risk, or security issue. Must be fixed before merge.
   - SQL injection via unsanitized user input in a database query
   - Null/undefined dereference in an error handling path that will crash at runtime
   - Off-by-one in array bounds causing data corruption or out-of-bounds access
-- **suggestion**: Meaningful improvements — missing error context, suboptimal patterns, incomplete handling. Worth addressing for code quality.
-  - Error message lacks context (e.g., logging "failed" without the error reason)
+- **warning**: Real behavioral concern — an edge case that will fail, misuse of an API that produces wrong output, a race condition. Not catastrophic but shouldn't ship.
+  - Missing timeout on a network request that could hang indefinitely
+  - Race condition on shared state without synchronization
+  - Error message lacks context that would help debugging a real failure
+- **suggestion**: Improvement open to discussion — refactoring, deduplication, API clarity, code style. Works today but could be cleaner.
   - Variable could be \`const\` instead of \`let\` since it is never reassigned
   - Function could be simplified by extracting a reusable helper
-- **nit**: Trivial nitpicks — naming, formatting, minor style preferences. Collected separately for triage.
+  - Duplicate logic that could be deduplicated
+- **nitpick**: Minor cosmetic — wording, formatting, tiny naming tweaks. Purely optional.
   - Variable name could be more descriptive (e.g., \`x\` → \`connectionCount\`)
   - Inconsistent import ordering compared to rest of file
   - Missing JSDoc on an exported function
@@ -1240,7 +1244,7 @@ export function parseFindings(responseText: string, reviewerName: string): Findi
 }
 
 export function validateSeverity(severity: unknown): Finding['severity'] {
-  if (severity === 'required' || severity === 'suggestion' || severity === 'nit' || severity === 'ignore') {
+  if (severity === 'blocker' || severity === 'warning' || severity === 'suggestion' || severity === 'nitpick' || severity === 'ignore') {
     return severity;
   }
   return 'suggestion';
@@ -1270,30 +1274,30 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
  * Pick a verdict plus a machine-readable reason.
  *
  * Decision order:
- *   1. any surviving `required` finding → REQUEST_CHANGES / required_present
- *   2. any `suggestion` that is NOT a prior-round dismissed match → REQUEST_CHANGES / novel_suggestion
- *   3. otherwise (only nits / previously-dismissed suggestions / empty) → APPROVE / only_dismissed_or_nit
+ *   1. any surviving `blocker` finding → REQUEST_CHANGES / required_present
+ *   2. any `warning` that is NOT a prior-round dismissed match → REQUEST_CHANGES / novel_suggestion
+ *   3. otherwise (only suggestions/nitpicks / previously-dismissed warnings / empty) → APPROVE / only_nit_or_suggestion
  *
- * Nits are cosmetic and non-blocking, and prior-round dismissed suggestions
- * have already been acknowledged by the author. Both cases approve the PR.
+ * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
+ * have already been acknowledged by the author. All these cases approve the PR.
  */
 export function determineVerdict(
   findings: Finding[],
   priorRounds?: HandoverFinding[],
 ): { verdict: ReviewVerdict; verdictReason: VerdictReason } {
-  if (findings.some(f => f.severity === 'required')) {
+  if (findings.some(f => f.severity === 'blocker')) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
   }
 
   const prior = priorRounds ?? [];
-  const hasNovelSuggestion = findings.some(
-    f => f.severity === 'suggestion' && !wasDismissedInPriorRound(f, prior),
+  const hasNovelWarning = findings.some(
+    f => f.severity === 'warning' && !wasDismissedInPriorRound(f, prior),
   );
-  if (hasNovelSuggestion) {
+  if (hasNovelWarning) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' };
   }
 
-  return { verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' };
+  return { verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' };
 }
 
 export function truncateDiff(rawDiff: string, maxLength: number = 50000): string {

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -74,7 +74,7 @@ function makeGraphqlThreadNode(overrides: {
     isResolved: overrides.isResolved ?? false,
     comments: {
       nodes: [{
-        body: overrides.body ?? '<!-- manki:required:test --> **Required**: test',
+        body: overrides.body ?? '<!-- manki:blocker:test --> **Blocker**: test',
         commit: overrides.commitOid !== undefined
           ? (overrides.commitOid === null ? null : { oid: overrides.commitOid })
           : { oid: 'old-sha-111' },
@@ -225,7 +225,7 @@ function makeGraphqlFetchThreadNode(overrides: {
     isResolved: overrides.isResolved ?? false,
     comments: {
       nodes: [{
-        body: overrides.body ?? '<!-- manki:required:test-finding --> **Required**: test finding',
+        body: overrides.body ?? '<!-- manki:blocker:test-finding --> **Blocker**: test finding',
         author: overrides.authorLogin !== undefined
           ? (overrides.authorLogin === null ? null : { login: overrides.authorLogin })
           : { login: 'github-actions[bot]' },
@@ -248,7 +248,7 @@ describe('fetchBotReviewThreads', () => {
   it('returns bot threads with parsed severity and title', async () => {
     const graphqlMock = jest.fn().mockResolvedValueOnce(
       makeGraphqlFetchResponse([
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:null-check --> **Required**: null check' }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:blocker:null-check --> **Blocker**: null check' }),
         makeGraphqlFetchThreadNode({ id: 't2', body: '<!-- manki:suggestion:rename-var --> **Suggestion**: rename var', isResolved: true }),
       ]),
     );
@@ -264,7 +264,7 @@ describe('fetchBotReviewThreads', () => {
   it('filters out non-bot threads', async () => {
     const graphqlMock = jest.fn().mockResolvedValueOnce(
       makeGraphqlFetchResponse([
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:test --> required finding' }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:blocker:test --> required finding' }),
         makeGraphqlFetchThreadNode({ id: 't2', body: 'just a regular human comment' }),
       ]),
     );
@@ -294,7 +294,7 @@ describe('fetchBotReviewThreads', () => {
   it('parses nit and ignore severities as non-required', async () => {
     const graphqlMock = jest.fn().mockResolvedValueOnce(
       makeGraphqlFetchResponse([
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:nit:style-issue --> nit' }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:nitpick:style-issue --> nit' }),
         makeGraphqlFetchThreadNode({ id: 't2', body: '<!-- manki:ignore:false-positive --> ignore' }),
       ]),
     );
@@ -365,7 +365,7 @@ describe('checkAndAutoApprove', () => {
     const createReviewMock = jest.fn().mockResolvedValue({});
     const octokit = makeMockOctokit({
       threads: [
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:fix-bug --> fix', isResolved: true }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:blocker:fix-bug --> fix', isResolved: true }),
         makeGraphqlFetchThreadNode({ id: 't2', body: '<!-- manki:suggestion:style --> style', isResolved: true }),
       ],
       prHeadSha: 'sha-456',
@@ -384,7 +384,7 @@ describe('checkAndAutoApprove', () => {
     const createReviewMock = jest.fn().mockResolvedValue({});
     const octokit = makeMockOctokit({
       threads: [
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:fix-bug --> fix', isResolved: true }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:blocker:fix-bug --> fix', isResolved: true }),
         makeGraphqlFetchThreadNode({ id: 't2', body: '<!-- manki:suggestion:style --> style', isResolved: false }),
       ],
       createReviewFn: createReviewMock,
@@ -399,7 +399,7 @@ describe('checkAndAutoApprove', () => {
   it('returns false when unresolved required threads remain', async () => {
     const octokit = makeMockOctokit({
       threads: [
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:fix-bug --> fix', isResolved: false }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:blocker:fix-bug --> fix', isResolved: false }),
       ],
     });
 
@@ -462,7 +462,7 @@ describe('checkAndAutoApprove', () => {
 
     const octokit = makeMockOctokit({
       threads: [
-        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:fix --> fix', isResolved: true }),
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:blocker:fix --> fix', isResolved: true }),
       ],
       prHeadSha: 'sha-789',
       createReviewFn: createReviewMock,

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -307,6 +307,22 @@ describe('fetchBotReviewThreads', () => {
     expect(threads[1]).toEqual({ id: 't2', isResolved: false, isRequired: false, findingTitle: 'false positive' });
   });
 
+  it('migrates legacy severity markers (`required`, `nit`) on read', async () => {
+    const graphqlMock = jest.fn().mockResolvedValueOnce(
+      makeGraphqlFetchResponse([
+        makeGraphqlFetchThreadNode({ id: 't1', body: '<!-- manki:required:legacy-blocker --> old' }),
+        makeGraphqlFetchThreadNode({ id: 't2', body: '<!-- manki:nit:legacy-nit --> old' }),
+      ]),
+    );
+
+    const octokit = { graphql: graphqlMock } as unknown as Octokit;
+    const threads = await fetchBotReviewThreads(octokit, 'owner', 'repo', 1);
+
+    expect(threads).toHaveLength(2);
+    expect(threads[0].isRequired).toBe(true);
+    expect(threads[1].isRequired).toBe(false);
+  });
+
   it('returns empty array when no threads exist', async () => {
     const graphqlMock = jest.fn().mockResolvedValueOnce(
       makeGraphqlFetchResponse([]),

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { dismissPreviousReviews, isReviewInProgress } from './github';
+import { migrateLegacySeverity, SEVERITY_TOKEN_PATTERN } from './types';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -76,8 +77,10 @@ async function fetchBotReviewThreads(
     })
     .map(thread => {
       const body = thread.comments.nodes[0]?.body ?? '';
-      const severityMatch = body.match(/<!-- manki:(blocker|warning|suggestion|nitpick|ignore):/);
-      const isRequired = severityMatch?.[1] === 'blocker';
+      const severityMatch = body.match(new RegExp(`<!-- manki:(${SEVERITY_TOKEN_PATTERN}):`));
+      const isRequired = severityMatch?.[1]
+        ? migrateLegacySeverity(severityMatch[1]) === 'blocker'
+        : false;
       const titleMatch = body.match(/<!-- manki:\w+:(.+?) -->/);
       const findingTitle = titleMatch?.[1]?.replace(/-/g, ' ') ?? 'Unknown';
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -76,8 +76,8 @@ async function fetchBotReviewThreads(
     })
     .map(thread => {
       const body = thread.comments.nodes[0]?.body ?? '';
-      const severityMatch = body.match(/<!-- manki:(required|suggestion|nit|ignore):/);
-      const isRequired = severityMatch?.[1] === 'required';
+      const severityMatch = body.match(/<!-- manki:(blocker|warning|suggestion|nitpick|ignore):/);
+      const isRequired = severityMatch?.[1] === 'blocker';
       const titleMatch = body.match(/<!-- manki:\w+:(.+?) -->/);
       const findingTitle = titleMatch?.[1]?.replace(/-/g, ' ') ?? 'Unknown';
 
@@ -91,9 +91,9 @@ async function fetchBotReviewThreads(
 }
 
 /**
- * Check if all bot review threads (required, suggestion, nit) are resolved.
+ * Check if all bot review threads (blocker, warning, suggestion, nitpick) are resolved.
  * Auto-approve should only fire when every finding is resolved, because
- * CHANGES_REQUESTED can be caused by high-confidence suggestions too.
+ * CHANGES_REQUESTED can be caused by high-confidence warnings too.
  */
 function areAllFindingsResolved(threads: ReviewThread[]): boolean {
   return threads.every(t => t.isResolved);

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,26 @@
+import { migrateLegacySeverity } from './types';
+
+describe('migrateLegacySeverity', () => {
+  it('maps `required` to `blocker`', () => {
+    expect(migrateLegacySeverity('required')).toBe('blocker');
+  });
+
+  it('maps `nit` to `nitpick`', () => {
+    expect(migrateLegacySeverity('nit')).toBe('nitpick');
+  });
+
+  it.each(['blocker', 'warning', 'suggestion', 'nitpick', 'ignore'])(
+    'passes through current severity `%s` unchanged',
+    severity => {
+      expect(migrateLegacySeverity(severity)).toBe(severity);
+    },
+  );
+
+  it('passes through unknown values unchanged', () => {
+    expect(migrateLegacySeverity('unknown-severity')).toBe('unknown-severity');
+  });
+
+  it('passes through the empty string unchanged', () => {
+    expect(migrateLegacySeverity('')).toBe('');
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,22 @@ export const MAX_AGENT_RETRIES = 1;
 
 export type FindingSeverity = 'blocker' | 'warning' | 'suggestion' | 'nitpick' | 'ignore';
 
+/**
+ * Maps legacy severity values written by older versions of manki to the
+ * current `FindingSeverity` set. `'required'` was renamed to `'blocker'` and
+ * `'nit'` to `'nitpick'`; `'suggestion'` and `'ignore'` are unchanged. Used
+ * when reading persisted data (handover JSON, posted review comment markers)
+ * so old artifacts continue to round-trip correctly.
+ */
+export function migrateLegacySeverity(severity: string): FindingSeverity | string {
+  if (severity === 'required') return 'blocker';
+  if (severity === 'nit') return 'nitpick';
+  return severity;
+}
+
+/** Regex source matching all current and legacy severity tokens. */
+export const SEVERITY_TOKEN_PATTERN = 'blocker|warning|suggestion|nitpick|ignore|required|nit';
+
 export type FindingReachability = 'reachable' | 'hypothetical' | 'unknown';
 
 export const DEFENSIVE_HARDENING_TAG = 'defensive-hardening' as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export const MAX_AGENT_RETRIES = 1;
 
-export type FindingSeverity = 'required' | 'suggestion' | 'nit' | 'ignore';
+export type FindingSeverity = 'blocker' | 'warning' | 'suggestion' | 'nitpick' | 'ignore';
 
 export type FindingReachability = 'reachable' | 'hypothetical' | 'unknown';
 
@@ -89,7 +89,7 @@ export interface PrHandover {
 
 export type ReviewVerdict = 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
 
-export type VerdictReason = 'required_present' | 'novel_suggestion' | 'only_dismissed_or_nit';
+export type VerdictReason = 'required_present' | 'novel_suggestion' | 'only_nit_or_suggestion';
 
 export interface ReviewResult {
   verdict: ReviewVerdict;


### PR DESCRIPTION
## Summary
- Renames `FindingSeverity` from `required | suggestion | nit` to `blocker | warning | suggestion | nitpick | ignore`, adds `warning` tier for real behavioral concerns vs `suggestion` for improvements open to discussion
- Replaces `<sub>[high confidence]</sub>` text with traffic-light dot prefix in review comment headers: 🔴 (high), 🟠 (medium), 🟡 (low)
- Updates `determineVerdict` so only `blocker` and `warning` trigger `REQUEST_CHANGES`. `suggestion` and `nitpick` produce `APPROVE` (`VerdictReason` renamed to `only_nit_or_suggestion`)

Closes #593