### PR TITLE
feat: pin review team across rounds with monotonic growth

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -456,6 +456,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -480,6 +481,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -506,6 +508,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -532,6 +535,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -558,6 +562,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -582,6 +587,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -597,6 +603,7 @@ describe('postReview generalFindings', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -621,6 +628,7 @@ describe('postReview generalFindings', () => {
       ],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -731,6 +739,7 @@ describe('postReview with stats', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
     const stats: ReviewStats = {
       model: 'claude-sonnet-4-20250514',
@@ -765,6 +774,7 @@ describe('postReview with stats', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -795,6 +805,7 @@ describe('postReview partialNote', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
       partialNote: '4 of 5 agents completed (Correctness & Logic failed after 2 attempts)',
     };
 
@@ -812,6 +823,7 @@ describe('postReview partialNote', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -2432,6 +2444,7 @@ describe('postReview fallback paths', () => {
       }],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     const reviewId = await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -2463,6 +2476,7 @@ describe('postReview fallback paths', () => {
       }],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     const reviewId = await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -2492,6 +2506,7 @@ describe('postReview fallback paths', () => {
       }],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     const reviewId = await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
@@ -2518,6 +2533,7 @@ describe('postReview fallback paths', () => {
       }],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await expect(postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result)).rejects.toThrow('API error');
@@ -2548,6 +2564,7 @@ describe('postReview fallback paths', () => {
       }],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result, diff);
@@ -2586,6 +2603,7 @@ describe('postReview fallback paths', () => {
       }],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     };
 
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result, diff);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2008,8 +2008,9 @@ describe('runFullReview orchestration', () => {
     // Write path: appendHandoverRound must be called once with the loaded handover
     expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
     const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
-    // existingHandover param (index 11) should be the already-loaded handover, not re-fetched
-    expect(appendCall[11]).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
+    const { 8: agentsArg, 11: existingHandoverArg } = appendCall;
+    // agents param carries the resolved team; existingHandover param should be the already-loaded handover, not re-fetched
+    expect(existingHandoverArg).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
   });
 
   it('persists the resolved team names on the new handover round', async () => {
@@ -2046,8 +2047,9 @@ describe('runFullReview orchestration', () => {
 
     expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
     const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
-    // agents param (index 8) carries the resolved team into the new round
-    expect(appendCall[8]).toEqual(resolvedNames);
+    const { 8: agentsArg } = appendCall;
+    // agents param carries the resolved team into the new round
+    expect(agentsArg).toEqual(resolvedNames);
   });
 
   it('forwards prior-round agents through to the dashboard selectTeam call', async () => {
@@ -2113,9 +2115,13 @@ describe('runFullReview orchestration', () => {
     // The dashboard selectTeam call inside the planning callback receives the
     // prior-round agents as the 6th positional argument.
     const calls = jest.mocked(reviewModule.selectTeam).mock.calls;
-    const planningCall = calls.find(c => c[3] === 3 && c[4]);
+    // Identify the planning-phase call by the exact agent picks the planner emitted.
+    const planningCall = calls.find(c =>
+      Array.isArray(c[4]) && c[4].length === 3 && c[4][0]?.name === 'Security & Safety',
+    );
     expect(planningCall).toBeDefined();
-    expect(planningCall![5]).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
+    const { 5: priorRoundAgentsArg } = planningCall!;
+    expect(priorRoundAgentsArg).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
   });
 
   it('does not load or write handover when memory is disabled', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2285,6 +2285,11 @@ describe('runFullReview orchestration', () => {
       expect(agentNames).not.toContain('Bogus Unknown Agent');
       // agentCount reflects only known-pool agents that were reconciled.
       expect(finalDashboard.agentCount).toBe(resolvedNames.length);
+      // The dashboard pre-population path silently skips unknown agents — no warning
+      // should fire for the unknown name here (selectTeam handles its own warning).
+      const bogusWarnings = jest.mocked(core.warning).mock.calls
+        .filter(c => String(c[0]).includes('Bogus Unknown Agent'));
+      expect(bogusWarnings).toHaveLength(0);
     });
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2021,166 +2021,136 @@ describe('runFullReview orchestration', () => {
     expect(existingHandoverArg).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
   });
 
-  it('persists the resolved team names on the new handover round', async () => {
-    const testFile = {
+  describe('prior-round agent pinning', () => {
+    const pinTestFile = {
       path: 'src/app.ts', changeType: 'modified' as const,
       hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
     };
-    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
-    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
-      files: [testFile], totalAdditions: 10, totalDeletions: 5,
-    });
-    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
 
-    jest.mocked(configModule.loadConfig).mockReturnValue({
-      auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
-      reviewers: [], instructions: '', review_level: 'auto',
-      review_thresholds: { small: 200, medium: 800 },
-      memory: { enabled: true, repo: 'owner/memory' },
-    });
-    jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
-    jest.mocked(memoryModule.loadMemory).mockResolvedValue({
-      learnings: [], suppressions: [], patterns: [],
-    });
-    jest.mocked(memoryModule.loadHandover).mockResolvedValue(null);
-
-    const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
-    jest.mocked(reviewModule.runReview).mockResolvedValue({
-      verdict: 'APPROVE', summary: 'ok',
-      findings: [], highlights: [], reviewComplete: true,
-      agentNames: resolvedNames,
-    });
-
-    await callRunFullReview();
-
-    expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
-    const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
-    const { 8: agentsArg } = appendCall;
-    // agents param carries the resolved team into the new round
-    expect(agentsArg).toEqual(resolvedNames);
-  });
-
-  it('forwards prior-round agents through to the dashboard selectTeam call', async () => {
-    const testFile = {
-      path: 'src/app.ts', changeType: 'modified' as const,
-      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
-    };
-    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
-    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
-      files: [testFile], totalAdditions: 10, totalDeletions: 5,
-    });
-    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
-
-    jest.mocked(configModule.loadConfig).mockReturnValue({
-      auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
-      reviewers: [], instructions: '', review_level: 'auto',
-      review_thresholds: { small: 200, medium: 800 },
-      memory: { enabled: true, repo: 'owner/memory' },
-    });
-    jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
-    jest.mocked(memoryModule.loadMemory).mockResolvedValue({
-      learnings: [], suppressions: [], patterns: [],
-    });
-
-    const priorRounds = [{
-      round: 1,
-      commitSha: 'abc',
-      timestamp: '2025-01-01T00:00:00Z',
-      findings: [],
-      agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
-    }];
-    jest.mocked(memoryModule.loadHandover).mockResolvedValue({
-      prNumber: 1, repo: 'test-repo', rounds: priorRounds,
-    });
-
-    // Trigger the planning-phase progress callback so the dashboard selectTeam runs.
-    jest.mocked(reviewModule.runReview).mockImplementation(async (_clients, _config, _diff, _rawDiff, _ctx, _mem, _files, _pr, _issues, onProgress) => {
-      onProgress?.({
-        phase: 'planning',
-        rawFindingCount: 0,
-        plannerResult: {
-          teamSize: 3,
-          reviewerEffort: 'medium',
-          judgeEffort: 'medium',
-          prType: 'feature',
-          agents: [
-            { name: 'Security & Safety', effort: 'high' },
-            { name: 'Architecture & Design', effort: 'medium' },
-            { name: 'Correctness & Logic', effort: 'medium' },
-          ],
-        },
-        plannerDurationMs: 100,
+    beforeEach(() => {
+      jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [pinTestFile], totalAdditions: 10, totalDeletions: 5,
       });
-      return {
+      jest.mocked(diffModule.filterFiles).mockReturnValue([pinTestFile]);
+      jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
+      jest.mocked(memoryModule.loadMemory).mockResolvedValue({
+        learnings: [], suppressions: [], patterns: [],
+      });
+      jest.mocked(configModule.loadConfig).mockReturnValue({
+        auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+        reviewers: [], instructions: '', review_level: 'auto',
+        review_thresholds: { small: 200, medium: 800 },
+        memory: { enabled: true, repo: 'owner/memory' },
+      });
+    });
+
+    it('persists the resolved team names on the new handover round', async () => {
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue(null);
+
+      const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+      jest.mocked(reviewModule.runReview).mockResolvedValue({
         verdict: 'APPROVE', summary: 'ok',
         findings: [], highlights: [], reviewComplete: true,
-        agentNames: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
-      };
+        agentNames: resolvedNames,
+      });
+
+      await callRunFullReview();
+
+      expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
+      const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
+      const { 8: agentsArg } = appendCall;
+      // agents param carries the resolved team into the new round
+      expect(agentsArg).toEqual(resolvedNames);
     });
 
-    await callRunFullReview();
+    it('forwards prior-round agents through to the dashboard selectTeam call', async () => {
+      const priorRounds = [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+      }];
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+      });
 
-    // The dashboard selectTeam call inside the planning callback receives the
-    // prior-round agents as the 6th positional argument.
-    const calls = jest.mocked(reviewModule.selectTeam).mock.calls;
-    // Identify the planning-phase call by the exact agent picks the planner emitted.
-    const planningCall = calls.find(c =>
-      Array.isArray(c[4]) && c[4].length === 3 && c[4][0]?.name === 'Security & Safety',
-    );
-    expect(planningCall).toBeDefined();
-    const { 5: priorRoundAgentsArg } = planningCall!;
-    expect(priorRoundAgentsArg).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
-  });
+      // Trigger the planning-phase progress callback so the dashboard selectTeam runs.
+      jest.mocked(reviewModule.runReview).mockImplementation(async (_clients, _config, _diff, _rawDiff, _ctx, _mem, _files, _pr, _issues, onProgress) => {
+        onProgress?.({
+          phase: 'planning',
+          rawFindingCount: 0,
+          plannerResult: {
+            teamSize: 3,
+            reviewerEffort: 'medium',
+            judgeEffort: 'medium',
+            prType: 'feature',
+            agents: [
+              { name: 'Security & Safety', effort: 'high' },
+              { name: 'Architecture & Design', effort: 'medium' },
+              { name: 'Correctness & Logic', effort: 'medium' },
+            ],
+          },
+          plannerDurationMs: 100,
+        });
+        return {
+          verdict: 'APPROVE', summary: 'ok',
+          findings: [], highlights: [], reviewComplete: true,
+          agentNames: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+        };
+      });
 
-  it('reconciles non-planner dashboard with pinned agents after runReview', async () => {
-    const testFile = {
-      path: 'src/app.ts', changeType: 'modified' as const,
-      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
-    };
-    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
-    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
-      files: [testFile], totalAdditions: 10, totalDeletions: 5,
-    });
-    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+      await callRunFullReview();
 
-    // Non-planner path: review_level is explicitly 'small', not 'auto'.
-    jest.mocked(configModule.loadConfig).mockReturnValue({
-      auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
-      reviewers: [], instructions: '', review_level: 'small',
-      review_thresholds: { small: 200, medium: 800 },
-      memory: { enabled: true, repo: 'owner/memory' },
-    });
-    jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
-    jest.mocked(memoryModule.loadMemory).mockResolvedValue({
-      learnings: [], suppressions: [], patterns: [],
-    });
-
-    const priorRounds = [{
-      round: 1,
-      commitSha: 'abc',
-      timestamp: '2025-01-01T00:00:00Z',
-      findings: [],
-      agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
-    }];
-    jest.mocked(memoryModule.loadHandover).mockResolvedValue({
-      prNumber: 1, repo: 'test-repo', rounds: priorRounds,
-    });
-
-    const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'];
-    jest.mocked(reviewModule.runReview).mockResolvedValue({
-      verdict: 'APPROVE', summary: 'ok',
-      findings: [], highlights: [], reviewComplete: true,
-      agentNames: resolvedNames,
+      // The dashboard selectTeam call inside the planning callback receives the
+      // prior-round agents as the 6th positional argument.
+      const calls = jest.mocked(reviewModule.selectTeam).mock.calls;
+      // Identify the planning-phase call by the exact agent picks the planner emitted.
+      const planningCall = calls.find(c =>
+        Array.isArray(c[4]) && c[4].length === 3 && c[4][0]?.name === 'Security & Safety',
+      );
+      expect(planningCall).toBeDefined();
+      const { 5: priorRoundAgentsArg } = planningCall!;
+      expect(priorRoundAgentsArg).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
     });
 
-    await callRunFullReview();
+    it('reconciles non-planner dashboard with pinned agents after runReview', async () => {
+      // Non-planner path: review_level is explicitly 'small', not 'auto'.
+      jest.mocked(configModule.loadConfig).mockReturnValue({
+        auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+        reviewers: [], instructions: '', review_level: 'small',
+        review_thresholds: { small: 200, medium: 800 },
+        memory: { enabled: true, repo: 'owner/memory' },
+      });
 
-    // The final completeDashboard passed to updateProgressComment must include the pinned agents.
-    const progressCommentCalls = jest.mocked(ghUtils.updateProgressComment).mock.calls;
-    expect(progressCommentCalls.length).toBeGreaterThan(0);
-    const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
-    expect(finalDashboard.agentCount).toBe(4);
-    expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(resolvedNames);
+      const priorRounds = [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+      }];
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+      });
+
+      const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'];
+      jest.mocked(reviewModule.runReview).mockResolvedValue({
+        verdict: 'APPROVE', summary: 'ok',
+        findings: [], highlights: [], reviewComplete: true,
+        agentNames: resolvedNames,
+      });
+
+      await callRunFullReview();
+
+      // The final completeDashboard passed to updateProgressComment must include the pinned agents.
+      const progressCommentCalls = jest.mocked(ghUtils.updateProgressComment).mock.calls;
+      expect(progressCommentCalls.length).toBeGreaterThan(0);
+      const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
+      expect(finalDashboard.agentCount).toBe(4);
+      expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(resolvedNames);
+    });
   });
 
   it('does not load or write handover when memory is disabled', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2008,8 +2008,114 @@ describe('runFullReview orchestration', () => {
     // Write path: appendHandoverRound must be called once with the loaded handover
     expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
     const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
-    // existingHandover param (index 10) should be the already-loaded handover, not re-fetched
-    expect(appendCall[10]).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
+    // existingHandover param (index 11) should be the already-loaded handover, not re-fetched
+    expect(appendCall[11]).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
+  });
+
+  it('persists the resolved team names on the new handover round', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+      reviewers: [], instructions: '', review_level: 'auto',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: true, repo: 'owner/memory' },
+    });
+    jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
+    jest.mocked(memoryModule.loadMemory).mockResolvedValue({
+      learnings: [], suppressions: [], patterns: [],
+    });
+    jest.mocked(memoryModule.loadHandover).mockResolvedValue(null);
+
+    const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'APPROVE', summary: 'ok',
+      findings: [], highlights: [], reviewComplete: true,
+      agentNames: resolvedNames,
+    });
+
+    await callRunFullReview();
+
+    expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
+    const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
+    // agents param (index 8) carries the resolved team into the new round
+    expect(appendCall[8]).toEqual(resolvedNames);
+  });
+
+  it('forwards prior-round agents through to the dashboard selectTeam call', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+      reviewers: [], instructions: '', review_level: 'auto',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: true, repo: 'owner/memory' },
+    });
+    jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
+    jest.mocked(memoryModule.loadMemory).mockResolvedValue({
+      learnings: [], suppressions: [], patterns: [],
+    });
+
+    const priorRounds = [{
+      round: 1,
+      commitSha: 'abc',
+      timestamp: '2025-01-01T00:00:00Z',
+      findings: [],
+      agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+    }];
+    jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+      prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+    });
+
+    // Trigger the planning-phase progress callback so the dashboard selectTeam runs.
+    jest.mocked(reviewModule.runReview).mockImplementation(async (_clients, _config, _diff, _rawDiff, _ctx, _mem, _files, _pr, _issues, onProgress) => {
+      onProgress?.({
+        phase: 'planning',
+        rawFindingCount: 0,
+        plannerResult: {
+          teamSize: 3,
+          reviewerEffort: 'medium',
+          judgeEffort: 'medium',
+          prType: 'feature',
+          agents: [
+            { name: 'Security & Safety', effort: 'high' },
+            { name: 'Architecture & Design', effort: 'medium' },
+            { name: 'Correctness & Logic', effort: 'medium' },
+          ],
+        },
+        plannerDurationMs: 100,
+      });
+      return {
+        verdict: 'APPROVE', summary: 'ok',
+        findings: [], highlights: [], reviewComplete: true,
+        agentNames: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+      };
+    });
+
+    await callRunFullReview();
+
+    // The dashboard selectTeam call inside the planning callback receives the
+    // prior-round agents as the 6th positional argument.
+    const calls = jest.mocked(reviewModule.selectTeam).mock.calls;
+    const planningCall = calls.find(c => c[3] === 3 && c[4]);
+    expect(planningCall).toBeDefined();
+    expect(planningCall![5]).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
   });
 
   it('does not load or write handover when memory is disabled', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -111,6 +111,7 @@ jest.mock('./review', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     }),
     determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' }),
     selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
