### PR TITLE
feat: review convergence mechanisms (round cap, test-file nits, resolved-thread suppression)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -42,6 +42,36 @@ describe('config', () => {
     it('has no default custom reviewers', () => {
       expect(DEFAULT_CONFIG.reviewers).toEqual([]);
     });
+
+    it('exposes default convergence settings', () => {
+      expect(DEFAULT_CONFIG.convergence?.max_auto_rounds).toBe(5);
+      expect(DEFAULT_CONFIG.convergence?.suppress_resolved_threads).toBe(true);
+      expect(DEFAULT_CONFIG.convergence?.test_path_patterns).toContain('**/*.test.*');
+      expect(DEFAULT_CONFIG.convergence?.test_path_patterns).toContain('**/__tests__/**');
+    });
+  });
+
+  describe('convergence config', () => {
+    it('merges user-provided convergence overrides with defaults', () => {
+      const config = loadConfigFromContent('convergence:\n  max_auto_rounds: 3\n');
+      expect(config.convergence?.max_auto_rounds).toBe(3);
+      expect(config.convergence?.suppress_resolved_threads).toBe(true);
+    });
+
+    it('rejects negative max_auto_rounds', () => {
+      expect(() => loadConfigFromContent('convergence:\n  max_auto_rounds: -1\n'))
+        .toThrow(/max_auto_rounds/);
+    });
+
+    it('rejects non-array test_path_patterns', () => {
+      expect(() => loadConfigFromContent('convergence:\n  test_path_patterns: "not-an-array"\n'))
+        .toThrow(/test_path_patterns/);
+    });
+
+    it('rejects non-boolean suppress_resolved_threads', () => {
+      expect(() => loadConfigFromContent('convergence:\n  suppress_resolved_threads: "yes"\n'))
+        .toThrow(/suppress_resolved_threads/);
+    });
   });
 
   describe('loadConfig', () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -63,6 +63,11 @@ describe('config', () => {
         .toThrow(/max_auto_rounds/);
     });
 
+    it('rejects non-integer max_auto_rounds', () => {
+      expect(() => loadConfigFromContent('convergence:\n  max_auto_rounds: 1.5\n'))
+        .toThrow(/max_auto_rounds/);
+    });
+
     it('rejects non-array test_path_patterns', () => {
       expect(() => loadConfigFromContent('convergence:\n  test_path_patterns: "not-an-array"\n'))
         .toThrow(/test_path_patterns/);

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,11 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   },
   nit_handling: 'issues',
   review_passes: 1,
+  convergence: {
+    max_auto_rounds: 5,
+    test_path_patterns: ['**/*.test.*', '**/*.spec.*', '**/tests/**', '**/__tests__/**'],
+    suppress_resolved_threads: true,
+  },
 };
 
 const KNOWN_KEYS = new Set([
@@ -44,6 +49,7 @@ const KNOWN_KEYS = new Set([
   'planner',
   'nit_handling',
   'review_passes',
+  'convergence',
 ]);
 
 const REPO_FORMAT = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
@@ -181,6 +187,34 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
     }
   }
 
+  if ('convergence' in config) {
+    const convergence = config.convergence as Record<string, unknown>;
+    if (!convergence || typeof convergence !== 'object' || Array.isArray(convergence)) {
+      errors.push('`convergence` must be an object');
+    } else {
+      if ('max_auto_rounds' in convergence) {
+        if (
+          typeof convergence.max_auto_rounds !== 'number' ||
+          !Number.isInteger(convergence.max_auto_rounds) ||
+          convergence.max_auto_rounds < 0
+        ) {
+          errors.push('`convergence.max_auto_rounds` must be a non-negative integer');
+        }
+      }
+      if ('test_path_patterns' in convergence) {
+        if (
+          !Array.isArray(convergence.test_path_patterns) ||
+          !convergence.test_path_patterns.every(p => typeof p === 'string')
+        ) {
+          errors.push('`convergence.test_path_patterns` must be an array of strings');
+        }
+      }
+      if ('suppress_resolved_threads' in convergence && typeof convergence.suppress_resolved_threads !== 'boolean') {
+        errors.push('`convergence.suppress_resolved_threads` must be a boolean');
+      }
+    }
+  }
+
   if ('memory' in config) {
     const memory = config.memory as Record<string, unknown>;
     if (!memory || typeof memory !== 'object' || Array.isArray(memory)) {
@@ -216,6 +250,8 @@ function deepMerge(defaults: ReviewConfig, overrides: Record<string, unknown>): 
       result.planner = { ...defaults.planner, ...(value as Record<string, unknown>) } as ReviewConfig['planner'];
     } else if (key === 'review_thresholds' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
       result.review_thresholds = { ...defaults.review_thresholds, ...(value as Record<string, unknown>) } as ReviewConfig['review_thresholds'];
+    } else if (key === 'convergence' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      result.convergence = { ...defaults.convergence, ...(value as Record<string, unknown>) } as ReviewConfig['convergence'];
     } else {
       (result as Record<string, unknown>)[key] = value;
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3418,7 +3418,21 @@ describe('runFullReview orchestration', () => {
       expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
     });
 
-    it('reproduces the round-9 nit-spam scenario by either capping or dropping test-file nits', async () => {
+    it('cap never fires when memory is disabled (handover unavailable)', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue({
+        ...memoryEnabledConfig(1),
+        memory: { enabled: false, repo: '' },
+      });
+
+      await callRunFullReview();
+
+      // loadHandover is never called when memory is disabled, so priorRoundCount
+      // stays 0 and the cap cannot trigger even with max_auto_rounds: 1.
+      expect(jest.mocked(memoryModule.loadHandover)).not.toHaveBeenCalled();
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+
+    it('reproduces the round-9 nit-spam scenario by posting cap notice', async () => {
       jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
       jest.mocked(memoryModule.loadHandover).mockResolvedValue({
         prNumber: 42, repo: 'test-repo', rounds: priorRounds(5),
@@ -3431,37 +3445,26 @@ describe('runFullReview orchestration', () => {
         files: [testFile], totalAdditions: 5, totalDeletions: 5,
       });
       jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
-      jest.mocked(reviewModule.runReview).mockResolvedValue({
-        verdict: 'COMMENT', summary: 'nits',
-        findings: [
-          { severity: 'suggestion', title: 'Could simplify', file: 'src/foo.test.ts', line: 3, description: 'd', reviewers: ['Testing & Coverage'] },
-        ],
-        highlights: [], reviewComplete: true,
-        agentNames: ['general'],
+
+      await callRunFullReview();
+
+      expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+      expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining('Automatic review is paused') }),
+      );
+    });
+
+    it('runs review normally when below cap (test-nit suppression path exercises review.ts, not index.ts)', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 42, repo: 'test-repo', rounds: priorRounds(1),
       });
 
       await callRunFullReview();
 
-      // Cap path: runReview should have been skipped, OR if runReview ran the
-      // test-nit suppression in review.ts would have stripped findings before
-      // they got here. The contract this test enforces is: at round 6 with
-      // nits-only on a test file, the system does not post fresh nit findings.
-      const runReviewCalled = jest.mocked(reviewModule.runReview).mock.calls.length > 0;
-      const postReviewCalls = jest.mocked(ghUtils.postReview).mock.calls;
-      if (!runReviewCalled) {
-        expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
-          expect.objectContaining({ body: expect.stringContaining('Automatic review is paused') }),
-        );
-      } else {
-        for (const call of postReviewCalls) {
-          const result = call[5] as { findings: Array<{ severity: string; file: string }> };
-          for (const f of result.findings ?? []) {
-            const isLowSeverityTestNit = (f.severity === 'suggestion' || f.severity === 'nitpick')
-              && /\.test\.[a-z]+$/.test(f.file);
-            expect(isLowSeverityTestNit).toBe(false);
-          }
-        }
-      }
+      // Cap has not triggered (1 prior round < 5 max). runReview runs and test-nit
+      // suppression is exercised inside review.ts (tested in review.test.ts).
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
     });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -111,7 +111,7 @@ jest.mock('./review', () => {
       findings: [],
       highlights: [],
       reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     }),
     determineVerdict: jest.fn().mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' }),
     selectTeam: jest.fn().mockReturnValue({ level: 'standard', agents: [{ name: 'general' }] }),
@@ -1366,7 +1366,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'Looks good',
       findings: [], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
     jest.mocked(reviewModule.selectTeam).mockReturnValue({ level: 'standard' as 'small', agents: [{ name: 'general', focus: '' }], lineCount: 0 });
@@ -1516,7 +1516,7 @@ describe('runFullReview orchestration', () => {
       findings,
       highlights: [],
       reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: findings, duplicates: [] });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
@@ -1819,7 +1819,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Minor nits',
       findings: [nitFinding], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
@@ -1860,7 +1860,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Minor nits',
       findings: [nitFinding], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({
       unique: [nitFinding], duplicates: [],
@@ -1895,7 +1895,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'Review incomplete',
       findings: [], highlights: [], reviewComplete: false,
-      agentNames: [],
+      agentNames: ['general'],
     });
 
     await callRunFullReview();
@@ -1952,7 +1952,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Issues',
       findings: [finding2], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
 
     await callRunFullReview();
@@ -2348,7 +2348,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Nits',
       findings: [finding], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
     jest.mocked(memoryModule.applyEscalations).mockReturnValue([escalated]);
@@ -2382,7 +2382,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'Looks good',
       findings: [], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [], duplicates: [] });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
@@ -2412,7 +2412,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'Suggestions',
       findings: [finding], highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
     });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'COMMENT', verdictReason: 'only_nit_or_suggestion' });
