### PR TITLE
fix: inject missing `CORE_AGENTS` on planner path in `selectTeam`

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3807,6 +3807,8 @@ describe('selectTeam with teamSizeOverride', () => {
         'Maintainability & Readability',
         'Performance & Efficiency',
       ]);
+      expect(roster.agents).toHaveLength(6);
+      expect(roster.level).toBe('large');
       expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Security & Safety"; injecting');
       expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Architecture & Design"; injecting');
       expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Correctness & Logic"; injecting');
@@ -3827,11 +3829,13 @@ describe('selectTeam with teamSizeOverride', () => {
       const roster = selectTeam(diff, config, undefined, 2, picks);
       const names = roster.agents.map(a => a.name);
       expect(names).toEqual([
+        'Security & Safety',
         'Architecture & Design',
         'Correctness & Logic',
-        'Security & Safety',
         'Testing & Coverage',
       ]);
+      expect(roster.agents).toHaveLength(4);
+      expect(roster.level).toBe('medium');
       expect(names.filter(n => n === 'Security & Safety')).toHaveLength(1);
       expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Architecture & Design"; injecting');
       expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Correctness & Logic"; injecting');
@@ -3857,6 +3861,8 @@ describe('selectTeam with teamSizeOverride', () => {
         'Architecture & Design',
         'Correctness & Logic',
       ]);
+      expect(roster.agents).toHaveLength(3);
+      expect(roster.level).toBe('small');
       expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('planner omitted core agent'));
     } finally {
       infoSpy.mockRestore();
@@ -4494,10 +4500,11 @@ describe('selectTeam planner-driven path', () => {
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
     // Duplicate Security pick is dropped; Architecture is injected as missing core.
+    // Core agents appear in CORE_AGENTS order (Security, Architecture, Correctness).
     expect(roster.agents).toHaveLength(3);
     expect(roster.agents.map(a => a.name)).toEqual([
-      'Architecture & Design',
       'Security & Safety',
+      'Architecture & Design',
       'Correctness & Logic',
     ]);
   });

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3868,6 +3868,30 @@ describe('selectTeam with teamSizeOverride', () => {
       infoSpy.mockRestore();
     }
   });
