### PR TITLE
refactor: distinguish unfetched vs empty `openThreads` in `determineVerdict`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2742,6 +2742,51 @@ describe('runFullReview orchestration', () => {
     ]);
   });
 
+  it('passes openThreads to the post-escalation `determineVerdict` so prior unaddressed warnings block APPROVE', async () => {
+    // Regression for the dispatch-site bug: `runFullReview` recomputes the
+    // verdict after memory escalations and must forward `openThreads` so the
+    // `prior_unaddressed` branch can fire. Without the third argument every
+    // unresolved prior warning silently falls through to APPROVE.
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
+      previousFindings: [
+        { title: 'Old warning', file: 'src/app.ts', line: 5, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_OPEN' },
+      ],
+      recapContext: '',
+    });
+
+    const finding = { severity: 'nitpick' as const, title: 'Tiny', file: 'src/app.ts', line: 9, description: 'd', reviewers: ['general'] };
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'APPROVE', summary: 'Nits',
+      findings: [finding], highlights: [], reviewComplete: true,
+      agentNames: ['general'],
+    });
+    jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'prior_unaddressed' });
+
+    await callRunFullReview();
+
+    const determineVerdictCalls = jest.mocked(reviewModule.determineVerdict).mock.calls;
+    expect(determineVerdictCalls.length).toBeGreaterThan(0);
+    const lastCall = determineVerdictCalls[determineVerdictCalls.length - 1];
+    expect(lastCall[2]).toEqual([
+      expect.objectContaining({ threadId: 'PRRT_OPEN', file: 'src/app.ts', line: 5 }),
+    ]);
+
+    const reviewResultArg = jest.mocked(ghUtils.postReview).mock.calls[0][5];
+    expect(reviewResultArg?.verdict).toBe('REQUEST_CHANGES');
+    expect(reviewResultArg?.verdictReason).toBe('prior_unaddressed');
+  });
+
   it('populates openThreads[].currentCode with a windowed snippet when file contents are available', async () => {
     const threadFile = 'src/app.ts';
     const fileText = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -697,7 +697,7 @@ async function runFullReview(
     if (memory && memory.patterns.length > 0) {
       result.findings = applyEscalations(result.findings, memory.patterns);
     }
-    const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat);
+    const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat, openThreads);
     result.verdict = recomputedVerdict;
     result.verdictReason = verdictReason;
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -612,17 +612,22 @@ describe('determineVerdict', () => {
       expect(result.verdictReason).toBe('only_nit_or_suggestion');
     });
 
-    it('approves when `openThreads` is undefined and a prior has a `threadId` (legacy two-arg callers)', () => {
-      // Pre-`openThreads` callers omit the third argument. The `?? []`
-      // fallback treats every prior as resolved on GitHub, which lets the
-      // verdict fall through to the existing `only_nit_or_suggestion` rule.
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+    ] as const)('blocks APPROVE when `openThreads` is %s and a prior has a `threadId` (unknown thread state, conservative block)', (_label, sentinel) => {
+      // Both `undefined` and `null` mean "caller did not provide thread
+      // state". Treating either as "no threads open" would let a caller that
+      // failed to fetch (or simply forgot to pass) silently approve a PR
+      // with an unresolved prior warning. The unknown sentinel forces a
+      // conservative block until the caller passes an explicit list.
       const priors = [makePriorWarning()];
-      const result = determineVerdict([nitpick], priors, undefined);
-      expect(result.verdict).toBe('APPROVE');
-      expect(result.verdictReason).toBe('only_nit_or_suggestion');
+      const result = determineVerdict([nitpick], priors, sentinel);
+      expect(result.verdict).toBe('REQUEST_CHANGES');
+      expect(result.verdictReason).toBe('prior_unaddressed');
     });
 
-    it('approves when the prior thread is no longer in openThreads (resolved on GitHub)', () => {
+    it('approves when the prior thread is no longer in openThreads (fetched, none open)', () => {
       const priors = [makePriorWarning()];
       const result = determineVerdict([nitpick], priors, []);
       expect(result.verdict).toBe('APPROVE');

--- a/src/review.ts
+++ b/src/review.ts
@@ -1537,13 +1537,18 @@ function dedupePriorFindings(priorRounds: HandoverFinding[]): HandoverFinding[] 
  * `authorReply: 'none'` would still match `.some(...)` even if round 2
  * captured an `agree` for the same thread.
  *
- * Contract for `openThreads`: callers must pass the result of a successful
- * GitHub thread fetch. Both `undefined` and `[]` are interpreted the same way
- * (no thread is open on GitHub), so any prior finding with a `threadId` that
- * does not appear in the set is treated as resolved. Callers that fail to
- * fetch thread state must abort before reaching this function rather than
- * pass a partial or empty list, otherwise unaddressed warnings could be
- * silently approved.
+ * Contract for `openThreads`: three states with distinct meaning.
+ *   - `null` / omitted → "unknown": caller did not (or could not) fetch open
+ *     threads. Treated conservatively: any prior `warning`/`blocker` with a
+ *     non-`agree` `authorReply` and a `threadId` is assumed still open and
+ *     blocks APPROVE with `prior_unaddressed`. Use this when the GitHub fetch
+ *     failed, or at call sites that intentionally bypass the open-thread
+ *     check, so unresolved priors can never be silently approved.
+ *   - `[]` → "fetched, none open": GitHub confirmed no review threads are
+ *     open on the PR. Prior findings with a `threadId` that does not appear
+ *     here are treated as resolved.
+ *   - `OpenThread[]` (non-empty) → "fetched, here they are": only priors
+ *     whose `threadId` appears in the set are treated as still open.
  *
  * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
  * have already been acknowledged by the author. All these cases approve the PR.
@@ -1551,7 +1556,7 @@ function dedupePriorFindings(priorRounds: HandoverFinding[]): HandoverFinding[] 
 export function determineVerdict(
   findings: Finding[],
   priorRounds?: HandoverFinding[],
-  openThreads?: OpenThread[],
+  openThreads?: OpenThread[] | null,
 ): { verdict: ReviewVerdict; verdictReason: VerdictReason } {
   if (findings.some(f => f.severity === 'blocker')) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
@@ -1565,11 +1570,13 @@ export function determineVerdict(
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' };
   }
 
+  const openThreadsUnknown = openThreads == null;
   const openThreadIds = new Set((openThreads ?? []).map(t => t.threadId));
   const hasUnresolvedPrior = prior.some(p => {
     if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
     if (p.authorReply === 'agree') return false;
     if (!p.threadId) return true;
+    if (openThreadsUnknown) return true;
     return openThreadIds.has(p.threadId);
   });
   if (hasUnresolvedPrior) {


### PR DESCRIPTION
## Summary
- `determineVerdict` now treats `openThreads === null | undefined` as an "unknown / unfetched" sentinel and conservatively blocks APPROVE when prior rounds carry an unresolved warning/blocker with a `threadId` (closes the silent-bypass hole called out on PR [#631](https://github.com/manki-review/manki/pull/631)).
- `[]` continues to mean "fetched, none open" — existing behaviour stands.
- JSDoc on `determineVerdict` rewritten so the contract is internally consistent and spells out the three states.
- `src/index.ts` dispatch site at `runFullReview` now passes the already-in-scope `openThreads` array, so the production action handler actually exercises the `prior_unaddressed` branch.
- Existing `legacy two-arg callers` test rewritten as `it.each(['undefined','null'])` asserting `REQUEST_CHANGES`/`prior_unaddressed`. New integration test in `runFullReview` describe asserts `openThreads` reaches `determineVerdict` and re-classifies APPROVE → REQUEST_CHANGES on prior unaddressed warning.

Closes #634