@@ -2923,7 +2923,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'No changes since last review', findings: [],
       highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
       threadEvaluations: [
         { threadId: 'PRRT_a', status: 'addressed', reason: 'LLM hallucination' },
       ],
@@ -2984,7 +2984,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'COMMENT', summary: 'No changes since last review', findings: [],
       highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
       threadEvaluations: [
         { threadId: 'PRRT_a', status: 'not_addressed', reason: 'No code changes since prior review' },
       ],
@@ -3045,7 +3045,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
       threadEvaluations: [
         { threadId: 'PRRT_abc', status: 'addressed', reason: 'Fixed in latest push' },
       ],
@@ -3091,7 +3091,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
       threadEvaluations: [
         { threadId: 'PRRT_abc', status: 'addressed', reason: 'Fixed in new diff' },
         { threadId: 'PRRT_def', status: 'not_addressed', reason: 'Still applies' },
@@ -3145,7 +3145,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
       threadEvaluations: [
         { threadId: 'PRRT_known', status: 'addressed', reason: 'Legit fix' },
         { threadId: 'PRRT_unknown', status: 'addressed', reason: 'Injected by adversary' },
@@ -3221,7 +3221,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(reviewModule.runReview).mockResolvedValue({
       verdict: 'APPROVE', summary: 'ok', findings: [],
       highlights: [], reviewComplete: true,
-      agentNames: [],
+      agentNames: ['general'],
       threadEvaluations: [
         { threadId: 'PRRT_fail', status: 'addressed', reason: 'Should fail' },
       ],
@@ -3437,6 +3437,7 @@ describe('runFullReview orchestration', () => {
           { severity: 'suggestion', title: 'Could simplify', file: 'src/foo.test.ts', line: 3, description: 'd', reviewers: ['Testing & Coverage'] },
         ],
         highlights: [], reviewComplete: true,
+        agentNames: ['general'],
       });
 
       await callRunFullReview();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3315,6 +3315,154 @@ describe('runFullReview orchestration', () => {
     );
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
+
+  describe('convergence round-count cap', () => {
+    function memoryEnabledConfig(maxAutoRounds = 5): ReturnType<typeof configModule.loadConfig> {
+      return {
+        auto_review: true, auto_approve: false, max_diff_lines: 5000,
+        exclude_paths: [], nit_handling: 'issues',
+        reviewers: [], instructions: '', review_level: 'auto',
+        review_thresholds: { small: 200, medium: 800 },
+        memory: { enabled: true, repo: 'owner/memory' },
+        convergence: {
+          max_auto_rounds: maxAutoRounds,
+          test_path_patterns: ['**/*.test.*'],
+          suppress_resolved_threads: true,
+        },
+      };
+    }
+
+    function priorRounds(n: number): Array<{
+      round: number;
+      commitSha: string;
+      timestamp: string;
+      findings: never[];
+    }> {
+      return Array.from({ length: n }, (_, i) => ({
+        round: i + 1,
+        commitSha: `sha${i + 1}`,
+        timestamp: '2025-01-01T00:00:00Z',
+        findings: [],
+      }));
+    }
+
+    const reviewableFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+
+    beforeEach(() => {
+      jest.mocked(authModule.getMemoryToken).mockReturnValue('mem-token');
+      jest.mocked(memoryModule.loadMemory).mockResolvedValue({
+        learnings: [], suppressions: [], patterns: [],
+      });
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [reviewableFile], totalAdditions: 5, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([reviewableFile]);
+    });
+
+    it('runs review normally when prior rounds are below the cap', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 42, repo: 'test-repo', rounds: priorRounds(4),
+      });
+
+      await callRunFullReview();
+
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+
+    it('skips review and posts notice when prior rounds reach the cap on auto trigger', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 42, repo: 'test-repo', rounds: priorRounds(5),
+      });
+
+      await callRunFullReview();
+
+      expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+      expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          issue_number: 42,
+          body: expect.stringContaining('Automatic review is paused'),
+        }),
+      );
+    });
+
+    it('bypasses the cap when forceReview is true', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 42, repo: 'test-repo', rounds: priorRounds(5),
+      });
+
+      await runFullReview(
+        baseArgs.owner, baseArgs.repo, baseArgs.prNumber,
+        baseArgs.commitSha, baseArgs.baseRef, baseArgs.prContext,
+        undefined, true,
+      );
+
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+
+    it('does nothing when max_auto_rounds is 0 (cap disabled)', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(0));
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 42, repo: 'test-repo', rounds: priorRounds(20),
+      });
+
+      await callRunFullReview();
+
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+
+    it('reproduces the round-9 nit-spam scenario by either capping or dropping test-file nits', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 42, repo: 'test-repo', rounds: priorRounds(5),
+      });
+      const testFile = {
+        path: 'src/foo.test.ts', changeType: 'modified' as const,
+        hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+      };
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [testFile], totalAdditions: 5, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+      jest.mocked(reviewModule.runReview).mockResolvedValue({
+        verdict: 'COMMENT', summary: 'nits',
+        findings: [
+          { severity: 'suggestion', title: 'Could simplify', file: 'src/foo.test.ts', line: 3, description: 'd', reviewers: ['Testing & Coverage'] },
+        ],
+        highlights: [], reviewComplete: true,
+      });
+
+      await callRunFullReview();
+
+      // Cap path: runReview should have been skipped, OR if runReview ran the
+      // test-nit suppression in review.ts would have stripped findings before
+      // they got here. The contract this test enforces is: at round 6 with
+      // nits-only on a test file, the system does not post fresh nit findings.
+      const runReviewCalled = jest.mocked(reviewModule.runReview).mock.calls.length > 0;
+      const postReviewCalls = jest.mocked(ghUtils.postReview).mock.calls;
+      if (!runReviewCalled) {
+        expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
+          expect.objectContaining({ body: expect.stringContaining('Automatic review is paused') }),
+        );
+      } else {
+        for (const call of postReviewCalls) {
+          const result = call[5] as { findings: Array<{ severity: string; file: string }> };
+          for (const f of result.findings ?? []) {
+            const isLowSeverityTestNit = (f.severity === 'suggestion' || f.severity === 'nitpick')
+              && /\.test\.[a-z]+$/.test(f.file);
+            expect(isLowSeverityTestNit).toBe(false);
+          }
+        }
+      }
+    });
+  });
 });
 
 describe('handleInteraction', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,7 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
     baseBranch: pr.base.ref,
   };
 