+
+  it('reorders core agents to CORE_AGENTS sequence when planner picks them out of order', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Correctness & Logic', effort: 'low' },
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 3, picks);
+      expect(roster.agents.map(a => a.name)).toEqual([
+        'Security & Safety',
+        'Architecture & Design',
+        'Correctness & Logic',
+      ]);
+      expect(roster.agents).toHaveLength(3);
+      expect(roster.level).toBe('small');
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('planner omitted core agent'));
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
 });
 
 describe('buildPlannerHints', () => {
@@ -4499,7 +4523,7 @@ describe('selectTeam planner-driven path', () => {
       { name: 'Correctness & Logic', effort: 'low' },
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
-    // Duplicate Security pick is dropped; Architecture is injected as missing core.
+    // Duplicate Security pick is dropped. Architecture is injected as missing core.
     // Core agents appear in CORE_AGENTS order (Security, Architecture, Correctness).
     expect(roster.agents).toHaveLength(3);
     expect(roster.agents.map(a => a.name)).toEqual([

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3647,10 +3647,11 @@ describe('selectTeam with teamSizeOverride', () => {
     const config = makeConfig();
     const picks: AgentPick[] = [
       { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
       { name: 'Correctness & Logic', effort: 'medium' },
     ];
     const roster = selectTeam(diff, config, undefined, 2, picks);
-    expect(roster.agents).toHaveLength(2);
+    expect(roster.agents).toHaveLength(3);
     expect(roster.level).toBe('small');
   });
 
@@ -3732,14 +3733,14 @@ describe('selectTeam with teamSizeOverride', () => {
     const config = makeConfig();
     const picks: AgentPick[] = [
       { name: 'Security & Safety', effort: 'high' },
-      { name: 'Testing & Coverage', effort: 'medium' },
+      { name: 'Architecture & Design', effort: 'medium' },
       { name: 'Correctness & Logic', effort: 'low' },
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
     expect(roster.agents).toHaveLength(3);
     expect(roster.agents.map(a => a.name)).toEqual([
       'Security & Safety',
-      'Testing & Coverage',
+      'Architecture & Design',
       'Correctness & Logic',
     ]);
     expect(roster.level).toBe('small');
@@ -3765,11 +3766,12 @@ describe('selectTeam with teamSizeOverride', () => {
     const config = makeConfig();
     const picks: AgentPick[] = [
       { name: 'Security & Safety', effort: 'high' },
-      { name: 'Protocol Expert', effort: 'medium' },
+      { name: 'Architecture & Design', effort: 'medium' },
       { name: 'Correctness & Logic', effort: 'low' },
+      { name: 'Protocol Expert', effort: 'medium' },
     ];
-    const roster = selectTeam(diff, config, [custom], 3, picks);
-    expect(roster.agents).toHaveLength(3);
+    const roster = selectTeam(diff, config, [custom], 4, picks);
+    expect(roster.agents).toHaveLength(4);
     expect(roster.agents.map(a => a.name)).toContain('Protocol Expert');
   });
 
@@ -3784,6 +3786,81 @@ describe('selectTeam with teamSizeOverride', () => {
     expect(roster.level).toBe('small');
     expect(roster.agents.map(a => a.name)).toContain('Security & Safety');
     expect(roster.agents.map(a => a.name)).toContain('Correctness & Logic');
+  });
+
+  it('injects all core agents when planner omits all of them', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Testing & Coverage', effort: 'high' },
+      { name: 'Maintainability & Readability', effort: 'medium' },
+      { name: 'Performance & Efficiency', effort: 'low' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 3, picks);
+      expect(roster.agents.map(a => a.name)).toEqual([
+        'Security & Safety',
+        'Architecture & Design',
+        'Correctness & Logic',
+        'Testing & Coverage',
+        'Maintainability & Readability',
+        'Performance & Efficiency',
+      ]);
+      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Security & Safety"; injecting');
+      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Architecture & Design"; injecting');
+      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Correctness & Logic"; injecting');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('injects only missing core agents when planner picks a subset', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Testing & Coverage', effort: 'medium' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 2, picks);
+      const names = roster.agents.map(a => a.name);
+      expect(names).toEqual([
+        'Architecture & Design',
+        'Correctness & Logic',
+        'Security & Safety',
+        'Testing & Coverage',
+      ]);
+      expect(names.filter(n => n === 'Security & Safety')).toHaveLength(1);
+      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Architecture & Design"; injecting');
+      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Correctness & Logic"; injecting');
+      expect(infoSpy).not.toHaveBeenCalledWith('planner omitted core agent "Security & Safety"; injecting');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('does not inject when planner already picks all core agents', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'low' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 3, picks);
+      expect(roster.agents.map(a => a.name)).toEqual([
+        'Security & Safety',
+        'Architecture & Design',
+        'Correctness & Logic',
+      ]);
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('planner omitted core agent'));
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 });
 
@@ -4396,7 +4473,11 @@ describe('selectTeam planner-driven path', () => {
       { name: 'Maintainability & Readability', effort: 'low' },
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
+    // Core agents are injected at the front, planner picks follow.
     expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
       'Performance & Efficiency',
       'Dependencies & Integration',
       'Maintainability & Readability',
@@ -4412,8 +4493,10 @@ describe('selectTeam planner-driven path', () => {
       { name: 'Correctness & Logic', effort: 'low' },
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
-    expect(roster.agents).toHaveLength(2);
+    // Duplicate Security pick is dropped; Architecture is injected as missing core.
+    expect(roster.agents).toHaveLength(3);
     expect(roster.agents.map(a => a.name)).toEqual([
+      'Architecture & Design',
       'Security & Safety',
       'Correctness & Logic',
     ]);

--- a/src/review.ts
+++ b/src/review.ts
@@ -63,6 +63,29 @@ export function buildAgentPool(customReviewers?: ReviewerAgent[]): ReviewerAgent
   return pool;
 }
 
+// Ensures all CORE_AGENTS are present in the resolved team. Returns the agents
+// reordered so that core agents come first in CORE_AGENTS order (injecting any
+// that the planner omitted), followed by non-core planner picks in their
+// original planner order. Core inviolability supersedes teamSizeOverride.
+// The final roster may exceed the planner-requested size.
+function injectMissingCoreAgents(
+  resolved: ReviewerAgent[],
+  pool: ReviewerAgent[],
+): ReviewerAgent[] {
+  const coreSet = new Set(CORE_AGENTS.map(i => pool[i].name));
+  const orderedCore: ReviewerAgent[] = CORE_AGENTS.map(i => {
+    const coreAgent = pool[i];
+    const plannerPicked = resolved.find(r => r.name === coreAgent.name);
+    if (plannerPicked) {
+      return plannerPicked;
+    }
+    core.info(`planner omitted core agent "${coreAgent.name}"; injecting`);
+    return coreAgent;
+  });
+  const nonCore = resolved.filter(r => !coreSet.has(r.name));
+  return [...orderedCore, ...nonCore];
+}
+
 export function selectTeam(
   diff: ParsedDiff,
   config: ReviewConfig,
@@ -95,30 +118,16 @@ export function selectTeam(
     }
 
     if (resolved.length > 0) {
-      // Reconstruct order: all CORE_AGENTS first (in CORE_AGENTS order, injecting any missing),
-      // then non-core planner picks in their original planner order.
-      const coreSet = new Set(CORE_AGENTS.map(i => pool[i].name));
-      const orderedCore: ReviewerAgent[] = [];
-      for (const i of CORE_AGENTS) {
-        const coreAgent = pool[i];
-        const plannerPicked = resolved.find(r => r.name === coreAgent.name);
-        if (plannerPicked) {
-          orderedCore.push(plannerPicked);
-        } else {
-          orderedCore.push(coreAgent);
-          core.info(`planner omitted core agent "${coreAgent.name}"; injecting`);
-        }
-      }
-      const nonCore = resolved.filter(r => !coreSet.has(r.name));
-      resolved.length = 0;
-      resolved.push(...orderedCore, ...nonCore);
+      // Core inviolability: CORE_AGENTS are always present regardless of
+      // teamSizeOverride, so the final roster may exceed that value.
+      const final = injectMissingCoreAgents(resolved, pool);
 
       let level: 'trivial' | 'small' | 'medium' | 'large';
-      if (resolved.length === 1) level = 'small';
-      else if (resolved.length <= 3) level = 'small';
-      else if (resolved.length <= 5) level = 'medium';
+      if (final.length === 1) level = 'small';
+      else if (final.length <= 3) level = 'small';
+      else if (final.length <= 5) level = 'medium';
       else level = 'large';
-      return { level, agents: resolved, lineCount };
+      return { level, agents: final, lineCount };
     }
     // If resolution failed entirely, fall through to heuristic
   }

--- a/src/review.ts
+++ b/src/review.ts
@@ -95,6 +95,18 @@ export function selectTeam(
     }
 
     if (resolved.length > 0) {
+      const missingCore: ReviewerAgent[] = [];
+      for (const i of CORE_AGENTS) {
+        const coreAgent = pool[i];
+        if (!resolved.some(r => r.name === coreAgent.name)) {
+          missingCore.push(coreAgent);
+          core.info(`planner omitted core agent "${coreAgent.name}"; injecting`);
+        }
+      }
+      if (missingCore.length > 0) {
+        resolved.unshift(...missingCore);
+      }
+
       let level: 'trivial' | 'small' | 'medium' | 'large';
       if (resolved.length === 1) level = 'small';
       else if (resolved.length <= 3) level = 'small';

--- a/src/review.ts
+++ b/src/review.ts
@@ -95,17 +95,23 @@ export function selectTeam(
     }
 
     if (resolved.length > 0) {
-      const missingCore: ReviewerAgent[] = [];
+      // Reconstruct order: all CORE_AGENTS first (in CORE_AGENTS order, injecting any missing),
+      // then non-core planner picks in their original planner order.
+      const coreSet = new Set(CORE_AGENTS.map(i => pool[i].name));
+      const orderedCore: ReviewerAgent[] = [];
       for (const i of CORE_AGENTS) {
         const coreAgent = pool[i];
-        if (!resolved.some(r => r.name === coreAgent.name)) {
-          missingCore.push(coreAgent);
+        const plannerPicked = resolved.find(r => r.name === coreAgent.name);
+        if (plannerPicked) {
+          orderedCore.push(plannerPicked);
+        } else {
+          orderedCore.push(coreAgent);
           core.info(`planner omitted core agent "${coreAgent.name}"; injecting`);
         }
       }
-      if (missingCore.length > 0) {
-        resolved.unshift(...missingCore);
-      }
+      const nonCore = resolved.filter(r => !coreSet.has(r.name));
+      resolved.length = 0;
+      resolved.push(...orderedCore, ...nonCore);
 
       let level: 'trivial' | 'small' | 'medium' | 'large';
       if (resolved.length === 1) level = 'small';


### PR DESCRIPTION
## Summary

- The planner-driven branch of `selectTeam` resolved only the agents the planner picked, silently dropping core agents (Security, Architecture, Correctness) when the planner omitted them. This caused team drift across review rounds (see [#626](https://github.com/manki-review/manki/pull/626)).
- After resolving picks, missing core agents are now prepended to the resolved team in `CORE_AGENTS` order. Each injection is logged via `core.info`.
- Fall-through to the heuristic path is unchanged when zero picks resolve.

Closes #638. Sub 1 of #637.

## Test plan

- [x] `npm run test` — `src/review.test.ts` covers the three new cases (planner omits all core, planner picks subset, planner picks all three).
- [x] `npm run lint`
- [x] `npm run typecheck`