@@ -1363,6 +1364,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'Looks good',
       findings: [], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
     jest.mocked(reviewModule.selectTeam).mockReturnValue({ level: 'standard' as 'small', agents: [{ name: 'general', focus: '' }], lineCount: 0 });
@@ -1512,6 +1514,7 @@ describe('runFullReview orchestration', () => {
       findings,
       highlights: [],
       reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
@@ -1814,6 +1817,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Minor nits',
       findings: [nitFinding], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
@@ -1854,6 +1858,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Minor nits',
       findings: [nitFinding], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
@@ -1888,6 +1893,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'Review incomplete',
       findings: [], highlights: [], reviewComplete: false,
+      agentNames: [],
     });
 
     await callRunFullReview();
@@ -1944,6 +1950,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Issues',
       findings: [finding2], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
 
     await callRunFullReview();
@@ -2173,9 +2180,7 @@ describe('runFullReview orchestration', () => {
     expect(progressCommentCalls.length).toBeGreaterThan(0);
     const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
     expect(finalDashboard.agentCount).toBe(4);
-    expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(
-      expect.arrayContaining(resolvedNames),
-    );
+    expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(resolvedNames);
   });
 
   it('does not load or write handover when memory is disabled', async () => {
@@ -2233,6 +2238,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Nits',
       findings: [finding], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
     jest.mocked(memoryModule.applyEscalations).mockReturnValue([escalated]);
@@ -2266,6 +2272,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'Looks good',
       findings: [], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [], duplicates: [] });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
@@ -2295,6 +2302,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Suggestions',
       findings: [finding], highlights: [], reviewComplete: true,
+      agentNames: [],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_nit_or_suggestion' });
@@ -2358,6 +2366,7 @@ describe('runFullReview orchestration', () => {
         return {
           verdict: 'APPROVE', summary: 'ok', findings: [],
           highlights: [], reviewComplete: true,
+          agentNames: [],
         };
       },
     );
@@ -2414,6 +2423,7 @@ describe('runFullReview orchestration', () => {
         return {
           verdict: 'APPROVE', summary: 'ok', findings: [],
           highlights: [], reviewComplete: true,
+          agentNames: [],
         };
       },
     );
@@ -2460,6 +2470,7 @@ describe('runFullReview orchestration', () => {
         return {
           verdict: 'APPROVE', summary: 'ok', findings: [],
           highlights: [], reviewComplete: true,
+          agentNames: [],
         };
       },
     );
@@ -2502,6 +2513,7 @@ describe('runFullReview orchestration', () => {
         return {
           verdict: 'APPROVE', summary: 'ok', findings: [],
           highlights: [], reviewComplete: true,
+          agentNames: [],
         };
       },
     );
@@ -2562,6 +2574,7 @@ describe('runFullReview orchestration', () => {
         return {
           verdict: 'COMMENT', summary: 'Issues found',
           findings: [finding1, finding2], highlights: [], reviewComplete: true,
+          agentNames: [],
         };
       },
     );
@@ -2800,6 +2813,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'No changes since last review', findings: [],
       highlights: [], reviewComplete: true,
