### PR TITLE
fix: nit-only and dismissed-suggestion verdicts now APPROVE

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -293,6 +293,22 @@ describe('determineVerdict', () => {
     expect(result.verdictReason).toBe('only_dismissed_or_nit');
   });
 
+  it('returns APPROVE for a mix of nits and dismissed suggestions', () => {
+    const findings: Finding[] = [
+      makeFinding({ severity: 'nit' }),
+      { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
+      severity: 'suggestion',
+      title: 'Missing null check',
+      authorReply: 'agree',
+    }];
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_dismissed_or_nit');
+  });
+
   it('returns REQUEST_CHANGES when mixing dismissed and novel suggestions', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -252,15 +252,15 @@ describe('determineVerdict', () => {
     expect(determineVerdict(findings).verdictReason).toBe('novel_suggestion');
   });
 
-  it('returns COMMENT when there are only nits', () => {
+  it('returns APPROVE when there are only nits', () => {
     const findings: Finding[] = [makeFinding({ severity: 'nit' })];
-    expect(determineVerdict(findings).verdict).toBe('COMMENT');
+    expect(determineVerdict(findings).verdict).toBe('APPROVE');
     expect(determineVerdict(findings).verdictReason).toBe('only_dismissed_or_nit');
   });
 
-  it('returns COMMENT when there are only ignores', () => {
+  it('returns APPROVE when there are only ignores', () => {
     const findings: Finding[] = [makeFinding({ severity: 'ignore' })];
-    expect(determineVerdict(findings).verdict).toBe('COMMENT');
+    expect(determineVerdict(findings).verdict).toBe('APPROVE');
     expect(determineVerdict(findings).verdictReason).toBe('only_dismissed_or_nit');
   });
 
@@ -278,7 +278,7 @@ describe('determineVerdict', () => {
     expect(result.verdictReason).toBe('novel_suggestion');
   });
 
-  it('returns COMMENT when the only suggestion matches a prior-round agreement', () => {
+  it('returns APPROVE when the only suggestion matches a prior-round agreement', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
@@ -289,7 +289,7 @@ describe('determineVerdict', () => {
       authorReply: 'agree',
     }];
     const result = determineVerdict(findings, priors);
-    expect(result.verdict).toBe('COMMENT');
+    expect(result.verdict).toBe('APPROVE');
     expect(result.verdictReason).toBe('only_dismissed_or_nit');
   });
 
@@ -356,7 +356,7 @@ describe('determineVerdict', () => {
       title: 'Drifted',
       authorReply: 'agree',
     }];
-    expect(determineVerdict(findings, priors).verdict).toBe('COMMENT');
+    expect(determineVerdict(findings, priors).verdict).toBe('APPROVE');
   });
 
   it('rejects matches outside the ±5 line tolerance', () => {
@@ -383,7 +383,7 @@ describe('determineVerdict', () => {
       { severity: 'suggestion', title: 'Boundary', file: 'f.ts', line: 15, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v1, verdictReason: vr1 } = determineVerdict(atBoundary, [prior]);
-    expect(v1).toBe('COMMENT');
+    expect(v1).toBe('APPROVE');
     expect(vr1).toBe('only_dismissed_or_nit');
   });
 
@@ -413,7 +413,7 @@ describe('determineVerdict', () => {
       { severity: 'suggestion', title: 'Boundary2', file: 'f.ts', line: 25, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v2, verdictReason: vr2 } = determineVerdict(atEndBoundary, [prior]);
-    expect(v2).toBe('COMMENT');
+    expect(v2).toBe('APPROVE');
     expect(vr2).toBe('only_dismissed_or_nit');
   });
 
@@ -443,7 +443,7 @@ describe('determineVerdict', () => {
       { severity: 'suggestion', title: 'Boundary', file: 'f.ts', line: 5, description: 'd', reviewers: ['r'] },
     ];
     const { verdict: v3, verdictReason: vr3 } = determineVerdict(atLowerBoundary, [prior]);
-    expect(v3).toBe('COMMENT');
+    expect(v3).toBe('APPROVE');
     expect(vr3).toBe('only_dismissed_or_nit');
   });
 
@@ -462,7 +462,7 @@ describe('determineVerdict', () => {
     expect(vr6).toBe('novel_suggestion');
   });
 
-  it('returns COMMENT for a PR #106 R7 replay (4 suggestions all dismissed)', () => {
+  it('returns APPROVE for a PR #106 R7 replay (4 suggestions all dismissed)', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'F1', file: 'src/a.ts', line: 10, description: 'd', reviewers: ['r'] },
       { severity: 'suggestion', title: 'F2', file: 'src/b.ts', line: 20, description: 'd', reviewers: ['r'] },
@@ -476,7 +476,7 @@ describe('determineVerdict', () => {
       authorReply: 'agree' as const,
     }));
     const result = determineVerdict(findings, priors);
-    expect(result.verdict).toBe('COMMENT');
+    expect(result.verdict).toBe('APPROVE');
     expect(result.verdictReason).toBe('only_dismissed_or_nit');
   });
 
@@ -1767,7 +1767,7 @@ describe('runReview', () => {
     expect(mockedRunJudgeAgent).toHaveBeenCalledTimes(1);
   });
 
-  it('returns COMMENT when priorRounds agreed suggestion matches current finding (verdict ceiling)', async () => {
+  it('returns APPROVE when priorRounds agreed suggestion matches current finding (verdict ceiling)', async () => {
     const findingTitle = 'Missing null check';
     const findingFile = 'src/handler.ts';
     const findingLine = 10;
@@ -1802,7 +1802,7 @@ describe('runReview', () => {
       priorRounds,
     );
 
-    expect(result.verdict).toBe('COMMENT');
+    expect(result.verdict).toBe('APPROVE');
     expect(result.verdictReason).toBe('only_dismissed_or_nit');
     expect(result.reviewComplete).toBe(true);
   });

--- a/src/review.ts
+++ b/src/review.ts
@@ -1272,10 +1272,10 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
  * Decision order:
  *   1. any surviving `required` finding → REQUEST_CHANGES / required_present
  *   2. any `suggestion` that is NOT a prior-round dismissed match → REQUEST_CHANGES / novel_suggestion
- *   3. otherwise (only nits / previously-dismissed suggestions / empty) → COMMENT / only_dismissed_or_nit
+ *   3. otherwise (only nits / previously-dismissed suggestions / empty) → APPROVE / only_dismissed_or_nit
  *
- * Empty `findings` yields APPROVE / only_dismissed_or_nit so callers can still
- * distinguish "clean review" from "ceiling triggered".
+ * Nits are cosmetic and non-blocking, and prior-round dismissed suggestions
+ * have already been acknowledged by the author. Both cases approve the PR.
  */
 export function determineVerdict(
   findings: Finding[],
@@ -1293,8 +1293,7 @@ export function determineVerdict(
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' };
   }
 
-  const verdict: ReviewVerdict = findings.length === 0 ? 'APPROVE' : 'COMMENT';
-  return { verdict, verdictReason: 'only_dismissed_or_nit' };
+  return { verdict: 'APPROVE', verdictReason: 'only_dismissed_or_nit' };
 }
 
 export function truncateDiff(rawDiff: string, maxLength: number = 50000): string {


### PR DESCRIPTION
## Summary

- Rule 3 of `determineVerdict` previously returned `COMMENT` for any non-empty findings remaining after rules 1 and 2
- At rule 3, only nits and already-dismissed suggestions remain — both are non-blocking, so the PR should approve
- Added test coverage for the mixed nit + dismissed suggestion case

Closes #603