### PR TITLE
fix: replace tiny `⟳` retry symbol with full-size `🔄` emoji

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1839,6 +1839,17 @@ describe('buildDashboard', () => {
     expect(md).toContain(`${INDENT}⏳ Correctness & Logic`);
   });
 
+  it('renders retrying agent status without retry count', () => {
+    const data: DashboardData = {
+      phase: 'started', lineCount: 100, agentCount: 1,
+      agentProgress: [
+        { name: 'Security & Safety', status: 'retrying' },
+      ],
+    };
+    const md = buildDashboard(data);
+    expect(md).toContain(`${INDENT}🔄 Security & Safety — retrying...`);
+  });
+
   it('renders failed agent with retry count showing total attempts', () => {
     const data: DashboardData = {
       phase: 'complete', lineCount: 100, agentCount: 3,

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1834,7 +1834,7 @@ describe('buildDashboard', () => {
     };
     const md = buildDashboard(data);
     expect(md).toContain('2/3 agents complete');
-    expect(md).toContain(`${INDENT}⟳ Security & Safety — retrying (2/2)...`);
+    expect(md).toContain(`${INDENT}🔄 Security & Safety — retrying (2/2)...`);
     expect(md).toContain(`${INDENT}✅ Architecture & Design — 2 (3s)`);
     expect(md).toContain(`${INDENT}⏳ Correctness & Logic`);
   });

--- a/src/github.ts
+++ b/src/github.ts
@@ -242,9 +242,9 @@ function renderAgentLines(agents: AgentProgressEntry[]): string {
     }
     if (a.status === 'retrying') {
       if (a.retryCount != null) {
-        return `${INDENT}⟳ ${a.name} — retrying (${a.retryCount + 1}/${MAX_AGENT_RETRIES + 1})...`;
+        return `${INDENT}🔄 ${a.name} — retrying (${a.retryCount + 1}/${MAX_AGENT_RETRIES + 1})...`;
       }
-      return `${INDENT}⟳ ${a.name} — retrying...`;
+      return `${INDENT}🔄 ${a.name} — retrying...`;
     }
     if (a.status === 'reviewing') {
       return `${INDENT}⏳ ${a.name}`;


### PR DESCRIPTION
## Summary
- Swap `⟳` (U+27F3) for `🔄` (U+1F504) in the retrying agent status output so it renders at the same visual scale as `✅`.
- Update the matching assertion in `src/github.test.ts`.

Closes #621