### PR TITLE
chore: remove redundant `reviewer` model override from `.manki.yml`

### DIFF
--- a/.manki.yml
+++ b/.manki.yml
@@ -1,5 +1,3 @@
-models:
-  reviewer: claude-sonnet-4-6
 auto_review: true
 auto_approve: true
 


### PR DESCRIPTION
## Summary
- Removes `reviewer: claude-sonnet-4-6` from `.manki.yml` — it's the hardcoded default so the override is redundant