### PR TITLE
test: cover multi-line `suggestedFix` matching in `computeProvenanceMap`

### DIFF
--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -2173,6 +2173,30 @@ describe('computeProvenanceMap', () => {
     const entries = computeProvenanceMap(rounds, diff);
     expect(entries).toHaveLength(0);
   });
+
+  it('returns no entry when a multi-line suggestedFix is split across two separate hunks', () => {
+    const multiLineFix = [
+      'const clamped = Math.min(value, SYSTEM_TIME_MAX);',
+      'if (clamped !== value) logger.warn("time clamped", { value, clamped });',
+      'return clamped;',
+    ].join('\n');
+    const rounds = [makeRound(1, [makeHandoverFinding({ suggestedFix: multiLineFix })])];
+    // All three fix lines appear as added lines, but the third is in a separate
+    // hunk. Block-level matching flushes at each `@@` header, so neither block
+    // contains the full multi-line fix and no entry should be produced.
+    const diff =
+      'diff --git a/src/a.ts b/src/a.ts\n' +
+      '--- a/src/a.ts\n' +
+      '+++ b/src/a.ts\n' +
+      '@@ -10,0 +10,2 @@\n' +
+      '+const clamped = Math.min(value, SYSTEM_TIME_MAX);\n' +
+      '+if (clamped !== value) logger.warn("time clamped", { value, clamped });\n' +
+      '@@ -20,0 +22,1 @@\n' +
+      '+return clamped;\n';
+
+    const entries = computeProvenanceMap(rounds, diff);
+    expect(entries).toHaveLength(0);
+  });
 });
 
 describe('buildJudgeUserMessage with linked issues', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -2128,6 +2128,33 @@ describe('computeProvenanceMap', () => {
     expect(entries[0].lineStart).toBe(20);
     expect(entries[0].lineEnd).toBe(20);
   });
+
+  it('matches a 3-line suggestedFix against contiguous added lines in the same hunk', () => {
+    const multiLineFix = [
+      'const clamped = Math.min(value, SYSTEM_TIME_MAX);',
+      'if (clamped !== value) logger.warn("time clamped", { value, clamped });',
+      'return clamped;',
+    ].join('\n');
+    const rounds = [makeRound(1, [makeHandoverFinding({ suggestedFix: multiLineFix })])];
+    // The diff adds 5 lines: a preamble, then the 3-line fix, then a closing brace.
+    const diff = buildDiff('src/a.ts', 10, [
+      'function clampTime(value: number): number {',
+      'const clamped = Math.min(value, SYSTEM_TIME_MAX);',
+      'if (clamped !== value) logger.warn("time clamped", { value, clamped });',
+      'return clamped;',
+      '}',
+    ]);
+
+    const entries = computeProvenanceMap(rounds, diff);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      file: 'src/a.ts',
+      lineStart: 10,
+      lineEnd: 14,
+      originatingRound: 1,
+      originatingTitle: 'Clamp future time',
+    });
+  });
 });
 
 describe('buildJudgeUserMessage with linked issues', () => {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -2155,6 +2155,24 @@ describe('computeProvenanceMap', () => {
       originatingTitle: 'Clamp future time',
     });
   });
+
+  it('returns no entry when a multi-line suggestedFix does not appear in the diff', () => {
+    const multiLineFix = [
+      'const clamped = Math.min(value, SYSTEM_TIME_MAX);',
+      'if (clamped !== value) logger.warn("time clamped", { value, clamped });',
+      'return clamped;',
+    ].join('\n');
+    const rounds = [makeRound(1, [makeHandoverFinding({ suggestedFix: multiLineFix })])];
+    // The diff adds an unrelated block that contains none of the fix lines.
+    const diff = buildDiff('src/a.ts', 10, [
+      'function unrelated(value: number): number {',
+      'return value * 2;',
+      '}',
+    ]);
+
+    const entries = computeProvenanceMap(rounds, diff);
+    expect(entries).toHaveLength(0);
+  });
 });
 
 describe('buildJudgeUserMessage with linked issues', () => {


### PR DESCRIPTION
## Summary

- Adds a test for a 3-line `suggestedFix` matched against a 5-line added hunk in `computeProvenanceMap`, verifying the entry spans the full contiguous added block.
- Existing tests only covered single-line fixes; this covers the multi-line case.

Closes #579