-  await runFullReview(owner, repo, prNumber, pr.head.sha, pr.base.ref, prContext, pr.user?.login);
+  await runFullReview(owner, repo, prNumber, pr.head.sha, pr.base.ref, prContext, pr.user?.login, forceReview);
 }
 
 function reconcileDashboardAgents(dashboard: DashboardData, names: string[]): void {
@@ -319,6 +319,7 @@ async function runFullReview(
   baseRef: string,
   prContext?: PrContext,
   prAuthorLogin?: string,
+  forceReview?: boolean,
 ): Promise<void> {
   core.info(`Starting review for ${owner}/${repo}#${prNumber}`);
 
@@ -489,6 +490,32 @@ async function runFullReview(
           core.warning(`Failed to load handover for PR #${prNumber}: ${error}`);
         }
       }
+    }
+
+    const priorRoundCount = handover?.rounds.length ?? 0;
+    const maxAutoRounds = config.convergence?.max_auto_rounds ?? 0;
+    if (
+      maxAutoRounds > 0 &&
+      priorRoundCount >= maxAutoRounds &&
+      !forceReview
+    ) {
+      core.info(`Round cap reached (${priorRoundCount} prior rounds >= max ${maxAutoRounds}) — skipping auto review`);
+      try {
+        await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId });
+      } catch (error) {
+        core.debug(`Failed to delete progress comment: ${error}`);
+      }
+      try {
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body: `${PROGRESS_MARKER}\nManki has completed ${priorRoundCount} review rounds on this PR. Automatic review is paused; comment \`@manki review\` to force another round.`,
+        });
+      } catch (error) {
+        core.warning(`Failed to post round-cap notice: ${error}`);
+      }
+      return;
     }
 
     const fullContext = [repoContext, recap.recapContext].filter(Boolean).join('\n\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -503,7 +503,7 @@ async function runFullReview(
       try {
         await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId });
       } catch (error) {
-        core.debug(`Failed to delete progress comment: ${error}`);
+        core.warning(`Failed to delete progress comment: ${error}`);
       }
       try {
         await octokit.rest.issues.createComment({

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -3294,6 +3294,146 @@ describe('applyCrossRoundSuppression', () => {
     expect(result.findings[0].severity).toBe('ignore');
     expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
   });
+
+  describe('resolved-thread cross-round suppression', () => {
+    it('suppresses a finding matching a prior thread that was resolved without an agree reply', () => {
+      const findings = [makeFinding({ title: 'Old issue', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Old issue') },
+        severity: 'suggestion',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(['TH1']),
+        suppressResolvedThreads: true,
+      });
+      expect(result.suppressedCount).toBe(1);
+      expect(result.findings[0].severity).toBe('ignore');
+      expect(result.findings[0].tags).toContain('suppressed-by-resolved-thread');
+    });
+
+    it('preserves the agree-reply ratchet behaviour for non-resolved priors', () => {
+      const findings = [makeFinding({ title: 'Old issue', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Old issue') },
+        severity: 'suggestion',
+        title: 'Old issue',
+        authorReply: 'agree',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(),
+        suppressResolvedThreads: true,
+      });
+      expect(result.suppressedCount).toBe(1);
+      expect(result.findings[0].severity).toBe('ignore');
+      expect(result.findings[0].tags).toContain('suppressed-by-ratchet');
+    });
+
+    it('does not suppress when the prior thread is unresolved and authorReply is not agree', () => {
+      const findings = [makeFinding({ title: 'Old issue', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Old issue') },
+        severity: 'suggestion',
+        title: 'Old issue',
+        authorReply: 'disagree',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(['TH-other']),
+        suppressResolvedThreads: true,
+      });
+      expect(result.suppressedCount).toBe(0);
+      expect(result.findings[0].severity).toBe('suggestion');
+    });
+
+    it('matches by fuzzy line proximity when slug differs and the prior thread is resolved', () => {
+      const findings = [makeFinding({
+        title: 'Reworded title for same concern',
+        file: 'src/a.ts',
+        line: 13,
+        severity: 'suggestion',
+      })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Original concern') },
+        severity: 'suggestion',
+        title: 'Original concern',
+        authorReply: 'none',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(['TH1']),
+        suppressResolvedThreads: true,
+      });
+      expect(result.suppressedCount).toBe(1);
+      expect(result.findings[0].severity).toBe('ignore');
+    });
+
+    it('does not match when neither slug nor line proximity match the resolved prior', () => {
+      const findings = [makeFinding({
+        title: 'Different concern',
+        file: 'src/a.ts',
+        line: 100,
+        severity: 'suggestion',
+      })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Original concern') },
+        severity: 'suggestion',
+        title: 'Original concern',
+        authorReply: 'none',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(['TH1']),
+        suppressResolvedThreads: true,
+      });
+      expect(result.suppressedCount).toBe(0);
+      expect(result.findings[0].severity).toBe('suggestion');
+    });
+
+    it('does not suppress blocker findings even when matching a resolved prior', () => {
+      const findings = [makeFinding({ title: 'Old issue', file: 'src/a.ts', line: 10, severity: 'blocker' })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Old issue') },
+        severity: 'suggestion',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(['TH1']),
+        suppressResolvedThreads: true,
+      });
+      expect(result.suppressedCount).toBe(0);
+      expect(result.findings[0].severity).toBe('blocker');
+    });
+
+    it('does nothing when suppressResolvedThreads is false', () => {
+      const findings = [makeFinding({ title: 'Old issue', file: 'src/a.ts', line: 10, severity: 'suggestion' })];
+      const prior = [makePriorRound([{
+        fingerprint: { file: 'src/a.ts', lineStart: 10, lineEnd: 10, slug: titleToSlug('Old issue') },
+        severity: 'suggestion',
+        title: 'Old issue',
+        authorReply: 'none',
+        threadId: 'TH1',
+      }])];
+
+      const result = applyCrossRoundSuppression(findings, prior, {
+        resolvedThreadIds: new Set(['TH1']),
+        suppressResolvedThreads: false,
+      });
+      expect(result.suppressedCount).toBe(0);
+      expect(result.findings[0].severity).toBe('suggestion');
+    });
+  });
 });
 
 describe('runJudgeAgent cross-round suppression', () => {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -14,7 +14,7 @@ import {
 import { dynamicFence, LinkedIssue, safeTruncate, titleToSlug } from './github';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
-import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverFinding, HandoverRound, IN_PR_SUPPRESSED_TAG, InPrSuppression, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, ReviewConfig, ParsedDiff, PrContext, ThreadEvaluation } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverFinding, HandoverRound, IN_PR_SUPPRESSED_TAG, InPrSuppression, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewConfig, ParsedDiff, PrContext, ThreadEvaluation } from './types';
 
 /** Cap on how many prior rounds we pass to the judge. */
 const PRIOR_ROUNDS_WINDOW = 3;
@@ -241,6 +241,10 @@ export interface JudgeInput {
    * prior round to compare against (first round of a PR).
    */
   interRoundDiff?: string;
+  /** IDs of prior-round threads currently resolved on GitHub. */
+  resolvedThreadIds?: Set<string>;
+  /** When true, resolved prior-round threads suppress matching findings. */
+  suppressResolvedThreads?: boolean;
 }
 
 export interface JudgedFinding {
@@ -801,7 +805,8 @@ export async function runJudgeAgent(
   crossRoundDemoted?: number;
   inPrSuppressedCount?: number;
 }> {
-  const { findings, diff, rawDiff, memory, prContext, linkedIssues, agentCount, isFollowUp, openThreads, priorRounds, inPrSuppressions, interRoundDiff } = input;
+  const { findings, diff, rawDiff, memory, prContext, linkedIssues, agentCount, isFollowUp, openThreads, priorRounds, inPrSuppressions, interRoundDiff, resolvedThreadIds, suppressResolvedThreads } = input;
+  const crossRoundOptions: CrossRoundSuppressionOptions = { resolvedThreadIds, suppressResolvedThreads };
   const provenanceMap = input.provenanceMap ?? (rawDiff ? computeProvenanceMap(priorRounds, rawDiff) : []);
 
   const hasOpenThreads = (openThreads?.length ?? 0) > 0;
@@ -852,7 +857,7 @@ export async function runJudgeAgent(
     const earlyWithProvenance = provenanceMap.length > 0
       ? findings.map(f => { const copy = { ...f }; applyOwnProposal(copy, provenanceMap); return copy; })
       : findings;
-    const earlySuppress = applyCrossRoundSuppression(earlyWithProvenance, priorRounds);
+    const earlySuppress = applyCrossRoundSuppression(earlyWithProvenance, priorRounds, crossRoundOptions);
     const { findings: earlySuppressedInPr, count: earlyInPrCount } = applyInPrSuppression(earlySuppress.findings, inPrSuppressions);
     return {
       findings: earlySuppressedInPr,
@@ -865,7 +870,7 @@ export async function runJudgeAgent(
   }
 
   const mapped = deduplicateFindings(mapJudgedToFindings(findings, judgeResult.findings, provenanceMap));
-  const suppression = applyCrossRoundSuppression(mapped, priorRounds);
+  const suppression = applyCrossRoundSuppression(mapped, priorRounds, crossRoundOptions);
   const { findings: suppressed, count: inPrCount } = applyInPrSuppression(suppression.findings, inPrSuppressions);
 
   return {
@@ -1065,30 +1070,63 @@ function mapMergedFindings(
 }
 
 /**
+ * Options for `applyCrossRoundSuppression` that broaden the suppression set
+ * beyond `authorReply === 'agree'` priors.
+ */
+export interface CrossRoundSuppressionOptions {
+  /**
+   * IDs of prior-round threads currently resolved on GitHub. Any prior finding
+   * whose `threadId` is in this set is treated as accepted regardless of how
+   * the thread was resolved (agree reply, manual resolve, etc.). Requires
+   * `suppressResolvedThreads` to be true.
+   */
+  resolvedThreadIds?: Set<string>;
+  /** When true, treat resolved prior-round threads as accepted priors. */
+  suppressResolvedThreads?: boolean;
+}
+
+/**
  * Apply cross-round suppression rules using prior-round handover state.
  *
  * Ratchet: if a prior finding with the same slug + file exists and the author
- * agreed, suppress the current finding unless it is `blocker`.
+ * agreed (or, when `suppressResolvedThreads` is true, the prior thread is
+ * resolved on GitHub), suppress the current finding unless it is `blocker`.
  *
  * Contradiction: if a prior finding with the same slug + file + line proximity
  * exists, the author agreed, and the current finding uses a reversal word,
  * demote `suggestion`/`warning` to `nitpick` and annotate `judgeNotes`. `blocker`
  * findings are intentionally excluded from contradiction demotion to prevent
  * prompt injection attacks where adversarial PR content could silently hide real bugs.
+ *
+ * Resolved-thread priors also match by fuzzy line proximity (±`LINE_WINDOW`)
+ * when slug differs, since reflowed code can shift line numbers and authors
+ * may have resolved the thread without a fingerprint-stable reply.
  */
 export function applyCrossRoundSuppression(
   findings: Finding[],
   priorRounds: HandoverRound[] | undefined,
+  options: CrossRoundSuppressionOptions = {},
 ): { findings: Finding[]; suppressedCount: number; demotedCount: number } {
   if (!priorRounds || priorRounds.length === 0) {
     return { findings, suppressedCount: 0, demotedCount: 0 };
   }
 
-  const acceptedPriors: Array<{ round: number; finding: HandoverFinding }> = [];
+  const { resolvedThreadIds, suppressResolvedThreads } = options;
+  const useResolved = suppressResolvedThreads === true && resolvedThreadIds !== undefined && resolvedThreadIds.size > 0;
+
+  type Prior = {
+    round: number;
+    finding: HandoverFinding;
+    /** 'agree' priors keep the existing contradiction-citation behaviour; 'resolved' priors only ratchet. */
+    source: 'agree' | 'resolved';
+  };
+  const acceptedPriors: Prior[] = [];
   for (const round of priorRounds) {
     for (const f of round.findings) {
       if (f.authorReply === 'agree') {
-        acceptedPriors.push({ round: round.round, finding: f });
+        acceptedPriors.push({ round: round.round, finding: f, source: 'agree' });
+      } else if (useResolved && f.threadId && resolvedThreadIds!.has(f.threadId)) {
+        acceptedPriors.push({ round: round.round, finding: f, source: 'resolved' });
       }
     }
   }
@@ -1115,8 +1153,11 @@ export function applyCrossRoundSuppression(
     // Contradiction is checked before ratchet for `warning`/`suggestion` findings only.
     // `blocker` and `nitpick` skip this branch: blocker is protected from any
     // silent demotion (prompt-injection guard); nitpick falls through to ratchet.
-    const contradictionMatch = acceptedPriors.find(({ finding: prior }) =>
-      prior.fingerprint.file === current.file
+    // Only `agree` priors trigger contradiction; resolved-thread priors do not
+    // imply the author articulated a position to contradict.
+    const contradictionMatch = acceptedPriors.find(({ finding: prior, source }) =>
+      source === 'agree'
+      && prior.fingerprint.file === current.file
       && prior.fingerprint.slug === slug
       && (
         current.line >= prior.fingerprint.lineStart - LINE_WINDOW
@@ -1133,12 +1174,21 @@ export function applyCrossRoundSuppression(
       return current;
     }
 
-    const ratchetMatch = acceptedPriors.find(({ finding: prior }) =>
-      prior.fingerprint.file === current.file && prior.fingerprint.slug === slug,
-    );
+    const ratchetMatch = acceptedPriors.find(({ finding: prior, source }) => {
+      if (prior.fingerprint.file !== current.file) return false;
+      if (prior.fingerprint.slug === slug) return true;
+      // Resolved-thread priors fall back to fuzzy line proximity when the slug
+      // differs, since refactors can shift line numbers and the same underlying
+      // concern may surface with a reworded title.
+      if (source !== 'resolved') return false;
+      return (
+        current.line >= prior.fingerprint.lineStart - LINE_WINDOW
+        && current.line <= prior.fingerprint.lineEnd + LINE_WINDOW
+      );
+    });
     if (ratchetMatch && current.severity !== 'blocker') {
       current.severity = 'ignore';
-      current.tags = addTag(current.tags, RATCHET_SUPPRESSED_TAG);
+      current.tags = addTag(current.tags, ratchetMatch.source === 'resolved' ? RESOLVED_THREAD_SUPPRESSED_TAG : RATCHET_SUPPRESSED_TAG);
       suppressedCount++;
       return current;
     }

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -1179,8 +1179,10 @@ export function applyCrossRoundSuppression(
       if (prior.fingerprint.slug === slug) return true;
       // Resolved-thread priors fall back to fuzzy line proximity when the slug
       // differs, since refactors can shift line numbers and the same underlying
-      // concern may surface with a reworded title.
+      // concern may surface with a reworded title. Restricted to suggestion/nitpick
+      // to prevent proximity alone from silently suppressing higher-severity findings.
       if (source !== 'resolved') return false;
+      if (current.severity === 'warning') return false;
       return (
         current.line >= prior.fingerprint.lineStart - LINE_WINDOW
         && current.line <= prior.fingerprint.lineEnd + LINE_WINDOW

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -39,6 +39,11 @@ const makeConfig = (overrides: Partial<ReviewConfig> = {}): ReviewConfig => ({
   review_level: 'auto',
   review_thresholds: { small: 200, medium: 1000 },
   memory: { enabled: false, repo: '' },
+  convergence: {
+    max_auto_rounds: 5,
+    test_path_patterns: ['**/*.test.*', '**/*.spec.*', '**/tests/**', '**/__tests__/**'],
+    suppress_resolved_threads: true,
+  },
   ...overrides,
 });
 
@@ -3857,6 +3862,120 @@ describe('runReview', () => {
     expect(result.agentNames).toContain('Security & Safety');
     // No duplicates from the union of core and prior-round agents.
     expect(new Set(result.agentNames).size).toBe(result.agentNames.length);
+  });
+});
+
+describe('runReview test-file nit suppression', () => {
+  const mockedRunJudgeAgent = jest.mocked(runJudgeAgent);
+
+  function makeClients(): ReviewClients {
+    return {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./claude').ClaudeClient,
+      judge: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '{"summary":"ok","findings":[]}' }),
+      } as unknown as import('./claude').ClaudeClient,
+    };
+  }
+
+  function buildPriorRound(round: number): HandoverRound {
+    return {
+      round,
+      commitSha: `sha${round}`,
+      timestamp: `2025-01-0${round}T00:00:00Z`,
+      findings: [],
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(applySuppressions).mockReturnValue({ kept: [], suppressed: [] });
+  });
+
+  it('drops a suggestion finding on a test file in round 2', async () => {
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [makeFinding({ severity: 'suggestion', file: 'src/foo.test.ts', title: 'Could simplify' })],
+      summary: 'ok',
+    });
+    const result = await runReview(
+      makeClients(), makeConfig(), makeDiff({ totalAdditions: 5, totalDeletions: 0 }),
+      'raw', 'ctx', undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, [buildPriorRound(1)],
+    );
+    expect(result.findings).toHaveLength(0);
+    expect(result.testNitSuppressedCount).toBe(1);
+  });
+
+  it('keeps a suggestion finding on a test file in round 1', async () => {
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [makeFinding({ severity: 'suggestion', file: 'src/foo.test.ts', title: 'Could simplify' })],
+      summary: 'ok',
+    });
+    const result = await runReview(
+      makeClients(), makeConfig(), makeDiff({ totalAdditions: 5, totalDeletions: 0 }),
+      'raw', 'ctx',
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.testNitSuppressedCount).toBeUndefined();
+  });
+
+  it('keeps a blocker finding on a test file in round 2', async () => {
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [makeFinding({ severity: 'blocker', file: 'src/foo.test.ts', title: 'Real bug in test' })],
+      summary: 'ok',
+    });
+    const result = await runReview(
+      makeClients(), makeConfig(), makeDiff({ totalAdditions: 5, totalDeletions: 0 }),
+      'raw', 'ctx', undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, [buildPriorRound(1)],
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('blocker');
+  });
+
+  it('keeps a suggestion finding on a non-test file in round 2', async () => {
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [makeFinding({ severity: 'suggestion', file: 'src/app.ts', title: 'Could simplify' })],
+      summary: 'ok',
+    });
+    const result = await runReview(
+      makeClients(), makeConfig(), makeDiff({ totalAdditions: 5, totalDeletions: 0 }),
+      'raw', 'ctx', undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, [buildPriorRound(1)],
+    );
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('honours configurable test_path_patterns', async () => {
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [makeFinding({ severity: 'nitpick', file: 'spec/integration.rb', title: 'Style nit' })],
+      summary: 'ok',
+    });
+    const result = await runReview(
+      makeClients(),
+      makeConfig({ convergence: { test_path_patterns: ['spec/**'], suppress_resolved_threads: false } }),
+      makeDiff({ totalAdditions: 5, totalDeletions: 0 }),
+      'raw', 'ctx', undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, [buildPriorRound(1)],
+    );
+    expect(result.findings).toHaveLength(0);
+    expect(result.testNitSuppressedCount).toBe(1);
+  });
+
+  it('does not suppress when test_path_patterns is empty', async () => {
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [makeFinding({ severity: 'suggestion', file: 'src/foo.test.ts', title: 'Could simplify' })],
+      summary: 'ok',
+    });
+    const result = await runReview(
+      makeClients(),
+      makeConfig({ convergence: { test_path_patterns: [], suppress_resolved_threads: false } }),
+      makeDiff({ totalAdditions: 5, totalDeletions: 0 }),
+      'raw', 'ctx', undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, [buildPriorRound(1)],
+    );
+    expect(result.findings).toHaveLength(1);
   });
 });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import { minimatch } from 'minimatch';
 
 import { ClaudeClient } from './claude';
 import { runJudgeAgent, JudgeInput, computeProvenanceMap } from './judge';
