### PR TITLE
fix: `determineVerdict` blocks APPROVE on unresolved prior warnings/blockers

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2234,6 +2234,51 @@ describe('runReview', () => {
     expect(result.reviewComplete).toBe(true);
   });
 
+  it('returns REQUEST_CHANGES / prior_unaddressed when a prior warning thread is still open', async () => {
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    // Judge returns no current-round findings, but reports no per-thread evaluations.
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [],
+      summary: 'No new findings.',
+      threadEvaluations: [],
+    });
+
+    const priorRounds: HandoverRound[] = [{
+      round: 1,
+      commitSha: 'sha1',
+      timestamp: '2025-01-01T00:00:00Z',
+      findings: [{
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'T1',
+      }],
+    }];
+    const openThreads: OpenThread[] = [{
+      threadId: 'T1',
+      title: 'Old issue',
+      file: 'src/x.ts',
+      line: 10,
+      severity: 'warning',
+    }];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      openThreads,
+      undefined,
+      priorRounds,
+    );
+
+    expect(result.verdict).toBe('REQUEST_CHANGES');
+    expect(result.verdictReason).toBe('prior_unaddressed');
+    expect(result.reviewComplete).toBe(true);
+  });
+
   it('uses planner result to set team size and effort when planner client is provided', async () => {
     const plannerResponse = JSON.stringify({
       teamSize: 5,

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -700,6 +700,50 @@ describe('determineVerdict', () => {
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
+
+    it('collapses multi-round priors by threadId, keeping the most recent round (round 2 agree wins over round 1 none)', () => {
+      const round1: HandoverFinding = {
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'T1',
+      };
+      const round2: HandoverFinding = { ...round1, authorReply: 'agree' };
+      const open = [makeOpenThread()];
+      // Flat priors come in chronological order (round 1 first, round 2 last).
+      const result = determineVerdict([nitpick], [round1, round2], open, []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('collapses multi-round priors by fingerprint when threadId is absent (latest round wins)', () => {
+      const round1: HandoverFinding = {
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'none',
+      };
+      const round2: HandoverFinding = { ...round1, authorReply: 'agree' };
+      const result = determineVerdict([nitpick], [round1, round2], [], []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('keeps the round 2 unresolved state when round 1 had agree and round 2 reopened with none', () => {
+      const round1: HandoverFinding = {
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'agree',
+        threadId: 'T1',
+      };
+      const round2: HandoverFinding = { ...round1, authorReply: 'none' };
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], [round1, round2], open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -24,7 +24,7 @@ import {
 } from './review';
 import * as core from '@actions/core';
 import { LinkedIssue, titleToSlug } from './github';
-import { Finding, HandoverFinding, HandoverRound, OpenThread, ThreadEvaluation, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
+import { Finding, HandoverFinding, HandoverRound, OpenThread, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
 import { runJudgeAgent, computeProvenanceMap } from './judge';
 import { applySuppressions } from './memory';
 
@@ -593,7 +593,7 @@ describe('determineVerdict', () => {
     it('blocks APPROVE on a nit-only round when a prior warning is still open', () => {
       const priors = [makePriorWarning()];
       const open = [makeOpenThread()];
-      const result = determineVerdict([nitpick], priors, open, []);
+      const result = determineVerdict([nitpick], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
@@ -601,46 +601,28 @@ describe('determineVerdict', () => {
     it('approves when the prior warning was author-agreed', () => {
       const priors = [makePriorWarning({ authorReply: 'agree' })];
       const open = [makeOpenThread()];
-      const result = determineVerdict([nitpick], priors, open, []);
+      const result = determineVerdict([nitpick], priors, open);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
 
     it('approves when the prior thread is no longer in openThreads (resolved on GitHub)', () => {
       const priors = [makePriorWarning()];
-      const result = determineVerdict([nitpick], priors, [], []);
+      const result = determineVerdict([nitpick], priors, []);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
-    });
-
-    it('approves when the judge marked the prior thread addressed in this round', () => {
-      const priors = [makePriorWarning()];
-      const open = [makeOpenThread()];
-      const evals: ThreadEvaluation[] = [{ threadId: 'T1', status: 'addressed', reason: 'fixed in diff' }];
-      const result = determineVerdict([nitpick], priors, open, evals);
-      expect(result.verdict).toBe('APPROVE');
-      expect(result.verdictReason).toBe('only_nit_or_suggestion');
-    });
-
-    it('still blocks when the judge marked the prior thread not_addressed or uncertain', () => {
-      const priors = [makePriorWarning()];
-      const open = [makeOpenThread()];
-      const notAddressed: ThreadEvaluation[] = [{ threadId: 'T1', status: 'not_addressed', reason: 'still missing' }];
-      expect(determineVerdict([nitpick], priors, open, notAddressed).verdictReason).toBe('prior_unaddressed');
-      const uncertain: ThreadEvaluation[] = [{ threadId: 'T1', status: 'uncertain', reason: 'cannot tell' }];
-      expect(determineVerdict([nitpick], priors, open, uncertain).verdictReason).toBe('prior_unaddressed');
     });
 
     it('blocks APPROVE on an unresolved prior blocker', () => {
       const priors = [makePriorWarning({ severity: 'blocker' })];
       const open = [makeOpenThread({ severity: 'blocker' })];
-      const result = determineVerdict([nitpick], priors, open, []);
+      const result = determineVerdict([nitpick], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
 
     it('first review round (no priors) falls through to existing rules', () => {
-      const result = determineVerdict([nitpick], [], [], []);
+      const result = determineVerdict([nitpick], [], []);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
@@ -648,7 +630,7 @@ describe('determineVerdict', () => {
     it('treats a prior warning without threadId as unresolved (conservative default)', () => {
       const priors = [makePriorWarning({ threadId: undefined })];
       const open = [makeOpenThread({ threadId: 'OTHER' })];
-      const result = determineVerdict([nitpick], priors, open, []);
+      const result = determineVerdict([nitpick], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
@@ -659,7 +641,7 @@ describe('determineVerdict', () => {
       };
       const priors = [makePriorWarning()];
       const open = [makeOpenThread()];
-      const result = determineVerdict([novelWarning], priors, open, []);
+      const result = determineVerdict([novelWarning], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('novel_suggestion');
     });
@@ -667,7 +649,7 @@ describe('determineVerdict', () => {
     it('ignores prior findings that are not warning or blocker (e.g. suggestion)', () => {
       const priorSuggestion = makePriorWarning({ severity: 'suggestion' });
       const open = [makeOpenThread()];
-      const result = determineVerdict([nitpick], [priorSuggestion], open, []);
+      const result = determineVerdict([nitpick], [priorSuggestion], open);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
@@ -675,7 +657,7 @@ describe('determineVerdict', () => {
     it('treats prior findings with severity "unknown" as non-blocking (falls through to APPROVE)', () => {
       const priorUnknown = makePriorWarning({ severity: 'unknown' });
       const open = [makeOpenThread()];
-      const result = determineVerdict([nitpick], [priorUnknown], open, []);
+      const result = determineVerdict([nitpick], [priorUnknown], open);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
@@ -686,7 +668,7 @@ describe('determineVerdict', () => {
       };
       const priors = [makePriorWarning()];
       const open = [makeOpenThread()];
-      const result = determineVerdict([blocker], priors, open, []);
+      const result = determineVerdict([blocker], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('required_present');
     });
@@ -694,7 +676,7 @@ describe('determineVerdict', () => {
     it.each(['disagree', 'partial'] as const)('blocks APPROVE when authorReply is %s', (reply) => {
       const priors = [makePriorWarning({ authorReply: reply })];
       const open = [makeOpenThread()];
-      const result = determineVerdict([nitpick], priors, open, []);
+      const result = determineVerdict([nitpick], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
@@ -703,8 +685,20 @@ describe('determineVerdict', () => {
       const resolved = makePriorWarning({ threadId: 'T_RESOLVED', authorReply: 'agree' });
       const unresolved = makePriorWarning({ threadId: 'T_OPEN' });
       const open = [makeOpenThread({ threadId: 'T_OPEN' })];
-      const evals: ThreadEvaluation[] = [{ threadId: 'T_RESOLVED', status: 'addressed', reason: 'fixed' }];
-      const result = determineVerdict([nitpick], [resolved, unresolved], open, evals);
+      const result = determineVerdict([nitpick], [resolved, unresolved], open);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
+
+    it('does not unblock APPROVE on a judge-addressed signal alone (resolution must come from `openThreads` or `authorReply`)', () => {
+      // The judge's `threadEvaluations` is LLM-derived and could be flipped by
+      // prompt injection in prior-round source or comments. `determineVerdict`
+      // intentionally only consults `openThreads` and `authorReply`, so a
+      // still-open thread with no author agreement remains `prior_unaddressed`
+      // even when the judge claims it is `addressed`.
+      const priors = [makePriorWarning()];
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], priors, open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
@@ -720,7 +714,7 @@ describe('determineVerdict', () => {
       const round2: HandoverFinding = { ...round1, authorReply: 'agree' };
       const open = [makeOpenThread()];
       // Flat priors come in chronological order (round 1 first, round 2 last).
-      const result = determineVerdict([nitpick], [round1, round2], open, []);
+      const result = determineVerdict([nitpick], [round1, round2], open);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
@@ -733,7 +727,7 @@ describe('determineVerdict', () => {
         authorReply: 'none',
       };
       const round2: HandoverFinding = { ...round1, authorReply: 'agree' };
-      const result = determineVerdict([nitpick], [round1, round2], [], []);
+      const result = determineVerdict([nitpick], [round1, round2], []);
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
@@ -748,7 +742,7 @@ describe('determineVerdict', () => {
       };
       const round2: HandoverFinding = { ...round1, authorReply: 'none' };
       const open = [makeOpenThread()];
-      const result = determineVerdict([nitpick], [round1, round2], open, []);
+      const result = determineVerdict([nitpick], [round1, round2], open);
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
@@ -2336,11 +2330,60 @@ describe('runReview', () => {
     expect(result.reviewComplete).toBe(true);
   });
 
-  it('returns APPROVE / only_nit_or_suggestion when judge marks the prior thread addressed', async () => {
+  it('returns APPROVE / only_nit_or_suggestion when the prior thread is no longer open on GitHub, ignoring the judge addressed signal', async () => {
     const clients = makeClients('[]');
     const config = makeConfig();
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
 
+    // Judge claims the thread is addressed, but `determineVerdict` only trusts
+    // GitHub thread state. The empty `openThreads` below is what actually
+    // unblocks APPROVE.
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [],
+      summary: 'Prior thread addressed.',
+      threadEvaluations: [{ threadId: 'T1', status: 'addressed', reason: 'fixed in diff' }],
+    });
+
+    const priorRounds: HandoverRound[] = [{
+      round: 1,
+      commitSha: 'sha1',
+      timestamp: '2025-01-01T00:00:00Z',
+      findings: [{
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'T1',
+      }],
+    }];
+    const openThreads: OpenThread[] = [];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      /* memory */         undefined,
+      /* fileContents */   undefined,
+      /* prContext */      undefined,
+      /* linkedIssues */   undefined,
+      /* onProgress */     undefined,
+      /* isFollowUp */     undefined,
+      openThreads,
+      /* previousFindings */ undefined,
+      priorRounds,
+    );
+
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    expect(result.reviewComplete).toBe(true);
+  });
+
+  it('returns REQUEST_CHANGES / prior_unaddressed when the GitHub thread is still open even if the judge says addressed', async () => {
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    // The judge's `addressed` signal is LLM-derived and could be flipped by
+    // prompt injection. `determineVerdict` no longer consults it, so an
+    // attacker who tricks the judge cannot bypass an open GitHub thread.
     mockedRunJudgeAgent.mockResolvedValue({
       findings: [],
       summary: 'Prior thread addressed.',
@@ -2380,8 +2423,8 @@ describe('runReview', () => {
       priorRounds,
     );
 
-    expect(result.verdict).toBe('APPROVE');
-    expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    expect(result.verdict).toBe('REQUEST_CHANGES');
+    expect(result.verdictReason).toBe('prior_unaddressed');
     expect(result.reviewComplete).toBe(true);
   });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -746,6 +746,58 @@ describe('determineVerdict', () => {
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('prior_unaddressed');
     });
+
+    it('collapses across rounds when only one round carries a threadId (older handover format on the other)', () => {
+      // Round 1 was written by an older handover format that did not record
+      // `threadId`, and authorReply was 'none'. Round 2 captured the same
+      // finding with a threadId and an 'agree' reply. The two must collapse
+      // to the round 2 entry so the agreement wins. If they did not collapse
+      // (e.g. when keyed by `threadId` vs fingerprint separately), the stale
+      // round 1 'none' entry would survive and falsely block APPROVE because
+      // its missing `threadId` is treated as unresolved.
+      const round1: HandoverFinding = {
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'none',
+      };
+      const round2: HandoverFinding = { ...round1, authorReply: 'agree', threadId: 'T1' };
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], [round1, round2], open);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('dedup makes a current-round warning fire `novel_suggestion` when round 2 reopened a prior agree', () => {
+      // Round 1 captured an `agree` for the finding, round 2 re-raised it
+      // with `authorReply: 'none'`. Without dedup, the round 1 `agree`
+      // would still satisfy `wasDismissedInPriorRound` and the matching
+      // current-round warning would be treated as dismissed, suppressing
+      // `novel_suggestion`. With dedup keyed by fingerprint, the round 2
+      // `none` entry overwrites round 1, so the current-round warning is
+      // correctly reported as novel.
+      const title = 'Old issue';
+      const round1: HandoverFinding = {
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug(title) },
+        severity: 'warning',
+        title,
+        authorReply: 'agree',
+        threadId: 'T1',
+      };
+      const round2: HandoverFinding = { ...round1, authorReply: 'none' };
+      const currentWarning: Finding = {
+        severity: 'warning',
+        title,
+        file: 'src/x.ts',
+        line: 10,
+        description: 'd',
+        reviewers: ['r'],
+      };
+      const open = [makeOpenThread()];
+      const result = determineVerdict([currentWarning], [round1, round2], open);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('novel_suggestion');
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -606,6 +606,16 @@ describe('determineVerdict', () => {
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
 
+    it('approves when `openThreads` is undefined and a prior has a `threadId` (legacy two-arg callers)', () => {
+      // Pre-`openThreads` callers omit the third argument. The `?? []`
+      // fallback treats every prior as resolved on GitHub, which lets the
+      // verdict fall through to the existing `only_nit_or_suggestion` rule.
+      const priors = [makePriorWarning()];
+      const result = determineVerdict([nitpick], priors, undefined);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
     it('approves when the prior thread is no longer in openThreads (resolved on GitHub)', () => {
       const priors = [makePriorWarning()];
       const result = determineVerdict([nitpick], priors, []);
@@ -2412,6 +2422,45 @@ describe('runReview', () => {
 
     const priorRounds: HandoverRound[] = [buildPriorRound(1, [makePriorWarningFinding()])];
     const openThreads: OpenThread[] = [];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      /* memory */         undefined,
+      /* fileContents */   undefined,
+      /* prContext */      undefined,
+      /* linkedIssues */   undefined,
+      /* onProgress */     undefined,
+      /* isFollowUp */     undefined,
+      openThreads,
+      /* previousFindings */ undefined,
+      priorRounds,
+    );
+
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    expect(result.reviewComplete).toBe(true);
+  });
+
+  it('returns APPROVE / only_nit_or_suggestion when `authorReply` is `agree` even with the prior thread still open', async () => {
+    // Covers the integration path where APPROVE is unblocked by `authorReply`
+    // rather than by the thread being absent from `openThreads`. Guards
+    // against the `authorReply` field being silently dropped or renamed
+    // somewhere in the `priorFindingsFlat` pipeline between `runReview` and
+    // `determineVerdict`.
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [],
+      summary: 'No new findings.',
+      threadEvaluations: [],
+    });
+
+    const priorRounds: HandoverRound[] = [
+      buildPriorRound(1, [makePriorWarningFinding({ authorReply: 'agree' })]),
+    ];
+    const openThreads: OpenThread[] = [makePriorOpenThread()];
 
     const result = await runReview(
       clients, config, diff, 'raw diff', 'repo context',

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -24,7 +24,7 @@ import {
 } from './review';
 import * as core from '@actions/core';
 import { LinkedIssue, titleToSlug } from './github';
-import { Finding, HandoverFinding, HandoverRound, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
+import { Finding, HandoverFinding, HandoverRound, OpenThread, ThreadEvaluation, ReviewerAgent, ReviewConfig, ParsedDiff, DiffFile, AgentPick, ProvenanceEntry, MAX_AGENT_RETRIES } from './types';
 import { runJudgeAgent, computeProvenanceMap } from './judge';
 import { applySuppressions } from './memory';
 
@@ -567,6 +567,110 @@ describe('determineVerdict', () => {
     }];
     expect(determineVerdict(findings, priors).verdict).toBe('REQUEST_CHANGES');
     expect(determineVerdict(findings, priors).verdictReason).toBe('novel_suggestion');
+  });
+
+  describe('unresolved prior findings', () => {
+    const makePriorWarning = (overrides: Partial<HandoverFinding> = {}): HandoverFinding => ({
+      fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+      severity: 'warning',
+      title: 'Old issue',
+      authorReply: 'none',
+      threadId: 'T1',
+      ...overrides,
+    });
+    const makeOpenThread = (overrides: Partial<OpenThread> = {}): OpenThread => ({
+      threadId: 'T1',
+      title: 'Old issue',
+      file: 'src/x.ts',
+      line: 10,
+      severity: 'warning',
+      ...overrides,
+    });
+    const nitpick: Finding = {
+      severity: 'nitpick', title: 'Tiny thing', file: 'src/y.ts', line: 1, description: 'd', reviewers: ['r'],
+    };
+
+    it('blocks APPROVE on a nit-only round when a prior warning is still open', () => {
+      const priors = [makePriorWarning()];
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], priors, open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
+
+    it('approves when the prior warning was author-agreed', () => {
+      const priors = [makePriorWarning({ authorReply: 'agree' })];
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], priors, open, []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('approves when the prior thread is no longer in openThreads (resolved on GitHub)', () => {
+      const priors = [makePriorWarning()];
+      const result = determineVerdict([nitpick], priors, [], []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('approves when the judge marked the prior thread addressed in this round', () => {
+      const priors = [makePriorWarning()];
+      const open = [makeOpenThread()];
+      const evals: ThreadEvaluation[] = [{ threadId: 'T1', status: 'addressed', reason: 'fixed in diff' }];
+      const result = determineVerdict([nitpick], priors, open, evals);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('still blocks when the judge marked the prior thread not_addressed or uncertain', () => {
+      const priors = [makePriorWarning()];
+      const open = [makeOpenThread()];
+      const notAddressed: ThreadEvaluation[] = [{ threadId: 'T1', status: 'not_addressed', reason: 'still missing' }];
+      expect(determineVerdict([nitpick], priors, open, notAddressed).verdictReason).toBe('prior_unaddressed');
+      const uncertain: ThreadEvaluation[] = [{ threadId: 'T1', status: 'uncertain', reason: 'cannot tell' }];
+      expect(determineVerdict([nitpick], priors, open, uncertain).verdictReason).toBe('prior_unaddressed');
+    });
+
+    it('blocks APPROVE on an unresolved prior blocker', () => {
+      const priors = [makePriorWarning({ severity: 'blocker' })];
+      const open = [makeOpenThread({ severity: 'blocker' })];
+      const result = determineVerdict([nitpick], priors, open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
+
+    it('first review round (no priors) falls through to existing rules', () => {
+      const result = determineVerdict([nitpick], [], [], []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
+    it('treats a prior warning without threadId as unresolved (conservative default)', () => {
+      const priors = [makePriorWarning({ threadId: undefined })];
+      const open = [makeOpenThread({ threadId: 'OTHER' })];
+      const result = determineVerdict([nitpick], priors, open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
+
+    it('novel current-round warning takes precedence over an unresolved prior', () => {
+      const novelWarning: Finding = {
+        severity: 'warning', title: 'Brand new', file: 'src/z.ts', line: 5, description: 'd', reviewers: ['r'],
+      };
+      const priors = [makePriorWarning()];
+      const open = [makeOpenThread()];
+      const result = determineVerdict([novelWarning], priors, open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('novel_suggestion');
+    });
+
+    it('ignores prior findings that are not warning or blocker (e.g. suggestion)', () => {
+      const priorSuggestion = makePriorWarning({ severity: 'suggestion' });
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], [priorSuggestion], open, []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1639,6 +1639,37 @@ describe('runReview', () => {
     };
   }
 
+  function buildPriorRound(round: number, findings: HandoverFinding[]): HandoverRound {
+    return {
+      round,
+      commitSha: `sha${round}`,
+      timestamp: `2025-01-0${round}T00:00:00Z`,
+      findings,
+    };
+  }
+
+  function makePriorWarningFinding(overrides: Partial<HandoverFinding> = {}): HandoverFinding {
+    return {
+      fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+      severity: 'warning',
+      title: 'Old issue',
+      authorReply: 'none',
+      threadId: 'T1',
+      ...overrides,
+    };
+  }
+
+  function makePriorOpenThread(overrides: Partial<OpenThread> = {}): OpenThread {
+    return {
+      threadId: 'T1',
+      title: 'Old issue',
+      file: 'src/x.ts',
+      line: 10,
+      severity: 'warning',
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'All clear.' });
@@ -2344,25 +2375,8 @@ describe('runReview', () => {
       threadEvaluations: [],
     });
 
-    const priorRounds: HandoverRound[] = [{
-      round: 1,
-      commitSha: 'sha1',
-      timestamp: '2025-01-01T00:00:00Z',
-      findings: [{
-        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
-        severity: 'warning',
-        title: 'Old issue',
-        authorReply: 'none',
-        threadId: 'T1',
-      }],
-    }];
-    const openThreads: OpenThread[] = [{
-      threadId: 'T1',
-      title: 'Old issue',
-      file: 'src/x.ts',
-      line: 10,
-      severity: 'warning',
-    }];
+    const priorRounds: HandoverRound[] = [buildPriorRound(1, [makePriorWarningFinding()])];
+    const openThreads: OpenThread[] = [makePriorOpenThread()];
 
     const result = await runReview(
       clients, config, diff, 'raw diff', 'repo context',
@@ -2396,18 +2410,7 @@ describe('runReview', () => {
       threadEvaluations: [{ threadId: 'T1', status: 'addressed', reason: 'fixed in diff' }],
     });
 
-    const priorRounds: HandoverRound[] = [{
-      round: 1,
-      commitSha: 'sha1',
-      timestamp: '2025-01-01T00:00:00Z',
-      findings: [{
-        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
-        severity: 'warning',
-        title: 'Old issue',
-        authorReply: 'none',
-        threadId: 'T1',
-      }],
-    }];
+    const priorRounds: HandoverRound[] = [buildPriorRound(1, [makePriorWarningFinding()])];
     const openThreads: OpenThread[] = [];
 
     const result = await runReview(
@@ -2442,25 +2445,48 @@ describe('runReview', () => {
       threadEvaluations: [{ threadId: 'T1', status: 'addressed', reason: 'fixed in diff' }],
     });
 
-    const priorRounds: HandoverRound[] = [{
-      round: 1,
-      commitSha: 'sha1',
-      timestamp: '2025-01-01T00:00:00Z',
-      findings: [{
-        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
-        severity: 'warning',
-        title: 'Old issue',
-        authorReply: 'none',
-        threadId: 'T1',
-      }],
-    }];
-    const openThreads: OpenThread[] = [{
-      threadId: 'T1',
-      title: 'Old issue',
-      file: 'src/x.ts',
-      line: 10,
-      severity: 'warning',
-    }];
+    const priorRounds: HandoverRound[] = [buildPriorRound(1, [makePriorWarningFinding()])];
+    const openThreads: OpenThread[] = [makePriorOpenThread()];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      /* memory */         undefined,
+      /* fileContents */   undefined,
+      /* prContext */      undefined,
+      /* linkedIssues */   undefined,
+      /* onProgress */     undefined,
+      /* isFollowUp */     undefined,
+      openThreads,
+      /* previousFindings */ undefined,
+      priorRounds,
+    );
+
+    expect(result.verdict).toBe('REQUEST_CHANGES');
+    expect(result.verdictReason).toBe('prior_unaddressed');
+    expect(result.reviewComplete).toBe(true);
+  });
+
+  it('sorts `priorRounds` by `round` before flattening, so an out-of-order array still picks the latest round', async () => {
+    // The caller may pass `priorRounds` out of order (e.g. round 2 first,
+    // round 1 second). `dedupePriorFindings` keeps the last entry per
+    // fingerprint, so chronological order matters: without the sort, the
+    // stale round 1 `agree` would overwrite the round 2 reopen and falsely
+    // approve the PR.
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [],
+      summary: 'No new findings.',
+      threadEvaluations: [],
+    });
+
+    const round1 = buildPriorRound(1, [makePriorWarningFinding({ authorReply: 'agree' })]);
+    const round2 = buildPriorRound(2, [makePriorWarningFinding({ authorReply: 'none' })]);
+    // Pass rounds out of chronological order on purpose.
+    const priorRounds: HandoverRound[] = [round2, round1];
+    const openThreads: OpenThread[] = [makePriorOpenThread()];
 
     const result = await runReview(
       clients, config, diff, 'raw diff', 'repo context',

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -671,6 +671,35 @@ describe('determineVerdict', () => {
       expect(result.verdict).toBe('APPROVE');
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
+
+    it('current-round blocker takes precedence over unresolved prior (required_present wins)', () => {
+      const blocker: Finding = {
+        severity: 'blocker', title: 'Critical', file: 'src/z.ts', line: 1, description: 'd', reviewers: ['r'],
+      };
+      const priors = [makePriorWarning()];
+      const open = [makeOpenThread()];
+      const result = determineVerdict([blocker], priors, open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('required_present');
+    });
+
+    it.each(['disagree', 'partial'] as const)('blocks APPROVE when authorReply is %s', (reply) => {
+      const priors = [makePriorWarning({ authorReply: reply })];
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], priors, open, []);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
+
+    it('blocks when at least one of multiple priors is still unresolved', () => {
+      const resolved = makePriorWarning({ threadId: 'T_RESOLVED', authorReply: 'agree' });
+      const unresolved = makePriorWarning({ threadId: 'T_OPEN' });
+      const open = [makeOpenThread({ threadId: 'T_OPEN' })];
+      const evals: ThreadEvaluation[] = [{ threadId: 'T_RESOLVED', status: 'addressed', reason: 'fixed' }];
+      const result = determineVerdict([nitpick], [resolved, unresolved], open, evals);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2268,14 +2268,68 @@ describe('runReview', () => {
 
     const result = await runReview(
       clients, config, diff, 'raw diff', 'repo context',
-      undefined, undefined, undefined, undefined, undefined, undefined,
+      /* memory */         undefined,
+      /* fileContents */   undefined,
+      /* prContext */      undefined,
+      /* linkedIssues */   undefined,
+      /* onProgress */     undefined,
+      /* isFollowUp */     undefined,
       openThreads,
-      undefined,
+      /* previousFindings */ undefined,
       priorRounds,
     );
 
     expect(result.verdict).toBe('REQUEST_CHANGES');
     expect(result.verdictReason).toBe('prior_unaddressed');
+    expect(result.reviewComplete).toBe(true);
+  });
+
+  it('returns APPROVE / only_nit_or_suggestion when judge marks the prior thread addressed', async () => {
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [],
+      summary: 'Prior thread addressed.',
+      threadEvaluations: [{ threadId: 'T1', status: 'addressed', reason: 'fixed in diff' }],
+    });
+
+    const priorRounds: HandoverRound[] = [{
+      round: 1,
+      commitSha: 'sha1',
+      timestamp: '2025-01-01T00:00:00Z',
+      findings: [{
+        fingerprint: { file: 'src/x.ts', lineStart: 10, lineEnd: 10, slug: 'old-issue' },
+        severity: 'warning',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'T1',
+      }],
+    }];
+    const openThreads: OpenThread[] = [{
+      threadId: 'T1',
+      title: 'Old issue',
+      file: 'src/x.ts',
+      line: 10,
+      severity: 'warning',
+    }];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      /* memory */         undefined,
+      /* fileContents */   undefined,
+      /* prContext */      undefined,
+      /* linkedIssues */   undefined,
+      /* onProgress */     undefined,
+      /* isFollowUp */     undefined,
+      openThreads,
+      /* previousFindings */ undefined,
+      priorRounds,
+    );
+
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
     expect(result.reviewComplete).toBe(true);
   });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -672,6 +672,14 @@ describe('determineVerdict', () => {
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
 
+    it('treats prior findings with severity "unknown" as non-blocking (falls through to APPROVE)', () => {
+      const priorUnknown = makePriorWarning({ severity: 'unknown' });
+      const open = [makeOpenThread()];
+      const result = determineVerdict([nitpick], [priorUnknown], open, []);
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+    });
+
     it('current-round blocker takes precedence over unresolved prior (required_present wins)', () => {
       const blocker: Finding = {
         severity: 'blocker', title: 'Critical', file: 'src/z.ts', line: 1, description: 'd', reviewers: ['r'],

--- a/src/review.ts
+++ b/src/review.ts
@@ -1338,8 +1338,12 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
 
 /**
  * Collapse multi-round prior findings to one entry per logical issue, keeping
- * the most recent round's view. Identity is `threadId` when present, otherwise
- * the fingerprint tuple. Callers must pass `priorRounds` in chronological order
+ * the most recent round's view. Identity is the fingerprint tuple, which is
+ * always present and stable across rounds. `threadId` is intentionally not
+ * used as the key because older handover rounds may have recorded the same
+ * finding without a `threadId` (the field was added later), and a mixed
+ * presence across rounds would otherwise split one logical finding into two
+ * surviving entries. Callers must pass `priorRounds` in chronological order
  * (round 1 first, latest last). A finding raised in round 1 with
  * `authorReply: 'none'` and re-raised in round 2 with `authorReply: 'agree'`
  * collapses to the round 2 entry, so the agreement is honored rather than the
@@ -1348,9 +1352,7 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
 function dedupePriorFindings(priorRounds: HandoverFinding[]): HandoverFinding[] {
   const byKey = new Map<string, HandoverFinding>();
   for (const p of priorRounds) {
-    const key = p.threadId
-      ? `t:${p.threadId}`
-      : `f:${p.fingerprint.file}:${p.fingerprint.lineStart}:${p.fingerprint.lineEnd}:${p.fingerprint.slug}`;
+    const key = `f:${p.fingerprint.file}:${p.fingerprint.lineStart}:${p.fingerprint.lineEnd}:${p.fingerprint.slug}`;
     byKey.set(key, p);
   }
   return Array.from(byKey.values());
@@ -1377,12 +1379,11 @@ function dedupePriorFindings(priorRounds: HandoverFinding[]): HandoverFinding[] 
  * GitHub thread state (`openThreads`) or from an explicit author agreement
  * captured in `authorReply`.
  *
- * Multi-round priors are collapsed to one entry per `threadId` (or per
- * fingerprint when no `threadId` is recorded), keeping the most recent
- * round's `authorReply`. Callers must pass `priorRounds` in chronological
- * order. Without this dedup, a stale round 1 `authorReply: 'none'` would
- * still match `.some(...)` even if round 2 captured an `agree` for the same
- * thread.
+ * Multi-round priors are collapsed to one entry per fingerprint, keeping the
+ * most recent round's `authorReply` and `threadId`. Callers must pass
+ * `priorRounds` in chronological order. Without this dedup, a stale round 1
+ * `authorReply: 'none'` would still match `.some(...)` even if round 2
+ * captured an `agree` for the same thread.
  *
  * Contract for `openThreads`: callers must pass the result of a successful
  * GitHub thread fetch. Both `undefined` and `[]` are interpreted the same way

--- a/src/review.ts
+++ b/src/review.ts
@@ -1016,7 +1016,7 @@ export async function runReview(
   }
 
   const priorFindingsFlat: HandoverFinding[] = (priorRounds ?? []).flatMap(r => r.findings);
-  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat, openThreads, judgeThreadEvaluations);
+  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat, openThreads);
 
   const summary = judgeSummary;
 
@@ -1366,10 +1366,16 @@ function dedupePriorFindings(priorRounds: HandoverFinding[]): HandoverFinding[] 
  *   4. otherwise (only suggestions/nitpicks / previously-dismissed warnings / empty) → APPROVE / only_nit_or_suggestion
  *
  * A prior `warning`/`blocker` is "unresolved" when the author has not agreed to
- * dismiss it (`authorReply !== 'agree'`), the underlying GitHub thread is still
- * in `openThreads`, and the judge did not mark it `addressed` in the current
- * round's `threadEvaluations`. A prior finding without a `threadId` is treated
- * as unresolved, which conservatively blocks APPROVE for older handover formats.
+ * dismiss it (`authorReply !== 'agree'`) and the underlying GitHub thread is
+ * still in `openThreads`. A prior finding without a `threadId` is treated as
+ * unresolved, which conservatively blocks APPROVE for older handover formats.
+ *
+ * The judge's `threadEvaluations.status === 'addressed'` is intentionally not
+ * consulted here. That signal is LLM-derived and could be flipped by prompt
+ * injection in prior-round source or comments, allowing an attacker to
+ * unblock APPROVE on an unaddressed warning. Resolution must come from the
+ * GitHub thread state (`openThreads`) or from an explicit author agreement
+ * captured in `authorReply`.
  *
  * Multi-round priors are collapsed to one entry per `threadId` (or per
  * fingerprint when no `threadId` is recorded), keeping the most recent
@@ -1393,7 +1399,6 @@ export function determineVerdict(
   findings: Finding[],
   priorRounds?: HandoverFinding[],
   openThreads?: OpenThread[],
-  threadEvaluations?: ThreadEvaluation[],
 ): { verdict: ReviewVerdict; verdictReason: VerdictReason } {
   if (findings.some(f => f.severity === 'blocker')) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
@@ -1408,16 +1413,11 @@ export function determineVerdict(
   }
 
   const openThreadIds = new Set((openThreads ?? []).map(t => t.threadId));
-  const addressedThreadIds = new Set(
-    (threadEvaluations ?? []).filter(e => e.status === 'addressed').map(e => e.threadId),
-  );
   const hasUnresolvedPrior = prior.some(p => {
     if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
     if (p.authorReply === 'agree') return false;
     if (!p.threadId) return true;
-    if (!openThreadIds.has(p.threadId)) return false;
-    if (addressedThreadIds.has(p.threadId)) return false;
-    return true;
+    return openThreadIds.has(p.threadId);
   });
   if (hasUnresolvedPrior) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'prior_unaddressed' };

--- a/src/review.ts
+++ b/src/review.ts
@@ -1337,6 +1337,26 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
 }
 
 /**
+ * Collapse multi-round prior findings to one entry per logical issue, keeping
+ * the most recent round's view. Identity is `threadId` when present, otherwise
+ * the fingerprint tuple. Callers must pass `priorRounds` in chronological order
+ * (round 1 first, latest last). A finding raised in round 1 with
+ * `authorReply: 'none'` and re-raised in round 2 with `authorReply: 'agree'`
+ * collapses to the round 2 entry, so the agreement is honored rather than the
+ * stale round 1 state.
+ */
+function dedupePriorFindings(priorRounds: HandoverFinding[]): HandoverFinding[] {
+  const byKey = new Map<string, HandoverFinding>();
+  for (const p of priorRounds) {
+    const key = p.threadId
+      ? `t:${p.threadId}`
+      : `f:${p.fingerprint.file}:${p.fingerprint.lineStart}:${p.fingerprint.lineEnd}:${p.fingerprint.slug}`;
+    byKey.set(key, p);
+  }
+  return Array.from(byKey.values());
+}
+
+/**
  * Pick a verdict plus a machine-readable reason.
  *
  * Decision order:
@@ -1350,6 +1370,13 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
  * in `openThreads`, and the judge did not mark it `addressed` in the current
  * round's `threadEvaluations`. A prior finding without a `threadId` is treated
  * as unresolved, which conservatively blocks APPROVE for older handover formats.
+ *
+ * Multi-round priors are collapsed to one entry per `threadId` (or per
+ * fingerprint when no `threadId` is recorded), keeping the most recent
+ * round's `authorReply`. Callers must pass `priorRounds` in chronological
+ * order. Without this dedup, a stale round 1 `authorReply: 'none'` would
+ * still match `.some(...)` even if round 2 captured an `agree` for the same
+ * thread.
  *
  * Contract for `openThreads`: callers must pass the result of a successful
  * GitHub thread fetch. Both `undefined` and `[]` are interpreted the same way
@@ -1372,7 +1399,7 @@ export function determineVerdict(
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
   }
 
-  const prior = priorRounds ?? [];
+  const prior = dedupePriorFindings(priorRounds ?? []);
   const hasNovelWarning = findings.some(
     f => f.severity === 'warning' && !wasDismissedInPriorRound(f, prior),
   );

--- a/src/review.ts
+++ b/src/review.ts
@@ -1351,6 +1351,14 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
  * round's `threadEvaluations`. A prior finding without a `threadId` is treated
  * as unresolved, which conservatively blocks APPROVE for older handover formats.
  *
+ * Contract for `openThreads`: callers must pass the result of a successful
+ * GitHub thread fetch. Both `undefined` and `[]` are interpreted the same way
+ * (no thread is open on GitHub), so any prior finding with a `threadId` that
+ * does not appear in the set is treated as resolved. Callers that fail to
+ * fetch thread state must abort before reaching this function rather than
+ * pass a partial or empty list, otherwise unaddressed warnings could be
+ * silently approved.
+ *
  * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
  * have already been acknowledged by the author. All these cases approve the PR.
  */

--- a/src/review.ts
+++ b/src/review.ts
@@ -1016,7 +1016,7 @@ export async function runReview(
   }
 
   const priorFindingsFlat: HandoverFinding[] = (priorRounds ?? []).flatMap(r => r.findings);
-  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat);
+  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat, openThreads, judgeThreadEvaluations);
 
   const summary = judgeSummary;
 
@@ -1342,7 +1342,14 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
  * Decision order:
  *   1. any surviving `blocker` finding → REQUEST_CHANGES / required_present
  *   2. any `warning` that is NOT a prior-round dismissed match → REQUEST_CHANGES / novel_suggestion
- *   3. otherwise (only suggestions/nitpicks / previously-dismissed warnings / empty) → APPROVE / only_nit_or_suggestion
+ *   3. any prior-round `warning`/`blocker` still unresolved → REQUEST_CHANGES / prior_unaddressed
+ *   4. otherwise (only suggestions/nitpicks / previously-dismissed warnings / empty) → APPROVE / only_nit_or_suggestion
+ *
+ * A prior `warning`/`blocker` is "unresolved" when the author has not agreed to
+ * dismiss it (`authorReply !== 'agree'`), the underlying GitHub thread is still
+ * in `openThreads`, and the judge did not mark it `addressed` in the current
+ * round's `threadEvaluations`. A prior finding without a `threadId` is treated
+ * as unresolved, which conservatively blocks APPROVE for older handover formats.
  *
  * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
  * have already been acknowledged by the author. All these cases approve the PR.
@@ -1350,6 +1357,8 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: HandoverFinding
 export function determineVerdict(
   findings: Finding[],
   priorRounds?: HandoverFinding[],
+  openThreads?: OpenThread[],
+  threadEvaluations?: ThreadEvaluation[],
 ): { verdict: ReviewVerdict; verdictReason: VerdictReason } {
   if (findings.some(f => f.severity === 'blocker')) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
@@ -1361,6 +1370,22 @@ export function determineVerdict(
   );
   if (hasNovelWarning) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' };
+  }
+
+  const openThreadIds = new Set((openThreads ?? []).map(t => t.threadId));
+  const addressedThreadIds = new Set(
+    (threadEvaluations ?? []).filter(e => e.status === 'addressed').map(e => e.threadId),
+  );
+  const hasUnresolvedPrior = prior.some(p => {
+    if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
+    if (p.authorReply === 'agree') return false;
+    if (!p.threadId) return true;
+    if (!openThreadIds.has(p.threadId)) return false;
+    if (addressedThreadIds.has(p.threadId)) return false;
+    return true;
+  });
+  if (hasUnresolvedPrior) {
+    return { verdict: 'REQUEST_CHANGES', verdictReason: 'prior_unaddressed' };
   }
 
   return { verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' };

--- a/src/review.ts
+++ b/src/review.ts
@@ -1015,7 +1015,9 @@ export async function runReview(
     };
   }
 
-  const priorFindingsFlat: HandoverFinding[] = (priorRounds ?? []).flatMap(r => r.findings);
+  const priorFindingsFlat: HandoverFinding[] = [...(priorRounds ?? [])]
+    .sort((a, b) => a.round - b.round)
+    .flatMap(r => r.findings);
   const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat, openThreads);
 
   const summary = judgeSummary;

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,7 +119,7 @@ export interface PrHandover {
 
 export type ReviewVerdict = 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
 
-export type VerdictReason = 'required_present' | 'novel_suggestion' | 'only_nit_or_suggestion';
+export type VerdictReason = 'required_present' | 'novel_suggestion' | 'prior_unaddressed' | 'only_nit_or_suggestion';
 
 export interface ReviewResult {
   verdict: ReviewVerdict;


### PR DESCRIPTION
## Summary

- `determineVerdict` now considers prior-round `warning`/`blocker` findings that the current round did not re-flag. A prior finding is treated as unresolved when severity is `warning`/`blocker`, `authorReply !== 'agree'`, the thread is still in `openThreads`, and no `threadEvaluations` entry marks it `addressed`. Missing `threadId` is treated as unresolved (conservative default).
- New `VerdictReason` value `prior_unaddressed`. Decision order: `required_present` → `novel_suggestion` → `prior_unaddressed` → `only_nit_or_suggestion`.
- `runReview` threads `openThreads` and the judge's `threadEvaluations` through to `determineVerdict`.

Closes #625. Sub 2 of #623.