### PR TITLE
chore: bump action runtime from Node.js 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4  # first-party GitHub action
       - uses: actions/setup-node@v4  # first-party GitHub action
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4  # first-party GitHub action
       - uses: actions/setup-node@v4  # first-party GitHub action
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/SETUP.md
+++ b/SETUP.md
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/SETUP.md
+++ b/SETUP.md
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ outputs:
     description: 'Model used for the judge agent'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/index.js'
   post-if: cancelled() || failure()

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ outputs:
     description: 'Model used for the judge agent'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'
   post: 'dist/index.js'
   post-if: cancelled() || failure()

--- a/docs/index.html
+++ b/docs/index.html
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/docs/index.html
+++ b/docs/index.html
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary
- Bump `runs.using` in `action.yml` from `node20` to `node24`.
- Bump `node-version` in CI / release / `manki.yml` self-test workflows from `'20'` to `'24'`.
- Bump matching example workflow snippets in `SETUP.md` and `docs/index.html`.

GitHub Actions removes Node 20 from runners on 2026-09-16 and forces Node 24 as default on 2026-06-02. The runner does not currently accept `node22` as `runs.using` (only `node20` or `node24`), so we skip Node 22 and go directly to Node 24.

Closes #522