+      agentNames: [],
       threadEvaluations: [
         { threadId: 'PRRT_a', status: 'addressed', reason: 'LLM hallucination' },
       ],
@@ -2860,6 +2874,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'No changes since last review', findings: [],
       highlights: [], reviewComplete: true,
+      agentNames: [],
       threadEvaluations: [
         { threadId: 'PRRT_a', status: 'not_addressed', reason: 'No code changes since prior review' },
       ],
@@ -2920,6 +2935,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
+      agentNames: [],
       threadEvaluations: [
         { threadId: 'PRRT_abc', status: 'addressed', reason: 'Fixed in latest push' },
       ],
@@ -2965,6 +2981,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
+      agentNames: [],
       threadEvaluations: [
         { threadId: 'PRRT_abc', status: 'addressed', reason: 'Fixed in new diff' },
         { threadId: 'PRRT_def', status: 'not_addressed', reason: 'Still applies' },
@@ -3018,6 +3035,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
+      agentNames: [],
       threadEvaluations: [
         { threadId: 'PRRT_known', status: 'addressed', reason: 'Legit fix' },
         { threadId: 'PRRT_unknown', status: 'addressed', reason: 'Injected by adversary' },
@@ -3093,6 +3111,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
+      agentNames: [],
       threadEvaluations: [
         { threadId: 'PRRT_fail', status: 'addressed', reason: 'Should fail' },
       ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,7 +116,9 @@ jest.mock('./review', () => {
     determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' }),
     selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
     buildPlannerHints: actual.buildPlannerHints,
+    buildAgentPool: actual.buildAgentPool,
     collectPriorRoundAgents: actual.collectPriorRoundAgents,
+    TRIVIAL_VERIFIER_AGENT: actual.TRIVIAL_VERIFIER_AGENT,
   };
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,6 +115,7 @@ jest.mock('./review', () => {
     determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' }),
     selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
     buildPlannerHints: actual.buildPlannerHints,
+    collectPriorRoundAgents: actual.collectPriorRoundAgents,
   };
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2066,6 +2066,22 @@ describe('runFullReview orchestration', () => {
       expect(agentsArg).toEqual(resolvedNames);
     });
 
+    it('filters TRIVIAL_VERIFIER_AGENT name from agents persisted to handover', async () => {
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue(null);
+      jest.mocked(reviewModule.runReview).mockResolvedValue({
+        verdict: 'APPROVE', summary: 'ok',
+        findings: [], highlights: [], reviewComplete: true,
+        agentNames: [reviewModule.TRIVIAL_VERIFIER_AGENT.name],
+      });
+
+      await callRunFullReview();
+
+      expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
+      const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
+      const { 8: agentsArg } = appendCall;
+      expect(agentsArg).toEqual([]);
+    });
+
     it('forwards prior-round agents through to the dashboard selectTeam call', async () => {
       const priorRounds = [{
         round: 1,
@@ -2115,6 +2131,60 @@ describe('runFullReview orchestration', () => {
       expect(planningCall).toBeDefined();
       const { 5: priorRoundAgentsArg } = planningCall!;
       expect(priorRoundAgentsArg).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
+    });
+
+    it('reconciles planner-path dashboard with prior-round agents after runReview', async () => {
+      // Planner path: review_level is 'auto' (set by beforeEach) and prior rounds exist.
+      const priorRounds = [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Architecture & Design'],
+      }];
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+      });
+
+      const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+      jest.mocked(reviewModule.runReview).mockImplementation(async (_clients, _config, _diff, _rawDiff, _ctx, _mem, _files, _pr, _issues, onProgress) => {
+        onProgress?.({
+          phase: 'planning',
+          rawFindingCount: 0,
+          plannerResult: {
+            teamSize: 3,
+            reviewerEffort: 'medium',
+            judgeEffort: 'medium',
+            prType: 'feature',
+            agents: [
+              { name: 'Security & Safety', effort: 'high' },
+              { name: 'Architecture & Design', effort: 'medium' },
+              { name: 'Correctness & Logic', effort: 'medium' },
+            ],
+          },
+          plannerDurationMs: 100,
+        });
+        return {
+          verdict: 'APPROVE', summary: 'ok',
+          findings: [], highlights: [], reviewComplete: true,
+          agentNames: resolvedNames,
+          plannerResult: {
+            teamSize: 3,
+            reviewerEffort: 'medium',
+            judgeEffort: 'medium',
+            prType: 'feature',
+            agents: [],
+          },
+        };
+      });
+
+      await callRunFullReview();
+
+      const progressCommentCalls = jest.mocked(ghUtils.updateProgressComment).mock.calls;
+      expect(progressCommentCalls.length).toBeGreaterThan(0);
+      const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
+      expect(finalDashboard.agentCount).toBe(3);
+      expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(resolvedNames);
     });
 
     it('reconciles non-planner dashboard with pinned agents after runReview', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2125,6 +2125,59 @@ describe('runFullReview orchestration', () => {
     expect(priorRoundAgentsArg).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage']);
   });
 
+  it('reconciles non-planner dashboard with pinned agents after runReview', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    // Non-planner path: review_level is explicitly 'small', not 'auto'.
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+      reviewers: [], instructions: '', review_level: 'small',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: true, repo: 'owner/memory' },
+    });
+    jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
+    jest.mocked(memoryModule.loadMemory).mockResolvedValue({
+      learnings: [], suppressions: [], patterns: [],
+    });
+
+    const priorRounds = [{
+      round: 1,
+      commitSha: 'abc',
+      timestamp: '2025-01-01T00:00:00Z',
+      findings: [],
+      agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+    }];
+    jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+      prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+    });
+
+    const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'];
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'APPROVE', summary: 'ok',
+      findings: [], highlights: [], reviewComplete: true,
+      agentNames: resolvedNames,
+    });
+
+    await callRunFullReview();
+
+    // The final completeDashboard passed to updateProgressComment must include the pinned agents.
+    const progressCommentCalls = jest.mocked(ghUtils.updateProgressComment).mock.calls;
+    expect(progressCommentCalls.length).toBeGreaterThan(0);
+    const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
+    expect(finalDashboard.agentCount).toBe(4);
+    expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(
+      expect.arrayContaining(resolvedNames),
+    );
+  });
+
   it('does not load or write handover when memory is disabled', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2008,8 +2008,8 @@ describe('runFullReview orchestration', () => {
     // Write path: appendHandoverRound must be called once with the loaded handover
     expect(jest.mocked(memoryModule.appendHandoverRound)).toHaveBeenCalledTimes(1);
     const appendCall = jest.mocked(memoryModule.appendHandoverRound).mock.calls[0];
-    const { 8: agentsArg, 11: existingHandoverArg } = appendCall;
-    // agents param carries the resolved team; existingHandover param should be the already-loaded handover, not re-fetched
+    const { 11: existingHandoverArg } = appendCall;
+    // existingHandover param should be the already-loaded handover, not re-fetched
     expect(existingHandoverArg).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2147,6 +2147,14 @@ describe('runFullReview orchestration', () => {
       });
 
       const resolvedNames = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+      // Override selectTeam so the planning-phase callback seeds the dashboard with the
+      // actual resolved agent names; this lets agent-complete metrics be preserved through
+      // the reconcileDashboardAgents call.
+      jest.mocked(reviewModule.selectTeam).mockReturnValue({
+        level: 'standard' as 'small',
+        agents: resolvedNames.map(n => ({ name: n, focus: '' })),
+        lineCount: 0,
+      });
       jest.mocked(reviewModule.runReview).mockImplementation(async (_clients, _config, _diff, _rawDiff, _ctx, _mem, _files, _pr, _issues, onProgress) => {
         onProgress?.({
           phase: 'planning',
@@ -2163,6 +2171,16 @@ describe('runFullReview orchestration', () => {
             ],
           },
           plannerDurationMs: 100,
+        });
+        onProgress?.({
+          phase: 'agent-complete',
+          agentName: 'Security & Safety',
+          agentFindingCount: 3,
+          agentDurationMs: 1200,
+          agentStatus: 'success',
+          rawFindingCount: 3,
+          completedAgents: 1,
+          totalAgents: 3,
         });
         return {
           verdict: 'APPROVE', summary: 'ok',
@@ -2185,6 +2203,10 @@ describe('runFullReview orchestration', () => {
       const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
       expect(finalDashboard.agentCount).toBe(3);
       expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(resolvedNames);
+      // Verify reconcileDashboardAgents preserves metrics from prior agent-complete callbacks.
+      const secEntry = finalDashboard.agentProgress?.find((a: { name: string }) => a.name === 'Security & Safety');
+      expect(secEntry?.findingCount).toBe(3);
+      expect(secEntry?.durationMs).toBe(1200);
     });
 
     it('reconciles non-planner dashboard with pinned agents after runReview', async () => {
@@ -2222,6 +2244,47 @@ describe('runFullReview orchestration', () => {
       const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
       expect(finalDashboard.agentCount).toBe(4);
       expect(finalDashboard.agentProgress?.map((a: { name: string }) => a.name)).toEqual(resolvedNames);
+    });
+
+    it('silently drops unknown prior-round agent from non-planner dashboard without error', async () => {
+      // Non-planner path with a prior-round agent name not present in the agent pool.
+      // The pool-check guard in runFullReview silently omits the unknown agent from the
+      // dashboard; selectTeam already warns for this case so no duplicate warning is needed.
+      jest.mocked(configModule.loadConfig).mockReturnValue({
+        auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+        reviewers: [], instructions: '', review_level: 'small',
+        review_thresholds: { small: 200, medium: 800 },
+        memory: { enabled: true, repo: 'owner/memory' },
+      });
+
+      const priorRounds = [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Bogus Unknown Agent'],
+      }];
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+      });
+
+      const resolvedNames = ['Security & Safety'];
+      jest.mocked(reviewModule.runReview).mockResolvedValue({
+        verdict: 'APPROVE', summary: 'ok',
+        findings: [], highlights: [], reviewComplete: true,
+        agentNames: resolvedNames,
+      });
+
+      await expect(callRunFullReview()).resolves.not.toThrow();
+
+      const progressCommentCalls = jest.mocked(ghUtils.updateProgressComment).mock.calls;
+      expect(progressCommentCalls.length).toBeGreaterThan(0);
+      const finalDashboard = progressCommentCalls[progressCommentCalls.length - 1][4];
+      // Unknown agent must not appear in the dashboard.
+      const agentNames = finalDashboard.agentProgress?.map((a: { name: string }) => a.name) ?? [];
+      expect(agentNames).not.toContain('Bogus Unknown Agent');
+      // agentCount reflects only known-pool agents that were reconciled.
+      expect(finalDashboard.agentCount).toBe(resolvedNames.length);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,6 +404,7 @@ async function runFullReview(
         findings: [],
         highlights: [],
         reviewComplete: true,
+        agentNames: [] as string[],
       };
       // Dismiss stale CHANGES_REQUESTED reviews before posting the skip comment
       try {
@@ -427,6 +428,7 @@ async function runFullReview(
         findings: [],
         highlights: [],
         reviewComplete: true,
+        agentNames: [] as string[],
       };
       await dismissPreviousReviews(octokit, owner, repo, prNumber);
       await postReview(octokit, owner, repo, prNumber, commitSha, result, diff);
@@ -679,7 +681,7 @@ async function runFullReview(
     }
 
     // Per-agent metrics: count raw and kept findings per agent
-    const agentNames = result.agentNames ?? [];
+    const agentNames = result.agentNames;
     const allJudged = result.allJudgedFindings ?? [];
     const rawFindings = result.rawFindings ?? allJudged;
     const agentMetrics = agentNames.length > 0
@@ -739,7 +741,7 @@ async function runFullReview(
       diffAdditions: diff.totalAdditions,
       diffDeletions: diff.totalDeletions,
       filesReviewed: filteredFiles.length,
-      agents: result.agentNames ?? [],
+      agents: result.agentNames,
       findingsRaw: result.rawFindingCount ?? result.findings.length,
       findingsKept: result.findings.length,
       findingsDropped: (result.rawFindingCount ?? result.findings.length) - result.findings.length,
@@ -826,7 +828,7 @@ async function runFullReview(
             result.findings,
             recap.previousFindings,
             result.summary,
-            result.agentNames ?? [],
+            result.agentNames,
             fingerprintFinding,
             classifyAuthorReply,
             handover,
@@ -844,12 +846,12 @@ async function runFullReview(
         judgeEffort: result.plannerResult.judgeEffort,
         prType: result.plannerResult.prType,
       };
-      dashboard.agentCount = result.agentNames?.length ?? dashboard.agentCount;
-      dashboard.agentProgress = result.agentNames?.map(name => {
+      dashboard.agentCount = result.agentNames.length;
+      dashboard.agentProgress = result.agentNames.map(name => {
         const existing = dashboard.agentProgress?.find(a => a.name === name);
         return existing ?? { name, status: 'done' as const };
       });
-    } else if (priorRoundAgents.length > 0 && result.agentNames) {
+    } else if (priorRoundAgents.length > 0) {
       // Non-planner path: reconcile the dashboard with the actual resolved team.
       // The initial dashboard was built without priorRoundAgents (not yet loaded),
       // so on round 2+ it would show a stale, too-small agent list.
@@ -911,7 +913,7 @@ async function runFullReview(
         judgeModel,
         reviewLevel: team.level,
         reviewLevelReason: `auto, ${diff.totalAdditions + diff.totalDeletions} lines`,
-        teamAgents: result.agentNames ?? team.agents.map(a => a.name),
+        teamAgents: result.agentNames,
         memoryEnabled: config.memory?.enabled ?? false,
         memoryRepo: config.memory?.repo ?? '',
         nitHandling,

--- a/src/index.ts
+++ b/src/index.ts
@@ -567,7 +567,7 @@ async function runFullReview(
               judgeEffort: progress.plannerResult.judgeEffort,
               prType: progress.plannerResult.prType,
             };
-            const plannerTeam = selectTeam(diff, config, config.reviewers, progress.plannerResult.teamSize, progress.plannerResult.agents, priorRoundAgents);
+            const plannerTeam = selectTeam(diff, config, config.reviewers, progress.plannerResult.teamSize, progress.plannerResult.agents, priorRoundAgents, true);
             dashboard.agentCount = plannerTeam.agents.length;
             dashboard.agentProgress = plannerTeam.agents.map(a => ({ name: a.name, status: 'reviewing' as const }));
             dashboard.plannerDurationMs = progress.plannerDurationMs;
@@ -846,6 +846,15 @@ async function runFullReview(
       };
       dashboard.agentCount = result.agentNames?.length ?? dashboard.agentCount;
       dashboard.agentProgress = result.agentNames?.map(name => {
+        const existing = dashboard.agentProgress?.find(a => a.name === name);
+        return existing ?? { name, status: 'done' as const };
+      });
+    } else if (priorRoundAgents.length > 0 && result.agentNames) {
+      // Non-planner path: reconcile the dashboard with the actual resolved team.
+      // The initial dashboard was built without priorRoundAgents (not yet loaded),
+      // so on round 2+ it would show a stale, too-small agent list.
+      dashboard.agentCount = result.agentNames.length;
+      dashboard.agentProgress = result.agentNames.map(name => {
         const existing = dashboard.agentProgress?.find(a => a.name === name);
         return existing ?? { name, status: 'done' as const };
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -564,7 +564,6 @@ async function runFullReview(
       for (const name of priorRoundAgents) {
         if (!inDashboard.has(name) && poolNames.has(name)) {
           dashboard.agentProgress.push({ name, status: 'reviewing' as const });
-          dashboard.agentCount++;
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,11 +854,11 @@ async function runFullReview(
         judgeEffort: result.plannerResult.judgeEffort,
         prType: result.plannerResult.prType,
       };
-      reconcileDashboardAgents(dashboard, result.agentNames);
-    } else if (priorRoundAgents.length > 0) {
-      // Non-planner path: reconcile the dashboard with the actual resolved team.
-      // The initial dashboard was built without priorRoundAgents (not yet loaded),
-      // so on round 2+ it would show a stale, too-small agent list.
+    }
+    if (result.plannerResult || priorRoundAgents.length > 0) {
+      // Reconcile the dashboard with the actual resolved team. On round 2+ the
+      // initial dashboard was built without priorRoundAgents (not yet loaded),
+      // so the agent list would otherwise show a stale, too-small count.
       reconcileDashboardAgents(dashboard, result.agentNames);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { isEmptyInterRoundDiff } from './judge';
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
-import { runReview, determineVerdict, selectTeam } from './review';
+import { collectPriorRoundAgents, runReview, determineVerdict, selectTeam } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
@@ -543,9 +543,7 @@ async function runFullReview(
     // Names of every agent that participated in any prior round of this PR.
     // Used to pin the team across rounds so the roster grows monotonically:
     // an agent that flagged something earlier always reviews later rounds.
-    const priorRoundAgents: string[] = handover
-      ? Array.from(new Set(handover.rounds.flatMap(r => r.agents ?? [])))
-      : [];
+    const priorRoundAgents = collectPriorRoundAgents(handover?.rounds);
 
     function scheduleDashboardFlush(): void {
       if (dashboardFlushTimer) clearTimeout(dashboardFlushTimer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,6 +377,9 @@ async function runFullReview(
     const parseEndTime = Date.now();
     const plannerEnabled = !!plannerClient && config.review_level === 'auto';
     const team = selectTeam(diff, config, config.reviewers);
+    // `team` here is only used for the initial dashboard preview; the actual
+    // review team is resolved inside `runReview` once the handover and planner
+    // result are available, so prior-round pinning is applied there.
     const lineCount = diff.totalAdditions + diff.totalDeletions;
 
     const dashboard: DashboardData = plannerEnabled
@@ -537,6 +540,13 @@ async function runFullReview(
 
     let reviewEndTime = parseEndTime;
 
+    // Names of every agent that participated in any prior round of this PR.
+    // Used to pin the team across rounds so the roster grows monotonically:
+    // an agent that flagged something earlier always reviews later rounds.
+    const priorRoundAgents: string[] = handover
+      ? Array.from(new Set(handover.rounds.flatMap(r => r.agents ?? [])))
+      : [];
+
     function scheduleDashboardFlush(): void {
       if (dashboardFlushTimer) clearTimeout(dashboardFlushTimer);
       dashboardFlushTimer = setTimeout(() => {
@@ -559,7 +569,7 @@ async function runFullReview(
               judgeEffort: progress.plannerResult.judgeEffort,
               prType: progress.plannerResult.prType,
             };
-            const plannerTeam = selectTeam(diff, config, config.reviewers, progress.plannerResult.teamSize, progress.plannerResult.agents);
+            const plannerTeam = selectTeam(diff, config, config.reviewers, progress.plannerResult.teamSize, progress.plannerResult.agents, priorRoundAgents);
             dashboard.agentCount = plannerTeam.agents.length;
             dashboard.agentProgress = plannerTeam.agents.map(a => ({ name: a.name, status: 'reviewing' as const }));
             dashboard.plannerDurationMs = progress.plannerDurationMs;
@@ -818,6 +828,7 @@ async function runFullReview(
             result.findings,
             recap.previousFindings,
             result.summary,
+            result.agentNames ?? [],
             fingerprintFinding,
             classifyAuthorReply,
             handover,

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,14 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
   await runFullReview(owner, repo, prNumber, pr.head.sha, pr.base.ref, prContext, pr.user?.login);
 }
 
+function reconcileDashboardAgents(dashboard: DashboardData, names: string[]): void {
+  dashboard.agentCount = names.length;
+  dashboard.agentProgress = names.map(name => {
+    const existing = dashboard.agentProgress?.find(a => a.name === name);
+    return existing ?? { name, status: 'done' as const };
+  });
+}
+
 async function runFullReview(
   owner: string,
   repo: string,
@@ -846,20 +854,12 @@ async function runFullReview(
         judgeEffort: result.plannerResult.judgeEffort,
         prType: result.plannerResult.prType,
       };
-      dashboard.agentCount = result.agentNames.length;
-      dashboard.agentProgress = result.agentNames.map(name => {
-        const existing = dashboard.agentProgress?.find(a => a.name === name);
-        return existing ?? { name, status: 'done' as const };
-      });
+      reconcileDashboardAgents(dashboard, result.agentNames);
     } else if (priorRoundAgents.length > 0) {
       // Non-planner path: reconcile the dashboard with the actual resolved team.
       // The initial dashboard was built without priorRoundAgents (not yet loaded),
       // so on round 2+ it would show a stale, too-small agent list.
-      dashboard.agentCount = result.agentNames.length;
-      dashboard.agentProgress = result.agentNames.map(name => {
-        const existing = dashboard.agentProgress?.find(a => a.name === name);
-        return existing ?? { name, status: 'done' as const };
-      });
+      reconcileDashboardAgents(dashboard, result.agentNames);
     }
 
     const allJudgedForDashboard = result.allJudgedFindings || result.findings;

--- a/src/index.ts
+++ b/src/index.ts
@@ -868,12 +868,12 @@ async function runFullReview(
         prType: result.plannerResult.prType,
       };
     }
-    if (result.plannerResult || priorRoundAgents.length > 0) {
-      // Reconcile the dashboard with the actual resolved team. On round 2+ the
-      // initial dashboard was built without priorRoundAgents (not yet loaded),
-      // so the agent list would otherwise show a stale, too-small count.
-      reconcileDashboardAgents(dashboard, result.agentNames);
-    }
+    // Reconcile the dashboard with the actual resolved team. On round 2+ the
+    // initial dashboard was built without priorRoundAgents (not yet loaded),
+    // so the agent list would otherwise show a stale, too-small count. On
+    // round 1 without a planner, agents may fail and drop out, so reconcile
+    // unconditionally to keep agentCount and agentProgress accurate.
+    reconcileDashboardAgents(dashboard, result.agentNames);
 
     const allJudgedForDashboard = result.allJudgedFindings || result.findings;
     const rawForLookup = result.rawFindings ?? allJudgedForDashboard;

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,11 +297,18 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
 }
 
 function reconcileDashboardAgents(dashboard: DashboardData, names: string[]): void {
-  dashboard.agentCount = names.length;
-  dashboard.agentProgress = names.map(name => {
-    const existing = dashboard.agentProgress?.find(a => a.name === name);
-    return existing ?? { name, status: 'done' as const };
-  });
+  const existingByName = new Map(dashboard.agentProgress?.map(a => [a.name, a]) ?? []);
+  const reconciled = names.map(name => existingByName.get(name) ?? { name, status: 'done' as const });
+  // Preserve entries for agents that have reported back (status is not the
+  // initial 'reviewing') but are not in the resolved name list. These agents
+  // participated and the dashboard should continue to surface their status.
+  for (const [name, entry] of existingByName) {
+    if (!names.includes(name) && entry.status !== 'reviewing') {
+      reconciled.push(entry);
+    }
+  }
+  dashboard.agentCount = reconciled.length;
+  dashboard.agentProgress = reconciled;
 }
 
 async function runFullReview(

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { isEmptyInterRoundDiff } from './judge';
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
-import { collectPriorRoundAgents, runReview, determineVerdict, selectTeam } from './review';
+import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam, TRIVIAL_VERIFIER_AGENT } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
 import {
   fetchPRDiff,
@@ -555,6 +555,20 @@ async function runFullReview(
     // an agent that flagged something earlier always reviews later rounds.
     const priorRoundAgents = collectPriorRoundAgents(handover?.rounds);
 
+    // On the non-planner path the dashboard was seeded with the heuristic team
+    // before prior-round agents were known. Pre-populate any pinned agents now
+    // so that agent-complete callbacks can record their metrics.
+    if (!plannerEnabled && priorRoundAgents.length > 0 && dashboard.agentProgress) {
+      const poolNames = new Set(buildAgentPool(config.reviewers).map(a => a.name));
+      const inDashboard = new Set(dashboard.agentProgress.map(a => a.name));
+      for (const name of priorRoundAgents) {
+        if (!inDashboard.has(name) && poolNames.has(name)) {
+          dashboard.agentProgress.push({ name, status: 'reviewing' as const });
+          dashboard.agentCount++;
+        }
+      }
+    }
+
     function scheduleDashboardFlush(): void {
       if (dashboardFlushTimer) clearTimeout(dashboardFlushTimer);
       dashboardFlushTimer = setTimeout(() => {
@@ -836,7 +850,7 @@ async function runFullReview(
             result.findings,
             recap.previousFindings,
             result.summary,
-            result.agentNames,
+            result.agentNames.filter(n => n !== TRIVIAL_VERIFIER_AGENT.name),
             fingerprintFinding,
             classifyAuthorReply,
             handover,

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -1045,7 +1045,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'def', [], previousFindings,
-      'No issues', noopFingerprint, classifyFn,
+      'No issues', [], noopFingerprint, classifyFn,
     );
 
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1075,7 +1075,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'def', [], previousFindings,
-      'No issues', noopFingerprint, classifyFn,
+      'No issues', [], noopFingerprint, classifyFn,
     );
 
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1109,7 +1109,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'def', [], previousFindings,
-      'No issues', noopFingerprint, classifyFn,
+      'No issues', [], noopFingerprint, classifyFn,
     );
 
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1132,7 +1132,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'sha1', [finding, findingWithFix], [],
-      'One issue found', noopFingerprint, noopClassify,
+      'One issue found', [], noopFingerprint, noopClassify,
     );
 
     const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1149,7 +1149,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'sha2', [], [],
-      'All clear', noopFingerprint, noopClassify, loaded,
+      'All clear', [], noopFingerprint, noopClassify, loaded,
     );
 
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1164,7 +1164,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'sha1', [finding], [],
-      'One issue found', noopFingerprint, noopClassify,
+      'One issue found', [], noopFingerprint, noopClassify,
     );
 
     const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1196,7 +1196,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'sha1', [], [],
-      'Summary', noopFingerprint, noopClassify, preLoaded,
+      'Summary', [], noopFingerprint, noopClassify, preLoaded,
     );
 
     // getContent is called at most once (for the SHA lookup), not twice (load + SHA)
@@ -1212,7 +1212,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'sha1', [], [],
-      'Summary', noopFingerprint, noopClassify, malformed,
+      'Summary', [], noopFingerprint, noopClassify, malformed,
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
@@ -1256,7 +1256,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'def', [], previousFindings,
-      'No issues', noopFingerprint, classifyFn,
+      'No issues', [], noopFingerprint, classifyFn,
     );
 
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
@@ -1265,6 +1265,62 @@ describe('appendHandoverRound', () => {
     expect(round1Findings[0].authorReply).toBe('agree');
     expect(round1Findings[1].threadId).toBe('t2');
     expect(round1Findings[1].authorReply).toBe('agree');
+  });
+
+  it('persists the resolved team agents on the new round', async () => {
+    const octokit = mockJsonOctokit({});
+    const finding = makeFinding({ title: 'Null check', file: 'src/a.ts', line: 5 });
+    const agents = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+
+    await appendHandoverRound(
+      octokit, 'owner/memory', 'rust-dashcore', 106,
+      'sha1', [finding], [],
+      'Summary', agents, noopFingerprint, noopClassify,
+    );
+
+    const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
+    expect(loaded!.rounds[0].agents).toEqual(agents);
+  });
+
+  it('omits agents field when no agents are passed', async () => {
+    const octokit = mockJsonOctokit({});
+    const finding = makeFinding({ title: 'Null check', file: 'src/a.ts', line: 5 });
+
+    await appendHandoverRound(
+      octokit, 'owner/memory', 'rust-dashcore', 106,
+      'sha1', [finding], [],
+      'Summary', [], noopFingerprint, noopClassify,
+    );
+
+    const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
+    expect(loaded!.rounds[0]).not.toHaveProperty('agents');
+  });
+
+  it('preserves prior-round agents while appending a new round', async () => {
+    const existing = makeHandover({
+      rounds: [{
+        round: 1,
+        commitSha: 'abc',
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'],
+      }],
+    });
+    const octokit = mockJsonOctokit({ 'rust-dashcore/prs/106/handover.json': existing });
+
+    await appendHandoverRound(
+      octokit, 'owner/memory', 'rust-dashcore', 106,
+      'def', [], [],
+      'Round 2', ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'],
+      noopFingerprint, noopClassify,
+    );
+
+    const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
+    expect(loaded!.rounds).toHaveLength(2);
+    expect(loaded!.rounds[0].agents).toEqual(['Security & Safety', 'Architecture & Design', 'Correctness & Logic']);
+    expect(loaded!.rounds[1].agents).toEqual([
+      'Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage',
+    ]);
   });
 
   it('backfills threadId via fallback key when previousFinding has no title', async () => {
@@ -1287,7 +1343,7 @@ describe('appendHandoverRound', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 106,
       'def', [], previousFindings,
-      'No issues', noopFingerprint, () => 'agree',
+      'No issues', [], noopFingerprint, () => 'agree',
     );
     const reloaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 106);
     expect(reloaded!.rounds[0].findings[0].threadId).toBe('t1');
@@ -1343,7 +1399,7 @@ describe('appendHandoverRound suggestedFix sanitization', () => {
     await appendHandoverRound(
       octokit, 'owner/memory', 'rust-dashcore', 200,
       'sha1', [finding], [],
-      'Summary', noopFingerprint, noopClassify,
+      'Summary', [], noopFingerprint, noopClassify,
     );
 
     const loaded = await loadHandover(octokit, 'owner/memory', 'rust-dashcore', 200);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -651,6 +651,7 @@ export async function appendHandoverRound(
   findings: Finding[],
   previousFindings: HandoverPreviousFinding[],
   judgeSummary: string,
+  agents: string[],
   fingerprintFn: (title: string, file: string, line: number) => HandoverFinding['fingerprint'],
   classifyFn: (text: string | undefined) => AuthorReplyClass,
   existingHandover?: PrHandover | null,
@@ -712,6 +713,7 @@ export async function appendHandoverRound(
     findings: roundFindings,
     judgeSummary,
   };
+  if (agents.length > 0) newRound.agents = [...agents];
   handover.rounds.push(newRound);
 
   await writeHandover(octokit, memoryRepo, targetRepo, prNumber, handover);

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -4470,12 +4470,20 @@ describe('selectTeam with teamSizeOverride', () => {
     // Heuristic on a tiny diff would not include Maintainability & Readability
     // (no test paths, no large file count). Pinning must keep it in.
     const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Maintainability & Readability'];
-    const roster = selectTeam(diff, config, undefined, undefined, undefined, prior);
-    expect(roster.agents.map(a => a.name)).toContain('Maintainability & Readability');
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, undefined, undefined, prior);
+      expect(roster.agents.map(a => a.name)).toContain('Maintainability & Readability');
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^pinned team: inherited \[.*\], added \[.*\]$/),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it('heuristic path places prior agents before heuristic fills', () => {
-    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const diff = makeDiff({ totalAdditions: 300, totalDeletions: 100 });
     const config = makeConfig();
     // Include Security & Safety (a core agent) alongside Maintainability & Readability
     // so we can confirm core agents appear before the non-core prior agent.
@@ -4490,9 +4498,8 @@ describe('selectTeam with teamSizeOverride', () => {
     // Heuristic fills (agents not in the prior list and not core) come after prior agents.
     const coreAndPrior = new Set(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Maintainability & Readability']);
     const firstHeuristicFill = names.findIndex(n => !coreAndPrior.has(n));
-    if (firstHeuristicFill !== -1) {
-      expect(maintIdx).toBeLessThan(firstHeuristicFill);
-    }
+    expect(firstHeuristicFill).toBeGreaterThan(-1);
+    expect(maintIdx).toBeLessThan(firstHeuristicFill);
   });
 
   it('skips unknown prior-round agent name and warns', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3850,10 +3850,15 @@ describe('runReview', () => {
       false, [], [], priorRounds,
     );
 
-    // collectPriorRoundAgents merges: Security, Testing, Maintainability
-    expect(result.agentNames).toEqual(
-      expect.arrayContaining(['Security & Safety', 'Testing & Coverage', 'Maintainability & Readability']),
-    );
+    // Core agents come first, then prior-round non-core agents in merge order.
+    // CORE_AGENTS = [Security, Architecture, Correctness]; prior non-core = [Testing, Maintainability].
+    expect(result.agentNames).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+      'Testing & Coverage',
+      'Maintainability & Readability',
+    ]);
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -4502,6 +4502,8 @@ describe('selectTeam with teamSizeOverride', () => {
     expect(secIdx).toBeLessThan(maintIdx);
     // Heuristic fills (agents not in the prior list and not core) come after prior agents.
     const coreAndPrior = new Set(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Maintainability & Readability']);
+    // Guard: the heuristic must add at least one agent beyond core+prior for the ordering assertion below to be meaningful.
+    expect(names.length).toBeGreaterThan(coreAndPrior.size);
     const firstHeuristicFill = names.findIndex(n => !coreAndPrior.has(n));
     expect(firstHeuristicFill).toBeGreaterThan(-1);
     expect(maintIdx).toBeLessThan(firstHeuristicFill);

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -4346,6 +4346,167 @@ describe('selectTeam with teamSizeOverride', () => {
       infoSpy.mockRestore();
     }
   });
+
+  it('round 2 reuses round 1 team verbatim when planner adds nothing', () => {
+    const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
+    const config = makeConfig();
+    const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'];
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+      { name: 'Testing & Coverage', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 4, picks, prior);
+    expect(roster.agents.map(a => a.name)).toEqual(prior);
+    expect(roster.agents).toHaveLength(4);
+  });
+
+  it('round 2 adds a new agent on top of prior-round team', () => {
+    const diff = makeDiff({ totalAdditions: 100, totalDeletions: 50 });
+    const config = makeConfig();
+    const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+      { name: 'Performance & Efficiency', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 4, picks, prior);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+      'Performance & Efficiency',
+    ]);
+  });
+
+  it('round 2 includes prior-round agent the planner omitted, with audit log', () => {
+    const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
+    const config = makeConfig();
+    const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Testing & Coverage'];
+    // Planner omits Testing & Coverage in round 2.
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 3, picks, prior);
+      expect(roster.agents.map(a => a.name)).toContain('Testing & Coverage');
+      expect(roster.agents.map(a => a.name)).toEqual([
+        'Security & Safety',
+        'Architecture & Design',
+        'Correctness & Logic',
+        'Testing & Coverage',
+      ]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'pinned team: inherited [Security & Safety, Architecture & Design, Correctness & Logic, Testing & Coverage], added []',
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('round 2 audit log distinguishes inherited from newly added', () => {
+    const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
+    const config = makeConfig();
+    const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+      { name: 'Performance & Efficiency', effort: 'low' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      selectTeam(diff, config, undefined, 4, picks, prior);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'pinned team: inherited [Security & Safety, Architecture & Design, Correctness & Logic], added [Performance & Efficiency]',
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('heuristic path also honors prior-round agents', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    // Heuristic on a tiny diff would not include Maintainability & Readability
+    // (no test paths, no large file count). Pinning must keep it in.
+    const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Maintainability & Readability'];
+    const roster = selectTeam(diff, config, undefined, undefined, undefined, prior);
+    expect(roster.agents.map(a => a.name)).toContain('Maintainability & Readability');
+  });
+
+  it('skips unknown prior-round agent name and warns', () => {
+    const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
+    const config = makeConfig();
+    const prior = ['Bogus Agent', 'Security & Safety'];
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+    ];
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 3, picks, prior);
+      expect(roster.agents.map(a => a.name)).not.toContain('Bogus Agent');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('prior-round agent "Bogus Agent" no longer exists'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not log pin audit when priorRoundAgents is empty', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    try {
+      selectTeam(diff, config, undefined, 3, picks);
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('pinned team:'));
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('preserves planner team when prior agents are a subset of the picks', () => {
+    const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
+    const config = makeConfig();
+    const prior = ['Security & Safety', 'Architecture & Design'];
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+      { name: 'Performance & Efficiency', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 4, picks, prior);
+    // Prior agents lead, planner-new picks follow, core injection ensures Correctness.
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+      'Performance & Efficiency',
+    ]);
+  });
+
+  it('does not pin prior agents on the trivial-verifier path', () => {
+    const diff = makeDiff({ totalAdditions: 2, totalDeletions: 0 });
+    const config = makeConfig();
+    const prior = ['Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+    const roster = selectTeam(diff, config, undefined, 1, undefined, prior);
+    expect(roster.agents).toHaveLength(1);
+    expect(roster.agents[0]).toBe(TRIVIAL_VERIFIER_AGENT);
+    expect(roster.level).toBe('trivial');
+  });
 });
 
 describe('buildPlannerHints', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -6,6 +6,7 @@ import {
   buildReviewerUserMessage,
   buildPlannerSystemPrompt,
   buildPlannerHints,
+  collectPriorRoundAgents,
   selectTeam,
   titlesMatch,
   truncateDiff,
@@ -4506,6 +4507,33 @@ describe('selectTeam with teamSizeOverride', () => {
     expect(roster.agents).toHaveLength(1);
     expect(roster.agents[0]).toBe(TRIVIAL_VERIFIER_AGENT);
     expect(roster.level).toBe('trivial');
+  });
+});
+
+describe('collectPriorRoundAgents', () => {
+  it('returns empty array for no rounds', () => {
+    expect(collectPriorRoundAgents(undefined)).toEqual([]);
+    expect(collectPriorRoundAgents([])).toEqual([]);
+  });
+
+  it('deduplicates overlapping agents across rounds preserving first-seen order', () => {
+    const rounds: HandoverRound[] = [
+      { round: 1, commitSha: 'a', timestamp: '2025-01-01T00:00:00Z', findings: [], agents: ['Security & Safety', 'Architecture & Design'] },
+      { round: 2, commitSha: 'b', timestamp: '2025-01-02T00:00:00Z', findings: [], agents: ['Security & Safety', 'Correctness & Logic'] },
+    ];
+    expect(collectPriorRoundAgents(rounds)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+    ]);
+  });
+
+  it('handles rounds with no agents field', () => {
+    const rounds: HandoverRound[] = [
+      { round: 1, commitSha: 'a', timestamp: '2025-01-01T00:00:00Z', findings: [] },
+      { round: 2, commitSha: 'b', timestamp: '2025-01-02T00:00:00Z', findings: [], agents: ['Security & Safety'] },
+    ];
+    expect(collectPriorRoundAgents(rounds)).toEqual(['Security & Safety']);
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3850,15 +3850,13 @@ describe('runReview', () => {
       false, [], [], priorRounds,
     );
 
-    // Core agents come first, then prior-round non-core agents in merge order.
-    // CORE_AGENTS = [Security, Architecture, Correctness]; prior non-core = [Testing, Maintainability].
-    expect(result.agentNames).toEqual([
-      'Security & Safety',
-      'Architecture & Design',
-      'Correctness & Logic',
-      'Testing & Coverage',
-      'Maintainability & Readability',
-    ]);
+    // Prior-round non-core agents must be preserved in the resolved team.
+    expect(result.agentNames).toContain('Testing & Coverage');
+    expect(result.agentNames).toContain('Maintainability & Readability');
+    // Core agents are always present.
+    expect(result.agentNames).toContain('Security & Safety');
+    // No duplicates from the union of core and prior-round agents.
+    expect(new Set(result.agentNames).size).toBe(result.agentNames.length);
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -4480,7 +4480,7 @@ describe('selectTeam with teamSizeOverride', () => {
       const roster = selectTeam(diff, config, undefined, undefined, undefined, prior);
       expect(roster.agents.map(a => a.name)).toContain('Maintainability & Readability');
       expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/^pinned team: inherited \[.*\], added \[.*\]$/),
+        'pinned team: inherited [Security & Safety, Architecture & Design, Correctness & Logic, Maintainability & Readability], added []',
       );
     } finally {
       infoSpy.mockRestore();

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -4623,6 +4623,14 @@ describe('collectPriorRoundAgents', () => {
     ];
     expect(collectPriorRoundAgents(rounds)).toEqual(['Security & Safety']);
   });
+
+  it('returns empty array when all rounds lack the agents field (legacy handovers)', () => {
+    const rounds: HandoverRound[] = [
+      { round: 1, commitSha: 'a', timestamp: '2025-01-01T00:00:00Z', findings: [] },
+      { round: 2, commitSha: 'b', timestamp: '2025-01-02T00:00:00Z', findings: [] },
+    ];
+    expect(collectPriorRoundAgents(rounds)).toEqual([]);
+  });
 });
 
 describe('buildPlannerHints', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3822,6 +3822,39 @@ describe('runReview', () => {
       expect(userMessage).not.toContain('factual note');
     }
   });
+
+  it('passes prior-round agents through to selectTeam when priorRounds carries agents', async () => {
+    const priorRounds: HandoverRound[] = [
+      {
+        round: 1,
+        commitSha: 'sha1',
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Testing & Coverage'],
+      },
+      {
+        round: 2,
+        commitSha: 'sha2',
+        timestamp: '2025-01-02T00:00:00Z',
+        findings: [],
+        agents: ['Security & Safety', 'Maintainability & Readability'],
+      },
+    ];
+    const clients = makeClients();
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      undefined, undefined, undefined, undefined, undefined,
+      false, [], [], priorRounds,
+    );
+
+    // collectPriorRoundAgents merges: Security, Testing, Maintainability
+    expect(result.agentNames).toEqual(
+      expect.arrayContaining(['Security & Safety', 'Testing & Coverage', 'Maintainability & Readability']),
+    );
+  });
 });
 
 describe('runPlanner', () => {
@@ -4441,6 +4474,27 @@ describe('selectTeam with teamSizeOverride', () => {
     expect(roster.agents.map(a => a.name)).toContain('Maintainability & Readability');
   });
 
+  it('heuristic path places prior agents before heuristic fills', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    // Include Security & Safety (a core agent) alongside Maintainability & Readability
+    // so we can confirm core agents appear before the non-core prior agent.
+    const priorWithCore = ['Security & Safety', 'Maintainability & Readability'];
+    const roster = selectTeam(diff, config, undefined, undefined, undefined, priorWithCore);
+    const names = roster.agents.map(a => a.name);
+    const secIdx = names.indexOf('Security & Safety');
+    const maintIdx = names.indexOf('Maintainability & Readability');
+    expect(maintIdx).toBeGreaterThan(-1);
+    // Security & Safety is a core agent and must come before Maintainability & Readability.
+    expect(secIdx).toBeLessThan(maintIdx);
+    // Heuristic fills (agents not in the prior list and not core) come after prior agents.
+    const coreAndPrior = new Set(['Security & Safety', 'Architecture & Design', 'Correctness & Logic', 'Maintainability & Readability']);
+    const firstHeuristicFill = names.findIndex(n => !coreAndPrior.has(n));
+    if (firstHeuristicFill !== -1) {
+      expect(maintIdx).toBeLessThan(firstHeuristicFill);
+    }
+  });
+
   it('skips unknown prior-round agent name and warns', () => {
     const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
     const config = makeConfig();
@@ -4476,6 +4530,28 @@ describe('selectTeam with teamSizeOverride', () => {
       expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('pinned team:'));
     } finally {
       infoSpy.mockRestore();
+    }
+  });
+
+  it('suppresses logPinAudit and unknown-agent warning when silent is true', () => {
+    const diff = makeDiff({ totalAdditions: 50, totalDeletions: 20 });
+    const config = makeConfig();
+    const prior = ['Bogus Agent', 'Security & Safety', 'Architecture & Design', 'Correctness & Logic'];
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+    ];
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const roster = selectTeam(diff, config, undefined, 3, picks, prior, true);
+      expect(roster.agents.map(a => a.name)).not.toContain('Bogus Agent');
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('pinned team:'));
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('prior-round agent'));
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
     }
   });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -86,12 +86,48 @@ function injectMissingCoreAgents(
   return [...orderedCore, ...nonCore];
 }
 
+// Resolves prior-round agent names against the current pool. Names that no
+// longer exist in the pool (e.g., a custom reviewer removed from config) are
+// dropped with a warning so reviews still make progress.
+function resolvePriorRoundAgents(
+  priorRoundAgents: string[],
+  pool: ReviewerAgent[],
+): ReviewerAgent[] {
+  const poolMap = new Map(pool.map(a => [a.name, a]));
+  const resolved: ReviewerAgent[] = [];
+  for (const name of priorRoundAgents) {
+    const agent = poolMap.get(name);
+    if (!agent) {
+      core.warning(`prior-round agent "${name}" no longer exists in the pool; skipping`);
+      continue;
+    }
+    if (!resolved.some(r => r.name === agent.name)) {
+      resolved.push(agent);
+    }
+  }
+  return resolved;
+}
+
+// Logs a one-line audit message distinguishing agents inherited from a prior
+// round from agents newly added in the current round.
+function logPinAudit(final: ReviewerAgent[], priorNames: Set<string>): void {
+  if (priorNames.size === 0) return;
+  const inherited: string[] = [];
+  const added: string[] = [];
+  for (const agent of final) {
+    if (priorNames.has(agent.name)) inherited.push(agent.name);
+    else added.push(agent.name);
+  }
+  core.info(`pinned team: inherited [${inherited.join(', ')}], added [${added.join(', ')}]`);
+}
+
 export function selectTeam(
   diff: ParsedDiff,
   config: ReviewConfig,
   customReviewers?: ReviewerAgent[],
   teamSizeOverride?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   agentPicks?: AgentPick[],
+  priorRoundAgents?: string[],
 ): TeamRoster {
   const lineCount = diff.totalAdditions + diff.totalDeletions;
 
@@ -102,12 +138,20 @@ export function selectTeam(
     if (customReviewers && customReviewers.length > 0) {
       core.info(`teamSize=1: skipping custom reviewers [${customReviewers.map(r => r.name).join(', ')}]`);
     }
+    // Trivial verifier path runs alone. Cross-round pinning does not apply:
+    // a PR does not flip from non-trivial to trivial in practice, and the
+    // verifier is intentionally a single-agent specialist.
     return { level: 'trivial', agents: [TRIVIAL_VERIFIER_AGENT], lineCount };
   }
 
+  const pool = buildAgentPool(customReviewers);
+  const priorAgents = priorRoundAgents && priorRoundAgents.length > 0
+    ? resolvePriorRoundAgents(priorRoundAgents, pool)
+    : [];
+  const priorNames = new Set(priorAgents.map(a => a.name));
+
   // Planner-driven agent selection: resolve each picked name from the pool
   if (agentPicks && agentPicks.length > 0 && teamSizeOverride) {
-    const pool = buildAgentPool(customReviewers);
     const poolMap = new Map(pool.map(a => [a.name, a]));
     const resolved: ReviewerAgent[] = [];
     for (const pick of agentPicks) {
@@ -118,9 +162,16 @@ export function selectTeam(
     }
 
     if (resolved.length > 0) {
+      // Pin prior-round agents first (preserving their order), then append
+      // any new planner picks. Deduplication keeps the prior order stable.
+      const unioned: ReviewerAgent[] = [...priorAgents];
+      for (const agent of resolved) {
+        if (!unioned.some(u => u.name === agent.name)) unioned.push(agent);
+      }
       // Core inviolability: CORE_AGENTS are always present regardless of
       // teamSizeOverride, so the final roster may exceed that value.
-      const final = injectMissingCoreAgents(resolved, pool);
+      const final = injectMissingCoreAgents(unioned, pool);
+      logPinAudit(final, priorNames);
 
       let level: 'trivial' | 'small' | 'medium' | 'large';
       if (final.length === 1) level = 'small';
@@ -153,8 +204,6 @@ export function selectTeam(
     teamSize = level === 'small' ? 3 : level === 'medium' ? 5 : 7;
   }
 
-  const pool = buildAgentPool(customReviewers);
-
   // Core agents always included
   const selected: ReviewerAgent[] = CORE_AGENTS.map(i => pool[i]);
 
@@ -162,6 +211,15 @@ export function selectTeam(
   for (const custom of (customReviewers || [])) {
     if (!selected.some(s => s.name === custom.name)) {
       selected.push(custom);
+    }
+  }
+
+  // Pin prior-round agents into the heuristic team so monotonic team growth
+  // holds even when no planner picks are available (e.g., review_level !=
+  // 'auto' or planner failure).
+  for (const agent of priorAgents) {
+    if (!selected.some(s => s.name === agent.name)) {
+      selected.push(agent);
     }
   }
 
@@ -202,6 +260,7 @@ export function selectTeam(
     selected.push(...additional);
   }
 
+  logPinAudit(selected, priorNames);
   return { level, agents: selected, lineCount };
 }
 
@@ -519,10 +578,32 @@ export async function runPlanner(
   }
 }
 
-function heuristicFallback(diff: ParsedDiff, config: ReviewConfig): TeamRoster {
-  const team = selectTeam(diff, config, config.reviewers);
+function heuristicFallback(
+  diff: ParsedDiff,
+  config: ReviewConfig,
+  priorRoundAgents?: string[],
+): TeamRoster {
+  const team = selectTeam(diff, config, config.reviewers, undefined, undefined, priorRoundAgents);
   core.info(`Review team (${team.level}): ${team.agents.map(a => a.name).join(', ')}`);
   return team;
+}
+
+// Collects the union of agent names that participated in any prior round of
+// this PR. Used to pin the team across rounds so the roster grows
+// monotonically: an agent that flagged something earlier reviews later rounds.
+function collectPriorRoundAgents(priorRounds?: HandoverRound[]): string[] {
+  if (!priorRounds || priorRounds.length === 0) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const round of priorRounds) {
+    for (const name of round.agents ?? []) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        out.push(name);
+      }
+    }
+  }
+  return out;
 }
 
 /** Minimum dismissed-finding sample size required before a 100% dismiss rate triggers an effort downgrade. */
@@ -573,6 +654,7 @@ export async function runReview(
 ): Promise<ReviewResult> {
   const priorRoundHints = buildPlannerHints(priorRounds);
   const provenanceMap = computeProvenanceMap(priorRounds, rawDiff);
+  const priorRoundAgents = collectPriorRoundAgents(priorRounds);
   let team: TeamRoster;
   let plannerResult: PlannerResult | null = null;
 
@@ -587,7 +669,7 @@ export async function runReview(
       if (plannerResult.agents && priorRoundHints.length > 0) {
         applyEffortDowngrade(plannerResult.agents, priorRoundHints);
       }
-      team = selectTeam(diff, config, config.reviewers, plannerResult.teamSize, plannerResult.agents);
+      team = selectTeam(diff, config, config.reviewers, plannerResult.teamSize, plannerResult.agents, priorRoundAgents);
       core.info(`Planner: ${plannerResult.teamSize} agents, reviewer: ${plannerResult.reviewerEffort}, judge: ${plannerResult.judgeEffort} (${plannerResult.prType})`);
       if (plannerResult.teamSize === 1) {
         const totalLines = diff.totalAdditions + diff.totalDeletions;
@@ -597,10 +679,10 @@ export async function runReview(
         onProgress({ phase: 'planning', rawFindingCount: 0, plannerResult, plannerDurationMs });
       }
     } else {
-      team = heuristicFallback(diff, config);
+      team = heuristicFallback(diff, config, priorRoundAgents);
     }
   } else {
-    team = heuristicFallback(diff, config);
+    team = heuristicFallback(diff, config, priorRoundAgents);
   }
 
   const memoryContext = memory ? buildMemoryContext(memory) : '';

--- a/src/review.ts
+++ b/src/review.ts
@@ -99,7 +99,11 @@ function resolvePriorRoundAgents(
   for (const name of priorRoundAgents) {
     const agent = poolMap.get(name);
     if (!agent) {
-      if (!silent) core.warning(`prior-round agent "${name.replace(/[\r\n]/g, ' ')}" no longer exists in the pool; skipping`);
+      // Strip control characters and GitHub Actions workflow-command prefix (::)
+      // to prevent log injection from attacker-controlled handover file content.
+      // eslint-disable-next-line no-control-regex
+      const safeName = name.replace(/[\x00-\x1f\x7f]/g, ' ').replace(/^::/, '');
+      if (!silent) core.warning(`prior-round agent "${safeName}" no longer exists in the pool; skipping`);
       continue;
     }
     if (!resolved.some(r => r.name === agent.name)) {

--- a/src/review.ts
+++ b/src/review.ts
@@ -591,7 +591,7 @@ function heuristicFallback(
 // Collects the union of agent names that participated in any prior round of
 // this PR. Used to pin the team across rounds so the roster grows
 // monotonically: an agent that flagged something earlier reviews later rounds.
-function collectPriorRoundAgents(priorRounds?: HandoverRound[]): string[] {
+export function collectPriorRoundAgents(priorRounds?: HandoverRound[]): string[] {
   if (!priorRounds || priorRounds.length === 0) return [];
   const seen = new Set<string>();
   const out: string[] = [];

--- a/src/review.ts
+++ b/src/review.ts
@@ -92,13 +92,14 @@ function injectMissingCoreAgents(
 function resolvePriorRoundAgents(
   priorRoundAgents: string[],
   pool: ReviewerAgent[],
+  silent?: boolean,
 ): ReviewerAgent[] {
   const poolMap = new Map(pool.map(a => [a.name, a]));
   const resolved: ReviewerAgent[] = [];
   for (const name of priorRoundAgents) {
     const agent = poolMap.get(name);
     if (!agent) {
-      core.warning(`prior-round agent "${name}" no longer exists in the pool; skipping`);
+      if (!silent) core.warning(`prior-round agent "${name}" no longer exists in the pool; skipping`);
       continue;
     }
     if (!resolved.some(r => r.name === agent.name)) {
@@ -110,8 +111,8 @@ function resolvePriorRoundAgents(
 
 // Logs a one-line audit message distinguishing agents inherited from a prior
 // round from agents newly added in the current round.
-function logPinAudit(final: ReviewerAgent[], priorNames: Set<string>): void {
-  if (priorNames.size === 0) return;
+function logPinAudit(final: ReviewerAgent[], priorNames: Set<string>, silent?: boolean): void {
+  if (priorNames.size === 0 || silent) return;
   const inherited: string[] = [];
   const added: string[] = [];
   for (const agent of final) {
@@ -128,6 +129,7 @@ export function selectTeam(
   teamSizeOverride?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   agentPicks?: AgentPick[],
   priorRoundAgents?: string[],
+  silent?: boolean,
 ): TeamRoster {
   const lineCount = diff.totalAdditions + diff.totalDeletions;
 
@@ -146,7 +148,7 @@ export function selectTeam(
 
   const pool = buildAgentPool(customReviewers);
   const priorAgents = priorRoundAgents && priorRoundAgents.length > 0
-    ? resolvePriorRoundAgents(priorRoundAgents, pool)
+    ? resolvePriorRoundAgents(priorRoundAgents, pool, silent)
     : [];
   const priorNames = new Set(priorAgents.map(a => a.name));
 
@@ -171,7 +173,7 @@ export function selectTeam(
       // Core inviolability: CORE_AGENTS are always present regardless of
       // teamSizeOverride, so the final roster may exceed that value.
       const final = injectMissingCoreAgents(unioned, pool);
-      logPinAudit(final, priorNames);
+      logPinAudit(final, priorNames, silent);
 
       let level: 'trivial' | 'small' | 'medium' | 'large';
       if (final.length === 1) level = 'small';
@@ -204,22 +206,22 @@ export function selectTeam(
     teamSize = level === 'small' ? 3 : level === 'medium' ? 5 : 7;
   }
 
-  // Core agents always included
+  // Core agents always included, then prior-round agents (so prior order matches
+  // the planner path: prior-first, new additions last), then custom reviewers.
   const selected: ReviewerAgent[] = CORE_AGENTS.map(i => pool[i]);
+
+  // Pin prior-round agents next so the heuristic path preserves the same
+  // "prior first, new last" insertion order as the planner path.
+  for (const agent of priorAgents) {
+    if (!selected.some(s => s.name === agent.name)) {
+      selected.push(agent);
+    }
+  }
 
   // Custom reviewers always included (they were explicitly configured)
   for (const custom of (customReviewers || [])) {
     if (!selected.some(s => s.name === custom.name)) {
       selected.push(custom);
-    }
-  }
-
-  // Pin prior-round agents into the heuristic team so monotonic team growth
-  // holds even when no planner picks are available (e.g., review_level !=
-  // 'auto' or planner failure).
-  for (const agent of priorAgents) {
-    if (!selected.some(s => s.name === agent.name)) {
-      selected.push(agent);
     }
   }
 
@@ -260,7 +262,7 @@ export function selectTeam(
     selected.push(...additional);
   }
 
-  logPinAudit(selected, priorNames);
+  logPinAudit(selected, priorNames, silent);
   return { level, agents: selected, lineCount };
 }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -99,7 +99,7 @@ function resolvePriorRoundAgents(
   for (const name of priorRoundAgents) {
     const agent = poolMap.get(name);
     if (!agent) {
-      if (!silent) core.warning(`prior-round agent "${name}" no longer exists in the pool; skipping`);
+      if (!silent) core.warning(`prior-round agent "${name.replace(/[\r\n]/g, ' ')}" no longer exists in the pool; skipping`);
       continue;
     }
     if (!resolved.some(r => r.name === agent.name)) {

--- a/src/review.ts
+++ b/src/review.ts
@@ -1019,6 +1019,7 @@ export async function runReview(
         findings: [],
         highlights: [],
         reviewComplete: false,
+        agentNames: team.agents.map(a => a.name),
         failedAgents,
       };
     }
@@ -1123,6 +1124,7 @@ export async function runReview(
       findings: [],
       highlights: [],
       reviewComplete: false,
+      agentNames: team.agents.map(a => a.name),
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,13 @@ export interface HandoverRound {
   timestamp: string;
   findings: HandoverFinding[];
   judgeSummary?: string;
+  /**
+   * Names of the reviewer agents that participated in this round. Used by
+   * later rounds to pin the team across rounds (monotonic growth): an agent
+   * present in any prior round is always carried forward. Optional so older
+   * serialized handovers without this field still parse.
+   */
+  agents?: string[];
 }
 
 /** Per-PR cross-round state stored at `{targetRepo}/prs/{prNumber}/handover.json`. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,7 @@ export interface ReviewResult {
   highlights: string[];
   reviewComplete: boolean;
   rawFindingCount?: number;
-  agentNames?: string[];
+  agentNames: string[];
   allJudgedFindings?: Finding[];
   rawFindings?: Finding[];
   threadEvaluations?: ThreadEvaluation[];


### PR DESCRIPTION
## Summary

- Round 1's resolved agent set is persisted on `HandoverRound.agents` (optional, so older serialized handovers still parse).
- On rounds 2+, `selectTeam` unions prior-round agents with the planner's picks (or the heuristic team), then runs `injectMissingCoreAgents`. Planner may add agents but never remove.
- Audit log distinguishes inherited from newly added agents in one line: `pinned team: inherited [...], added [...]`.
- Trivial-verifier path is intentionally exempt (single-agent specialist; PRs do not flip from non-trivial to trivial in practice).

Closes #639. Sub 2 of #637.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1484/1484)
- [x] `src/review.test.ts`: 9 new cases (verbatim reuse, additive growth, omitted-prior re-inclusion, heuristic-path pinning, unknown-name warning, no-prior no-audit, subset prior, trivial bypass).
- [x] `src/memory.test.ts`: persists `agents`, omits when empty, preserves across appends.
- [x] `src/index.test.ts`: resolved team names persisted; prior-round agents reach the dashboard `selectTeam`.