@@ -1085,6 +1086,14 @@ export async function runReview(
     core.info(`In-PR suppressions: ${inPrSuppressions.length} fingerprints (resolved or author-agreed)`);
   }
 
+  // Derive the set of currently-resolved thread IDs from the recap state. Used
+  // by `applyCrossRoundSuppression` (mechanism C) to ratchet down findings
+  // matching prior-round threads that have since been resolved.
+  const resolvedThreadIds = previousFindings
+    ? new Set(previousFindings.filter(f => f.status === 'resolved' && f.threadId).map(f => f.threadId!))
+    : new Set<string>();
+  const suppressResolvedThreads = config.convergence?.suppress_resolved_threads !== false;
+
   let finalFindings: Finding[];
   let allJudgedFindings: Finding[] | undefined;
   let judgeSummary = 'Review complete.';
@@ -1110,6 +1119,8 @@ export async function runReview(
       effort: judgeEffort as 'low' | 'medium' | 'high',
       provenanceMap,
       interRoundDiff,
+      resolvedThreadIds,
+      suppressResolvedThreads,
     };
     const judgeResult = await runJudgeAgent(clients.judge, config, judgeInput);
     judgeSummary = judgeResult.summary;
@@ -1132,6 +1143,26 @@ export async function runReview(
     };
   }
 
