### PR TITLE
fix: nit-only and dismissed-suggestion verdicts APPROVE in `determineVerdict`

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -309,15 +309,15 @@ describe('determineVerdict', () => {
     expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
-  it('returns APPROVE for a mix of nitpicks and dismissed warnings (additional coverage)', () => {
+  it('returns APPROVE for a mix of nitpicks and dismissed suggestions', () => {
     const findings: Finding[] = [
       makeFinding({ severity: 'nitpick' }),
-      { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'suggestion', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
     const priors: HandoverFinding[] = [{
-      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
-      severity: 'warning',
-      title: 'Missing null check',
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Extract-helper' },
+      severity: 'suggestion',
+      title: 'Extract helper',
       authorReply: 'agree',
     }];
     const result = determineVerdict(findings, priors);

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -309,20 +309,28 @@ describe('determineVerdict', () => {
     expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
-  it('returns APPROVE for a mix of nitpicks and dismissed suggestions', () => {
+  it('returns APPROVE for a single dismissed warning (no nitpick mix)', () => {
     const findings: Finding[] = [
-      makeFinding({ severity: 'nitpick' }),
-      { severity: 'suggestion', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'warning', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
     const priors: HandoverFinding[] = [{
       fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Extract-helper' },
-      severity: 'suggestion',
+      severity: 'warning',
       title: 'Extract helper',
       authorReply: 'agree',
     }];
     const result = determineVerdict(findings, priors);
     expect(result.verdict).toBe('APPROVE');
     expect(result.verdictReason).toBe('only_nit_or_suggestion');
+  });
+
+  it('returns APPROVE for suggestion-severity findings regardless of priors', () => {
+    const findings: Finding[] = [
+      { severity: 'suggestion', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+    ];
+    expect(determineVerdict(findings).verdict).toBe('APPROVE');
+    expect(determineVerdict(findings).verdictReason).toBe('only_nit_or_suggestion');
+    expect(determineVerdict(findings, []).verdict).toBe('APPROVE');
   });
 
   it('returns REQUEST_CHANGES when mixing dismissed and novel suggestions', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -314,7 +314,7 @@ describe('determineVerdict', () => {
       { severity: 'warning', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
     const priors: HandoverFinding[] = [{
-      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Extract-helper' },
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Extract helper') },
       severity: 'warning',
       title: 'Extract helper',
       authorReply: 'agree',
@@ -328,9 +328,28 @@ describe('determineVerdict', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
     ];
-    expect(determineVerdict(findings).verdict).toBe('APPROVE');
-    expect(determineVerdict(findings).verdictReason).toBe('only_nit_or_suggestion');
-    expect(determineVerdict(findings, []).verdict).toBe('APPROVE');
+    const resultNoPriors = determineVerdict(findings);
+    expect(resultNoPriors.verdict).toBe('APPROVE');
+    expect(resultNoPriors.verdictReason).toBe('only_nit_or_suggestion');
+    const resultEmptyPriors = determineVerdict(findings, []);
+    expect(resultEmptyPriors.verdict).toBe('APPROVE');
+    expect(resultEmptyPriors.verdictReason).toBe('only_nit_or_suggestion');
+  });
+
+  it('returns APPROVE for a mix of nitpick and dismissed suggestion', () => {
+    const findings: Finding[] = [
+      { severity: 'nitpick', title: 'Minor naming', file: 'src/handler.ts', line: 5, description: 'desc', reviewers: ['reviewer-1'] },
+      { severity: 'suggestion', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Extract helper') },
+      severity: 'suggestion',
+      title: 'Extract helper',
+      authorReply: 'agree',
+    }];
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('returns REQUEST_CHANGES when mixing dismissed and novel suggestions', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -309,6 +309,22 @@ describe('determineVerdict', () => {
     expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
+  it('returns APPROVE for a mix of nitpicks and dismissed warnings (additional coverage)', () => {
+    const findings: Finding[] = [
+      makeFinding({ severity: 'nitpick' }),
+      { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: 'Missing-null-check' },
+      severity: 'warning',
+      title: 'Missing null check',
+      authorReply: 'agree',
+    }];
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
+  });
+
   it('returns REQUEST_CHANGES when mixing dismissed and novel suggestions', () => {
     const findings: Finding[] = [
       { severity: 'warning', title: 'Missing null check', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -324,6 +324,21 @@ describe('determineVerdict', () => {
     expect(result.verdictReason).toBe('only_nit_or_suggestion');
   });
 
+  it('returns REQUEST_CHANGES when the matching prior warning has authorReply "disagree"', () => {
+    const findings: Finding[] = [
+      { severity: 'warning', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },
+    ];
+    const priors: HandoverFinding[] = [{
+      fingerprint: { file: 'src/handler.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Extract helper') },
+      severity: 'warning',
+      title: 'Extract helper',
+      authorReply: 'disagree',
+    }];
+    const result = determineVerdict(findings, priors);
+    expect(result.verdict).toBe('REQUEST_CHANGES');
+    expect(result.verdictReason).toBe('novel_suggestion');
+  });
+
   it('returns APPROVE for suggestion-severity findings regardless of priors', () => {
     const findings: Finding[] = [
       { severity: 'suggestion', title: 'Extract helper', file: 'src/handler.ts', line: 10, description: 'desc', reviewers: ['reviewer-1'] },


### PR DESCRIPTION
## Summary

- Rule 3 of `determineVerdict` previously returned `COMMENT` for any non-empty findings at that stage. Since rules 1 and 2 already filter `required` findings and novel suggestions, the only things reaching rule 3 are nits and dismissed suggestions — both of which should approve.
- Changes rule 3 fallback to always return `APPROVE`.
- Updates tests that asserted `COMMENT` for nit-only and dismissed-suggestion cases.

Closes #603