### PR TITLE
fix: restore review-in-progress tickbox for `@manki review` requests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -745,6 +745,7 @@ describe('handleCommentTrigger', () => {
 
   it('posts skip comment and returns early when review is already in progress', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    mockListComments.mockResolvedValueOnce({ data: [] });
 
     setContext({
       eventName: 'issue_comment',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -743,9 +743,8 @@ describe('handleCommentTrigger', () => {
     );
   });
 
-  it('cancels in-progress review and proceeds when review is already running', async () => {
+  it('posts skip comment and returns early when review is already in progress', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(true);
 
     setContext({
       eventName: 'issue_comment',
@@ -761,72 +760,21 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 42, 'eyes',
     );
-    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).toHaveBeenCalledWith(
-      expect.anything(), 'test-owner', 'test-repo', 1,
-    );
-    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Cancelled in-progress review — proceeding with new review');
-    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalledWith(
-      expect.anything(), 'test-owner', 'test-repo', 1, expect.any(String),
-    );
-    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalledWith(
+    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
       expect.objectContaining({ body: expect.stringContaining('Review skipped') }),
     );
-    expect(mockOctokitInstance.rest.pulls.get).toHaveBeenCalled();
-    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
-  });
-
-  it('skips review after cancel when already approved on current commit', async () => {
-    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(true);
-    jest.mocked(ghUtils.isApprovedOnCommit).mockResolvedValueOnce(true);
-
-    setContext({
-      eventName: 'issue_comment',
-      payload: {
-        action: 'created',
-        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
-      },
-    });
-
-    await handleCommentTrigger();
-
-    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).toHaveBeenCalledWith(
-      expect.anything(), 'test-owner', 'test-repo', 1,
-    );
-    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Cancelled in-progress review — proceeding with new review');
-    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalled();
-    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Already approved on this commit — skipping review');
+    const skipBody = mockOctokitInstance.rest.issues.createComment.mock.calls
+      .map((c: [{ body: string }]) => c[0].body)
+      .find((body: string) => body.includes('Review skipped'));
+    expect(skipBody).toContain(FORCE_REVIEW_MARKER);
+    expect(skipBody).toContain('- [ ] Force review');
+    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Review already in progress — skipping');
+    expect(jest.mocked(ghUtils.isApprovedOnCommit)).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
   });
 
-  it('proceeds even when cancel fails for in-progress review', async () => {
-    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    jest.mocked(ghUtils.cancelActiveReviewRun).mockResolvedValueOnce(false);
-
-    setContext({
-      eventName: 'issue_comment',
-      payload: {
-        action: 'created',
-        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
-      },
-    });
-
-    await handleCommentTrigger();
-
-    expect(jest.mocked(ghUtils.cancelActiveReviewRun)).toHaveBeenCalledWith(
-      expect.anything(), 'test-owner', 'test-repo', 1,
-    );
-    expect(jest.mocked(core.info)).toHaveBeenCalledWith('Could not cancel in-progress review — proceeding anyway');
-    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalledWith(
-      expect.anything(), 'test-owner', 'test-repo', 1, expect.any(String),
-    );
-    expect(mockOctokitInstance.rest.pulls.get).toHaveBeenCalled();
-    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
-  });
-
-  it('does not call cancelActiveReviewRun when forceReview is true', async () => {
+  it('bypasses in-progress check when forceReview is true', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true); // there IS an in-progress review
 
     setContext({
@@ -842,10 +790,13 @@ describe('handleCommentTrigger', () => {
 
     expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled(); // entire block skipped
     expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining('Review skipped') }),
+    );
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
-  it('does not call cancelActiveReviewRun when no review is in progress', async () => {
+  it('proceeds with review when no review is in progress', async () => {
     // Reset to clear any once-values leaked from preceding tests
     jest.mocked(ghUtils.isReviewInProgress).mockReset().mockResolvedValue(false);
     setContext({
@@ -860,6 +811,10 @@ describe('handleCommentTrigger', () => {
     await handleCommentTrigger();
 
     expect(jest.mocked(ghUtils.cancelActiveReviewRun)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.isApprovedOnCommit)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 1, expect.any(String),
+    );
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
   it('skips review when already approved on this commit', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -692,6 +692,8 @@ describe('handlePullRequest', () => {
       expect.objectContaining({ comment_id: 77, body: expect.stringContaining('Review skipped') }),
     );
     expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.isApprovedOnCommit)).not.toHaveBeenCalled();
   });
 
   it('skips review when already approved on this commit', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -774,6 +774,38 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
   });
 
+  it('updates existing skip comment instead of creating a duplicate', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    mockListComments.mockResolvedValueOnce({
+      data: [
+        {
+          id: 99,
+          body: `${ghUtils.BOT_MARKER}\n**Review skipped** — a review is currently in progress.`,
+          user: { login: ghUtils.BOT_LOGIN, type: 'Bot' },
+        },
+      ],
+    });
+
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await handleCommentTrigger();
+
+    expect(mockOctokitInstance.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 99, body: expect.stringContaining('Review skipped') }),
+    );
+    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining('Review skipped') }),
+    );
+    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+  });
+
   it('bypasses in-progress check when forceReview is true', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true); // there IS an in-progress review
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -808,6 +808,30 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
   });
 
+  it('swallows errors from skip-comment helpers and emits a warning', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    mockListComments.mockRejectedValueOnce(new Error('boom'));
+
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await expect(handleCommentTrigger()).resolves.toBeUndefined();
+
+    expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to post review-skipped comment'),
+    );
+    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();
+  });
+
   it('bypasses in-progress check when forceReview is true', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true); // there IS an in-progress review
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -773,6 +773,7 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(core.info)).toHaveBeenCalledWith('Review already in progress — skipping');
     expect(jest.mocked(ghUtils.isApprovedOnCommit)).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();
   });
 
   it('updates existing skip comment instead of creating a duplicate', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ import {
   isApprovedOnCommit,
   markOwnProgressCommentCancelled,
   postAppWarningIfNeeded,
-  cancelActiveReviewRun,
 } from './github';
 import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
@@ -272,12 +271,9 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
 
   if (!forceReview) {
     if (await isReviewInProgress(octokit, owner, repo, prNumber)) {
-      const cancelled = await cancelActiveReviewRun(octokit, owner, repo, prNumber);
-      if (cancelled) {
-        core.info('Cancelled in-progress review — proceeding with new review');
-      } else {
-        core.info('Could not cancel in-progress review — proceeding anyway');
-      }
+      await postReviewSkippedComment(octokit, owner, repo, prNumber);
+      core.info('Review already in progress — skipping');
+      return;
     }
 
     if (await isApprovedOnCommit(octokit, owner, repo, prNumber, pr.head.sha)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,6 +263,14 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
     return;
   }
 
+  if (!forceReview) {
+    if (await isReviewInProgress(octokit, owner, repo, prNumber)) {
+      await postReviewSkippedComment(octokit, owner, repo, prNumber);
+      core.info('Review already in progress — skipping');
+      return;
+    }
+  }
+
   const { data: pr } = await octokit.rest.pulls.get({
     owner,
     repo,
@@ -270,12 +278,6 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
   });
 
   if (!forceReview) {
-    if (await isReviewInProgress(octokit, owner, repo, prNumber)) {
-      await postReviewSkippedComment(octokit, owner, repo, prNumber);
-      core.info('Review already in progress — skipping');
-      return;
-    }
-
     if (await isApprovedOnCommit(octokit, owner, repo, prNumber, pr.head.sha)) {
       core.info('Already approved on this commit — skipping review');
       return;


### PR DESCRIPTION
## Summary
- Reverts the cancel-and-proceed behavior introduced in #542 that caused dual-review race conditions (two CHANGES_REQUESTED verdicts posted simultaneously)
- When `@manki review` is requested while a review is already in progress, posts the "Review skipped" tickbox comment and returns early — matching `handlePullRequest` behavior
- Removes the `cancelActiveReviewRun` call from `handleCommentTrigger` (the function remains in `src/github.ts` but is no longer called)
- The original problem #542 solved (zombie progress comments) was already fixed by #466 via Actions API verification — the cancel was redundant

Closes #600