+  // Mechanism B: drop low-severity findings on test files starting at round 2.
+  // Test scaffolding nits are the most common runaway-feedback driver in late
+  // rounds; structural pre-filtering converges faster than asking the judge.
+  let testNitSuppressedCount = 0;
+  const roundNumber = (priorRounds?.length ?? 0) + 1;
+  if (roundNumber >= 2) {
+    const patterns = config.convergence?.test_path_patterns ?? [];
+    if (patterns.length > 0) {
+      const before = finalFindings.length;
+      finalFindings = finalFindings.filter(f => {
+        if (f.severity !== 'suggestion' && f.severity !== 'nitpick') return true;
+        const onTestFile = patterns.some(p => minimatch(f.file, p));
+        if (onTestFile) {
+          core.info(`Test-nit suppression: dropping ${f.severity} "${f.title}" on ${f.file}:${f.line}`);
+        }
+        return !onTestFile;
+      });
+      testNitSuppressedCount = before - finalFindings.length;
+    }
+  }
   const priorFindingsFlat: HandoverFinding[] = [...(priorRounds ?? [])]
     .sort((a, b) => a.round - b.round)
     .flatMap(r => r.findings);
@@ -1174,6 +1205,7 @@ export async function runReview(
     agentResponseLengths,
     crossRoundSuppressed: judgeCrossRoundSuppressed,
     crossRoundDemoted: judgeCrossRoundDemoted,
+    ...(testNitSuppressedCount > 0 && { testNitSuppressedCount }),
   };
 }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -1145,7 +1145,8 @@ export async function runReview(
 
   // Mechanism B: drop low-severity findings on test files starting at round 2.
   // Test scaffolding nits are the most common runaway-feedback driver in late
-  // rounds; structural pre-filtering converges faster than asking the judge.
+  // rounds. The filter runs post-judge so that any nit the judge escalates to
+  // warning/blocker is correctly preserved; only suggestion/nitpick are dropped.
   let testNitSuppressedCount = 0;
   const roundNumber = (priorRounds?.length ?? 0) + 1;
   if (roundNumber >= 2) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type FindingReachability = 'reachable' | 'hypothetical' | 'unknown';
 export const DEFENSIVE_HARDENING_TAG = 'defensive-hardening' as const;
 export const RATCHET_SUPPRESSED_TAG = 'suppressed-by-ratchet' as const;
 export const CONTRADICTION_TAG = 'contradicts-prior-round' as const;
+export const RESOLVED_THREAD_SUPPRESSED_TAG = 'suppressed-by-resolved-thread' as const;
 
 export const OWN_PROPOSAL_TAG = 'own-proposal-followup' as const;
 export const IN_PR_SUPPRESSED_TAG = 'suppressed-in-pr' as const;
@@ -152,6 +153,7 @@ export interface ReviewResult {
   agentResponseLengths?: Map<string, number>;
   crossRoundSuppressed?: number;
   crossRoundDemoted?: number;
+  testNitSuppressedCount?: number;
 }
 
 export interface ReviewerAgent {
@@ -228,6 +230,18 @@ export interface ReviewConfig {
   };
   nit_handling?: 'issues' | 'comments';
   review_passes?: number;
+  convergence?: {
+    /**
+     * Hard cap on the number of automatic review rounds per PR. Once exceeded,
+     * automatic review is paused; the author can re-trigger with `@manki review`.
+     * Set to `0` to disable the cap.
+     */
+    max_auto_rounds?: number;
+    /** Glob patterns for test files. Suggestion/nitpick findings on these paths are dropped on round 2+. */
+    test_path_patterns?: string[];
+    /** When true, a prior-round finding whose thread is currently resolved on GitHub suppresses matching current findings. */
+    suppress_resolved_threads?: boolean;
+  };
 }
 
 export interface DiffFile {


### PR DESCRIPTION
Closes #640.

## Summary

Three independent, structurally enforced convergence mechanisms gated by a new `ReviewConfig.convergence` block. Each is toggleable.

- **Round-count hard cap** (`max_auto_rounds`, default 5). When `handover.rounds.length >= max_auto_rounds` and the trigger is automatic (push to PR), `runFullReview` posts a notice and skips the review. `@manki review` sets `forceReview=true` and bypasses the cap.
- **Test-file nit suppression** (`test_path_patterns`, default `**/*.test.*`, `**/*.spec.*`, `**/tests/**`, `**/__tests__/**`). On round 2+, `runReview` drops `suggestion`/`nitpick` findings whose file matches any pattern. `blocker`/`warning` are kept so real bugs in test code still surface. Counts tracked in `ReviewResult.testNitSuppressedCount`.
- **Resolved-thread cross-round suppression** (`suppress_resolved_threads`, default true). `applyCrossRoundSuppression` now accepts a `resolvedThreadIds` set; prior-round findings whose threads are currently resolved on GitHub ratchet matching current findings to `ignore`, regardless of `authorReply`. Fingerprint match first; fuzzy line proximity (±`LINE_WINDOW`) as fallback. Resolved-thread suppression tags use `RESOLVED_THREAD_SUPPRESSED_TAG` to distinguish from agree-driven ratchet. `blocker` findings remain protected.

Round-1 path is unchanged — every mechanism gates on `roundNumber >= 2` or on a non-zero prior-round count.

## Test plan

- [x] `npm run build` and `npm test` pass locally (1493 tests).
- [x] New unit tests for `applyCrossRoundSuppression` cover resolved-thread match, agree-only behaviour preserved, fuzzy line fallback, blocker protection, and toggle off.
- [x] New unit tests for `runReview` cover test-nit drop in round 2, kept in round 1, blocker preserved, non-test files preserved, configurable patterns, empty patterns disable.
- [x] New unit tests for `runFullReview` cover sub-cap, at-cap (notice posted, runReview skipped), `forceReview=true` bypass, `max_auto_rounds: 0` disables, and the round-9 nit-spam acceptance scenario.
- [x] New unit tests for `loadConfigFromContent` cover convergence default exposure, override merge, and validation rejects.