### PR TITLE
refactor: move `safeTruncate` from `github.ts` to `utils.ts`

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 
-import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, safeTruncate, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats } from './types';
 
 describe('formatFindingComment', () => {
@@ -1019,24 +1019,6 @@ describe('dynamicFence', () => {
 
   it('handles content with long backtick runs', () => {
     expect(dynamicFence('`````')).toBe('``````');
-  });
-});
-
-describe('safeTruncate', () => {
-  it('returns text unchanged when shorter than max', () => {
-    expect(safeTruncate('hello', 10)).toBe('hello');
-  });
-
-  it('truncates normal text at boundary', () => {
-    expect(safeTruncate('hello world', 5)).toBe('hello...');
-  });
-
-  it('avoids splitting a surrogate pair at the boundary', () => {
-    // U+1F600 (grinning face) is a surrogate pair: \uD83D\uDE00
-    const text = 'ab\u{1F600}cd';
-    // maxLen=3 would land between the high and low surrogate; safeTruncate backs up
-    const result = safeTruncate(text, 3);
-    expect(result).toBe('ab...');
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -6,6 +6,7 @@ import * as github from '@actions/github';
 import { AgentProgressEntry, DEFENSIVE_HARDENING_TAG, DashboardData, Finding, FindingSeverity, OWN_PROPOSAL_TAG, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats, ReviewVerdict } from './types';
 import { isLineInDiff, findClosestDiffLine } from './diff';
 import { MAX_AGENT_RETRIES } from './types';
+import { safeTruncate } from './utils';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -674,15 +675,6 @@ function truncateBody(text: string, maxLength: number = 60000): string {
   const safeMax = Math.max(0, maxLength - notice.length);
   const cutoff = text.lastIndexOf(' ', safeMax);
   return text.slice(0, cutoff > safeMax - 100 ? cutoff : safeMax) + notice;
-}
-
-function safeTruncate(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  let end = maxLen;
-  if (end > 0 && text.charCodeAt(end - 1) >= 0xD800 && text.charCodeAt(end - 1) <= 0xDBFF) {
-    end--;
-  }
-  return text.slice(0, end) + '...';
 }
 
 function sanitizeFilePath(file: string): string {
@@ -1384,4 +1376,4 @@ async function cancelActiveReviewRun(
   }
 }
 
-export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, safeTruncate, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -11,7 +11,8 @@ import {
   Suppression,
   RepoMemory,
 } from './memory';
-import { dynamicFence, LinkedIssue, safeTruncate, titleToSlug } from './github';
+import { dynamicFence, LinkedIssue, titleToSlug } from './github';
+import { safeTruncate } from './utils';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
 import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingReachability, FindingSeverity, HandoverFinding, HandoverRound, IN_PR_SUPPRESSED_TAG, InPrSuppression, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewConfig, ParsedDiff, PrContext, ThreadEvaluation } from './types';

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { truncate, formatDuration, safeJsonParse } from './utils';
+import { truncate, formatDuration, safeJsonParse, safeTruncate } from './utils';
 
 describe('utils', () => {
   describe('truncate', () => {
@@ -16,6 +16,23 @@ describe('utils', () => {
 
     it('handles empty strings', () => {
       expect(truncate('', 5)).toBe('');
+    });
+  });
+
+  describe('safeTruncate', () => {
+    it('returns text unchanged when shorter than max', () => {
+      expect(safeTruncate('hello', 10)).toBe('hello');
+    });
+
+    it('truncates normal text at boundary', () => {
+      expect(safeTruncate('hello world', 5)).toBe('hello...');
+    });
+
+    it('avoids splitting a surrogate pair at the boundary', () => {
+      // U+1F600 (grinning face) is a surrogate pair: 😀
+      const text = 'ab\u{1F600}cd';
+      const result = safeTruncate(text, 3);
+      expect(result).toBe('ab...');
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,19 @@ export function truncate(text: string, maxLength: number): string {
 }
 
 /**
+ * Truncate a string to `maxLen` code units, backing off one position if the
+ * boundary would land inside a UTF-16 surrogate pair, then appending "...".
+ */
+export function safeTruncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  let end = maxLen;
+  if (end > 0 && text.charCodeAt(end - 1) >= 0xD800 && text.charCodeAt(end - 1) <= 0xDBFF) {
+    end--;
+  }
+  return text.slice(0, end) + '...';
+}
+
+/**
  * Format a duration in milliseconds to a human-readable string.
  */
 export function formatDuration(ms: number): string {


### PR DESCRIPTION
## Summary
- Move `safeTruncate` from `src/github.ts` to `src/utils.ts` next to the existing `truncate` helper.
- Update internal callers in `github.ts` and `judge.ts` to import from `./utils`.
- Move the standalone `describe('safeTruncate', …)` test block from `github.test.ts` to `utils.test.ts`, matching the per-helper style already used for `safeJsonParse` / `formatDuration`.

The reviewer raised the cross-layer import on PR [#626](https://github.com/manki-review/manki/pull/626): the LLM orchestration layer (`judge.ts`) shouldn't reach into the GitHub API client just for a generic string utility. Deferred from that PR's scope.

Closes #629