### PR TITLE
feat: render open-thread references as GitHub links in judge prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -474,6 +474,7 @@ async function runFullReview(
       .filter(f => (f.status === 'open' || f.status === 'replied') && f.threadId)
       .map(f => ({
         threadId: f.threadId!,
+        threadUrl: f.threadUrl,
         title: f.title,
         file: f.file,
         line: f.line,

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -370,7 +370,7 @@ describe('buildJudgeUserMessage', () => {
     expect(msg).toContain('Unused import');
   });
 
-  it('renders thread reference as markdown link when threadUrl is provided', () => {
+  it('renders thread reference with view link suffix when threadUrl is provided', () => {
     const findings = [makeFinding()];
     const openThreads = [
       {
@@ -384,7 +384,7 @@ describe('buildJudgeUserMessage', () => {
     ];
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
 
-    expect(msg).toContain('[PRRT_abc](https://github.com/owner/repo/pull/1#discussion_r123)');
+    expect(msg).toContain('**PRRT_abc** ([view](https://github.com/owner/repo/pull/1#discussion_r123))');
   });
 
   it('renders thread reference as plain id when threadUrl is absent', () => {
@@ -395,7 +395,18 @@ describe('buildJudgeUserMessage', () => {
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
 
     expect(msg).toContain('**PRRT_abc**');
-    expect(msg).not.toContain('[PRRT_abc](');
+    expect(msg).not.toContain('[view]');
+  });
+
+  it('renders thread reference as plain id when threadUrl is an empty string', () => {
+    const findings = [makeFinding()];
+    const openThreads = [
+      { threadId: 'PRRT_abc', threadUrl: '', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'required' },
+    ];
+    const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
+
+    expect(msg).toContain('**PRRT_abc**');
+    expect(msg).not.toContain('[view]');
   });
 
   it('omits open threads section when openThreads is undefined', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -370,6 +370,34 @@ describe('buildJudgeUserMessage', () => {
     expect(msg).toContain('Unused import');
   });
 
+  it('renders thread reference as markdown link when threadUrl is provided', () => {
+    const findings = [makeFinding()];
+    const openThreads = [
+      {
+        threadId: 'PRRT_abc',
+        threadUrl: 'https://github.com/owner/repo/pull/1#discussion_r123',
+        title: 'Null check missing',
+        file: 'src/foo.ts',
+        line: 10,
+        severity: 'required',
+      },
+    ];
+    const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
+
+    expect(msg).toContain('[PRRT_abc](https://github.com/owner/repo/pull/1#discussion_r123)');
+  });
+
+  it('renders thread reference as plain id when threadUrl is absent', () => {
+    const findings = [makeFinding()];
+    const openThreads = [
+      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'required' },
+    ];
+    const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
+
+    expect(msg).toContain('**PRRT_abc**');
+    expect(msg).not.toContain('[PRRT_abc](');
+  });
+
   it('omits open threads section when openThreads is undefined', () => {
     const findings = [makeFinding()];
     const msg = buildJudgeUserMessage(findings, new Map(), '');

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -358,8 +358,8 @@ describe('buildJudgeUserMessage', () => {
   it('includes open threads section when openThreads provided', () => {
     const findings = [makeFinding()];
     const openThreads = [
-      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'blocker' },
-      { threadId: 'PRRT_def', title: 'Unused import', file: 'src/bar.ts', line: 20, severity: 'suggestion' },
+      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'blocker' as const },
+      { threadId: 'PRRT_def', title: 'Unused import', file: 'src/bar.ts', line: 20, severity: 'suggestion' as const },
     ];
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
 
@@ -379,7 +379,7 @@ describe('buildJudgeUserMessage', () => {
         title: 'Null check missing',
         file: 'src/foo.ts',
         line: 10,
-        severity: 'required',
+        severity: 'warning' as const,
       },
     ];
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
@@ -390,7 +390,7 @@ describe('buildJudgeUserMessage', () => {
   it('renders thread reference as plain id when threadUrl is absent', () => {
     const findings = [makeFinding()];
     const openThreads = [
-      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'required' },
+      { threadId: 'PRRT_abc', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'warning' as const },
     ];
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
 
@@ -401,7 +401,7 @@ describe('buildJudgeUserMessage', () => {
   it('renders thread reference as plain id when threadUrl is an empty string', () => {
     const findings = [makeFinding()];
     const openThreads = [
-      { threadId: 'PRRT_abc', threadUrl: '', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'required' },
+      { threadId: 'PRRT_abc', threadUrl: '', title: 'Null check missing', file: 'src/foo.ts', line: 10, severity: 'warning' as const },
     ];
     const msg = buildJudgeUserMessage(findings, new Map(), '', undefined, undefined, undefined, openThreads);
 

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -472,8 +472,8 @@ export function buildJudgeUserMessage(
     parts.push(`## Open Review Threads\n`);
     parts.push('These are unresolved review threads from the previous review. If the new changes address any of them, include them in `resolveThreads`.\n');
     for (const t of openThreads) {
-      const ref = t.threadUrl ? `[${t.threadId}](${t.threadUrl})` : t.threadId;
-      parts.push(`- **${ref}**: [${t.severity}] "${sanitize(t.title)}" at ${sanitize(t.file)}:${t.line}`);
+      const linkSuffix = t.threadUrl ? ` ([view](${t.threadUrl}))` : '';
+      parts.push(`- **${t.threadId}**${linkSuffix}: [${t.severity}] "${sanitize(t.title)}" at ${sanitize(t.file)}:${t.line}`);
     }
     parts.push('');
   }

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -213,7 +213,7 @@ export interface JudgeInput {
   linkedIssues?: LinkedIssue[];
   agentCount: number;
   isFollowUp?: boolean;
-  openThreads?: Array<{ threadId: string; title: string; file: string; line: number; severity: string }>;
+  openThreads?: Array<{ threadId: string; threadUrl?: string; title: string; file: string; line: number; severity: string }>;
   priorRounds?: HandoverRound[];
   effort?: 'low' | 'medium' | 'high';
   provenanceMap?: ProvenanceEntry[];
@@ -457,7 +457,7 @@ export function buildJudgeUserMessage(
   prContext?: PrContext,
   linkedIssues?: LinkedIssue[],
   changedFiles?: DiffFile[],
-  openThreads?: Array<{ threadId: string; title: string; file: string; line: number; severity: string }>,
+  openThreads?: Array<{ threadId: string; threadUrl?: string; title: string; file: string; line: number; severity: string }>,
   priorRounds?: HandoverRound[],
 ): string {
   const parts: string[] = [];
@@ -472,7 +472,8 @@ export function buildJudgeUserMessage(
     parts.push(`## Open Review Threads\n`);
     parts.push('These are unresolved review threads from the previous review. If the new changes address any of them, include them in `resolveThreads`.\n');
     for (const t of openThreads) {
-      parts.push(`- **${t.threadId}**: [${t.severity}] "${sanitize(t.title)}" at ${sanitize(t.file)}:${t.line}`);
+      const ref = t.threadUrl ? `[${t.threadId}](${t.threadUrl})` : t.threadId;
+      parts.push(`- **${ref}**: [${t.severity}] "${sanitize(t.title)}" at ${sanitize(t.file)}:${t.line}`);
     }
     parts.push('');
   }

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -14,7 +14,7 @@ import {
 import { LinkedIssue, titleToSlug } from './github';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
-import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverFinding, HandoverRound, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, ReviewConfig, ParsedDiff, PrContext } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverFinding, HandoverRound, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, ReviewConfig, ParsedDiff, PrContext } from './types';
 
 /** Cap on how many prior rounds we pass to the judge. */
 const PRIOR_ROUNDS_WINDOW = 3;
@@ -213,7 +213,7 @@ export interface JudgeInput {
   linkedIssues?: LinkedIssue[];
   agentCount: number;
   isFollowUp?: boolean;
-  openThreads?: Array<{ threadId: string; threadUrl?: string; title: string; file: string; line: number; severity: string }>;
+  openThreads?: OpenThread[];
   priorRounds?: HandoverRound[];
   effort?: 'low' | 'medium' | 'high';
   provenanceMap?: ProvenanceEntry[];
@@ -457,7 +457,7 @@ export function buildJudgeUserMessage(
   prContext?: PrContext,
   linkedIssues?: LinkedIssue[],
   changedFiles?: DiffFile[],
-  openThreads?: Array<{ threadId: string; threadUrl?: string; title: string; file: string; line: number; severity: string }>,
+  openThreads?: OpenThread[],
   priorRounds?: HandoverRound[],
 ): string {
   const parts: string[] = [];

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -699,6 +699,41 @@ describe('fetchRecapState', () => {
     expect(state.previousFindings[0].line).toBe(0);
   });
 
+  it('extracts threadUrl from the first comment and exposes it on PreviousFinding', async () => {
+    const octokit = mockOctokit([
+      makeThread({
+        id: 't1',
+        comments: {
+          nodes: [{
+            body: '<!-- manki:blocker:Null-check --> \u{1F6AB} **Blocker**: Missing null check',
+            url: 'https://github.com/owner/repo/pull/1#discussion_r123',
+            author: { login: 'github-actions[bot]' },
+          }],
+        },
+      }),
+    ]);
+
+    const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+    expect(state.previousFindings[0].threadUrl).toBe('https://github.com/owner/repo/pull/1#discussion_r123');
+  });
+
+  it('falls back to empty-string threadUrl when the first comment has no url', async () => {
+    const octokit = mockOctokit([
+      makeThread({
+        id: 't1',
+        comments: {
+          nodes: [{
+            body: '<!-- manki:blocker:Null-check --> \u{1F6AB} **Blocker**: Missing null check',
+            author: { login: 'github-actions[bot]' },
+          }],
+        },
+      }),
+    ]);
+
+    const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+    expect(state.previousFindings[0].threadUrl).toBe('');
+  });
+
   it('treats first non-bot comment body as author reply text', async () => {
     const octokit = mockOctokit([
       makeThread({

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -233,7 +233,7 @@ async function fetchReviewThreads(
               comments: {
                 nodes: Array<{
                   body: string;
-                  url: string;
+                  url?: string;
                   author: { login: string } | null;
                 }>;
               };

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -106,6 +106,7 @@ interface PreviousFinding {
   severity: FindingSeverity | 'unknown';
   status: 'open' | 'resolved' | 'replied';
   threadId?: string;
+  threadUrl?: string;
   authorReplyText?: string;
 }
 
@@ -135,6 +136,7 @@ async function fetchRecapState(
       severity: t.severity,
       status: t.isResolved ? 'resolved' as const : (t.hasHumanReply ? 'replied' as const : 'open' as const),
       threadId: t.threadId,
+      threadUrl: t.threadUrl,
       authorReplyText: t.authorReplyText,
     }));
 
@@ -170,6 +172,7 @@ async function fetchRecapState(
 
 interface ReviewThread {
   threadId: string;
+  threadUrl: string;
   isBotThread: boolean;
   isResolved: boolean;
   hasHumanReply: boolean;
@@ -203,6 +206,7 @@ async function fetchReviewThreads(
               comments(first: 10) {
                 nodes {
                   body
+                  url
                   author {
                     login
                   }
@@ -229,6 +233,7 @@ async function fetchReviewThreads(
               comments: {
                 nodes: Array<{
                   body: string;
+                  url: string;
                   author: { login: string } | null;
                 }>;
               };
@@ -261,6 +266,7 @@ async function fetchReviewThreads(
 
       return {
         threadId: thread.id,
+        threadUrl: firstComment?.url ?? '',
         isBotThread,
         isResolved: thread.isResolved,
         hasHumanReply,

--- a/src/review.ts
+++ b/src/review.ts
@@ -538,7 +538,7 @@ export async function runReview(
   linkedIssues?: LinkedIssue[],
   onProgress?: (progress: ReviewProgress) => void,
   isFollowUp?: boolean,
-  openThreads?: Array<{ threadId: string; title: string; file: string; line: number; severity: string }>,
+  openThreads?: Array<{ threadId: string; threadUrl?: string; title: string; file: string; line: number; severity: string }>,
   previousFindings?: PreviousFinding[],
   priorRounds?: HandoverRound[],
 ): Promise<ReviewResult> {

--- a/src/review.ts
+++ b/src/review.ts
@@ -5,7 +5,7 @@ import { runJudgeAgent, JudgeInput, ResolveThread, computeProvenanceMap } from '
 import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
 import { LinkedIssue, titleToSlug } from './github';
 import { deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
-import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, SpecialistOutcome, EffortLevel, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
+import { ReviewConfig, ReviewerAgent, Finding, HandoverFinding, HandoverRound, OpenThread, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, SpecialistOutcome, EffortLevel, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
 import { extractJSON } from './json';
 
 const DISMISSED_LINE_TOLERANCE = 5;
@@ -538,7 +538,7 @@ export async function runReview(
   linkedIssues?: LinkedIssue[],
   onProgress?: (progress: ReviewProgress) => void,
   isFollowUp?: boolean,
-  openThreads?: Array<{ threadId: string; threadUrl?: string; title: string; file: string; line: number; severity: string }>,
+  openThreads?: OpenThread[],
   previousFindings?: PreviousFinding[],
   priorRounds?: HandoverRound[],
 ): Promise<ReviewResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,7 +245,7 @@ export interface OpenThread {
   title: string;
   file: string;
   line: number;
-  severity: string;
+  severity: FindingSeverity | 'unknown';
 }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,19 @@ export interface PrContext {
   baseBranch: string;
 }
 
+/**
+ * An unresolved review thread carried into a follow-up review so the judge
+ * can decide whether the new diff addresses it.
+ */
+export interface OpenThread {
+  threadId: string;
+  threadUrl?: string;
+  title: string;
+  file: string;
+  line: number;
+  severity: string;
+}
+
 
 export interface ReviewStats {
   model: string;


### PR DESCRIPTION
## Summary
- Extends the `fetchReviewThreads` GraphQL query to fetch the first comment's `url`
- Passes `threadUrl` through `PreviousFinding` -> `openThreads` -> judge prompt builder
- Judge prompt now renders thread references as `[PRRT_xxx](url)` markdown links so LLM output includes clickable links instead of opaque node IDs

Closes #609