### PR TITLE
feat: add per-agent model resolution via `models.agents`

### DIFF
--- a/.manki.yml.example
+++ b/.manki.yml.example
@@ -43,6 +43,11 @@
 #   reviewer: claude-sonnet-4-6    # fast, parallel reviewers
 #   judge: claude-sonnet-4-6        # precise, single judge
 #   dedup: claude-haiku-4-5        # fast LLM dedup against prior findings
+#   # Per-agent model overrides. Keys must match a known reviewer name
+#   # (built-in agent or one declared under `reviewers:` above).
+#   # Resolution order per agent: agents[name] -> models.reviewer -> default.
+#   agents:
+#     "Security & Safety": claude-opus-4-7
 
 # Planner stage (default: enabled)
 # When enabled and review_level is "auto", a fast pre-review pass chooses the

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONFIG, loadConfig, loadConfigFromContent, resolveModel } from './config';
+import { DEFAULT_CONFIG, loadConfig, loadConfigFromContent, resolveAgentModel, resolveModel } from './config';
 import { ReviewConfig } from './types';
 
 // Suppress @actions/core output during tests
@@ -441,6 +441,99 @@ models:
         models: { planner: 'claude-sonnet-4-6' },
       };
       expect(resolveModel(config, 'planner')).toBe('claude-sonnet-4-6');
+    });
+  });
+
+  describe('resolveAgentModel', () => {
+    const baseConfig: ReviewConfig = { ...DEFAULT_CONFIG };
+
+    it('returns per-agent override when present', () => {
+      const config: ReviewConfig = {
+        ...baseConfig,
+        models: {
+          reviewer: 'claude-sonnet-4-6',
+          agents: { 'Security & Safety': 'claude-opus-4-7' },
+        },
+      };
+      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('claude-opus-4-7');
+    });
+
+    it('falls back to stage default when no per-agent override', () => {
+      const config: ReviewConfig = {
+        ...baseConfig,
+        models: {
+          reviewer: 'claude-haiku-4-5',
+          agents: { 'Security & Safety': 'claude-opus-4-7' },
+        },
+      };
+      expect(resolveAgentModel(config, 'Architecture & Design', 'reviewer')).toBe('claude-haiku-4-5');
+    });
+
+    it('falls back to built-in default when no stage override and no agent override', () => {
+      const config: ReviewConfig = { ...baseConfig, models: undefined };
+      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('claude-sonnet-4-6');
+    });
+
+    it('falls back to built-in default when models.agents is undefined', () => {
+      const config: ReviewConfig = { ...baseConfig, models: { reviewer: 'claude-haiku-4-5' } };
+      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('claude-haiku-4-5');
+    });
+  });
+
+  describe('models.agents config', () => {
+    it('accepts per-agent overrides for built-in agents', () => {
+      const yaml = `
+models:
+  reviewer: claude-sonnet-4-6
+  agents:
+    "Security & Safety": claude-opus-4-7
+`;
+      const config = loadConfig(yaml);
+      expect(config.models?.agents?.['Security & Safety']).toBe('claude-opus-4-7');
+    });
+
+    it('accepts per-agent overrides for custom reviewers declared in config', () => {
+      const yaml = `
+reviewers:
+  - name: "Protocol Compliance"
+    focus: "DIP compliance"
+models:
+  agents:
+    "Protocol Compliance": claude-opus-4-7
+`;
+      const config = loadConfig(yaml);
+      expect(config.models?.agents?.['Protocol Compliance']).toBe('claude-opus-4-7');
+    });
+
+    it('rejects unknown agent names with a list of known agents', () => {
+      const yaml = `
+models:
+  agents:
+    "Foo": claude-opus-4-7
+`;
+      expect(() => loadConfig(yaml)).toThrow(/Unknown agent name "Foo" in `models.agents`. Known agents: /);
+    });
+
+    it('rejects empty model string for an agent', () => {
+      const yaml = `
+models:
+  agents:
+    "Security & Safety": ""
+`;
+      expect(() => loadConfig(yaml)).toThrow(/`models.agents.Security & Safety` must be a non-empty string/);
+    });
+
+    it('rejects non-object models.agents', () => {
+      const yaml = `
+models:
+  agents: "not a map"
+`;
+      expect(() => loadConfig(yaml)).toThrow(/`models.agents` must be an object/);
+    });
+
+    it('omits agents key when not provided', () => {
+      const config = loadConfig('models:\n  reviewer: claude-sonnet-4-6\n');
+      expect(config.models?.agents).toBeUndefined();
     });
   });
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -478,6 +478,36 @@ models:
       const config: ReviewConfig = { ...baseConfig, models: { reviewer: 'claude-haiku-4-5' } };
       expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('claude-haiku-4-5');
     });
+
+    it('resolves the per-agent override regardless of stage', () => {
+      const config: ReviewConfig = {
+        ...baseConfig,
+        models: {
+          planner: 'claude-haiku-4-5',
+          judge: 'claude-opus-4-7',
+          dedup: 'claude-haiku-4-5',
+          agents: { 'Security & Safety': 'claude-opus-4-7' },
+        },
+      };
+      expect(resolveAgentModel(config, 'Security & Safety', 'planner')).toBe('claude-opus-4-7');
+      expect(resolveAgentModel(config, 'Security & Safety', 'judge')).toBe('claude-opus-4-7');
+      expect(resolveAgentModel(config, 'Security & Safety', 'dedup')).toBe('claude-opus-4-7');
+    });
+
+    it('falls back to the requested stage default for non-overridden agents', () => {
+      const config: ReviewConfig = {
+        ...baseConfig,
+        models: {
+          planner: 'planner-model',
+          judge: 'judge-model',
+          dedup: 'dedup-model',
+          reviewer: 'reviewer-model',
+        },
+      };
+      expect(resolveAgentModel(config, 'Architecture & Design', 'planner')).toBe('planner-model');
+      expect(resolveAgentModel(config, 'Architecture & Design', 'judge')).toBe('judge-model');
+      expect(resolveAgentModel(config, 'Architecture & Design', 'dedup')).toBe('dedup-model');
+    });
   });
 
   describe('models.agents config', () => {
@@ -534,6 +564,51 @@ models:
     it('omits agents key when not provided', () => {
       const config = loadConfig('models:\n  reviewer: claude-sonnet-4-6\n');
       expect(config.models?.agents).toBeUndefined();
+    });
+
+    it('rejects non-string (number) value for an agent override', () => {
+      const yaml = `
+models:
+  agents:
+    "Security & Safety": 42
+`;
+      expect(() => loadConfig(yaml)).toThrow(/`models.agents.Security & Safety` must be a non-empty string/);
+    });
+
+    it('rejects array value for models.agents', () => {
+      const yaml = `
+models:
+  agents:
+    - "Security & Safety"
+`;
+      expect(() => loadConfig(yaml)).toThrow(/`models.agents` must be an object/);
+    });
+
+    it('points malformed reviewer entries at the right error when an override targets them', () => {
+      const yaml = `
+reviewers:
+  - name: "Protocol Compliance"
+models:
+  agents:
+    "Protocol Compliance": claude-opus-4-7
+`;
+      expect(() => loadConfig(yaml)).toThrow(/Agent "Protocol Compliance" in `models.agents` matches a reviewer declared under `reviewers:` but that entry is invalid/);
+    });
+
+    it('merges per-agent overrides through deepMerge without dropping prior entries', () => {
+      const config = loadConfigFromContent(`
+reviewers:
+  - name: "Protocol Compliance"
+    focus: "DIP compliance"
+models:
+  agents:
+    "Security & Safety": claude-opus-4-7
+    "Protocol Compliance": claude-haiku-4-5
+`);
+      expect(config.models?.agents).toEqual({
+        'Security & Safety': 'claude-opus-4-7',
+        'Protocol Compliance': 'claude-haiku-4-5',
+      });
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,13 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
         .map(r => ({ name: r.name as string, focus: r.focus as string }))
     : [];
   const knownAgentNames = new Set(buildAgentPool(customReviewers as ReviewerAgent[]).map(a => a.name));
+  const declaredReviewerNames = new Set(
+    Array.isArray(config.reviewers)
+      ? (config.reviewers as Array<Record<string, unknown>>)
+          .filter(r => r && typeof r === 'object' && typeof r.name === 'string' && (r.name as string).length > 0)
+          .map(r => r.name as string)
+      : [],
+  );
 
   for (const key of Object.keys(config)) {
     if (!KNOWN_KEYS.has(key)) {
@@ -177,8 +184,12 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
               continue;
             }
             if (!knownAgentNames.has(agentName)) {
-              const known = Array.from(knownAgentNames).map(n => `"${n}"`).join(', ');
-              errors.push(`Unknown agent name "${agentName}" in \`models.agents\`. Known agents: ${known}`);
+              if (declaredReviewerNames.has(agentName)) {
+                errors.push(`Agent "${agentName}" in \`models.agents\` matches a reviewer declared under \`reviewers:\` but that entry is invalid. Check its \`name\` and \`focus\` fields.`);
+              } else {
+                const known = Array.from(knownAgentNames).map(n => `"${n}"`).join(', ');
+                errors.push(`Unknown agent name "${agentName}" in \`models.agents\`. Known agents: ${known}`);
+              }
             }
           }
         }
@@ -271,17 +282,14 @@ function deepMerge(defaults: ReviewConfig, overrides: Record<string, unknown>): 
       result.memory = { ...defaults.memory, ...(value as Record<string, unknown>) } as ReviewConfig['memory'];
     } else if (key === 'models' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
       const incoming = value as Record<string, unknown>;
-      const mergedAgents = (() => {
-        const existing = defaults.models?.agents;
-        const next = incoming.agents;
-        if (!existing && (!next || typeof next !== 'object' || Array.isArray(next))) return undefined;
-        return {
-          ...(existing ?? {}),
-          ...((next && typeof next === 'object' && !Array.isArray(next)) ? (next as Record<string, string>) : {}),
-        };
-      })();
+      const incomingAgents = incoming.agents as Record<string, string> | undefined;
+      const existingAgents = defaults.models?.agents;
       const merged = { ...defaults.models, ...incoming } as ReviewConfig['models'];
-      if (mergedAgents !== undefined && merged) merged.agents = mergedAgents;
+      if (merged) {
+        merged.agents = (existingAgents || incomingAgents)
+          ? { ...(existingAgents ?? {}), ...(incomingAgents ?? {}) }
+          : undefined;
+      }
       result.models = merged;
     } else if (key === 'planner' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
       result.planner = { ...defaults.planner, ...(value as Record<string, unknown>) } as ReviewConfig['planner'];

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { parse as parseYaml } from 'yaml';
 
 import { ReviewerAgent, ReviewConfig } from './types';
+// TODO: layering, temporary import from review.ts, cleanup tracked at https://github.com/manki-review/manki/issues/676
 import { buildAgentPool } from './review';
 
 export const DEFAULT_CONFIG: ReviewConfig = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,8 @@ import * as core from '@actions/core';
 import * as fs from 'fs';
 import { parse as parseYaml } from 'yaml';
 
-import { ReviewConfig } from './types';
+import { ReviewerAgent, ReviewConfig } from './types';
+import { buildAgentPool } from './review';
 
 export const DEFAULT_CONFIG: ReviewConfig = {
   auto_review: true,
@@ -63,6 +64,13 @@ interface ConfigValidationResult {
 function validateConfig(config: Record<string, unknown>): ConfigValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
+
+  const customReviewers = Array.isArray(config.reviewers)
+    ? (config.reviewers as Array<Record<string, unknown>>)
+        .filter(r => r && typeof r === 'object' && typeof r.name === 'string' && typeof r.focus === 'string')
+        .map(r => ({ name: r.name as string, focus: r.focus as string }))
+    : [];
+  const knownAgentNames = new Set(buildAgentPool(customReviewers as ReviewerAgent[]).map(a => a.name));
 
   for (const key of Object.keys(config)) {
     if (!KNOWN_KEYS.has(key)) {
@@ -158,6 +166,23 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
       if ('dedup' in models && typeof models.dedup !== 'string') {
         errors.push('`models.dedup` must be a string');
       }
+      if ('agents' in models) {
+        const agents = models.agents as Record<string, unknown>;
+        if (!agents || typeof agents !== 'object' || Array.isArray(agents)) {
+          errors.push('`models.agents` must be an object mapping agent names to model strings');
+        } else {
+          for (const [agentName, modelValue] of Object.entries(agents)) {
+            if (typeof modelValue !== 'string' || modelValue === '') {
+              errors.push(`\`models.agents.${agentName}\` must be a non-empty string`);
+              continue;
+            }
+            if (!knownAgentNames.has(agentName)) {
+              const known = Array.from(knownAgentNames).map(n => `"${n}"`).join(', ');
+              errors.push(`Unknown agent name "${agentName}" in \`models.agents\`. Known agents: ${known}`);
+            }
+          }
+        }
+      }
     }
   }
 
@@ -245,7 +270,19 @@ function deepMerge(defaults: ReviewConfig, overrides: Record<string, unknown>): 
     if (key === 'memory' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
       result.memory = { ...defaults.memory, ...(value as Record<string, unknown>) } as ReviewConfig['memory'];
     } else if (key === 'models' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      result.models = { ...defaults.models, ...(value as Record<string, unknown>) } as ReviewConfig['models'];
+      const incoming = value as Record<string, unknown>;
+      const mergedAgents = (() => {
+        const existing = defaults.models?.agents;
+        const next = incoming.agents;
+        if (!existing && (!next || typeof next !== 'object' || Array.isArray(next))) return undefined;
+        return {
+          ...(existing ?? {}),
+          ...((next && typeof next === 'object' && !Array.isArray(next)) ? (next as Record<string, string>) : {}),
+        };
+      })();
+      const merged = { ...defaults.models, ...incoming } as ReviewConfig['models'];
+      if (mergedAgents !== undefined && merged) merged.agents = mergedAgents;
+      result.models = merged;
     } else if (key === 'planner' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
       result.planner = { ...defaults.planner, ...(value as Record<string, unknown>) } as ReviewConfig['planner'];
     } else if (key === 'review_thresholds' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
@@ -314,6 +351,20 @@ export function loadConfigFromFile(filePath: string): ReviewConfig {
 
 export function resolveModel(config: ReviewConfig, stage: 'planner' | 'reviewer' | 'judge' | 'dedup'): string {
   return config.models?.[stage] || DEFAULT_CONFIG.models![stage]!;
+}
+
+/**
+ * Resolves the model for a specific reviewer agent. Resolution order:
+ * `models.agents[agentName]` → `models[stage]` → built-in default for `stage`.
+ */
+export function resolveAgentModel(
+  config: ReviewConfig,
+  agentName: string,
+  stage: 'planner' | 'reviewer' | 'judge' | 'dedup',
+): string {
+  const override = config.models?.agents?.[agentName];
+  if (override) return override;
+  return resolveModel(config, stage);
 }
 
 export function loadConfig(yamlContent: string | undefined): ReviewConfig {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -158,6 +158,7 @@ jest.mock('./state', () => ({
 
 import { run, runFullReview, handlePullRequest, handleCommentTrigger, handleInteraction, handleIssueInteraction, handleReviewCommentInteraction, handleReviewStateCheck, main, _resetOctokitCache } from './index';
 import { FORCE_REVIEW_MARKER } from './github';
+import type { ReviewConfig } from './types';
 import { createLLMClient, parseModelSpec } from './providers';
 import * as interaction from './interaction';
 import * as ghUtils from './github';
@@ -3667,6 +3668,126 @@ describe('runFullReview orchestration', () => {
       expect.stringContaining('Unknown model "x"'),
     );
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+  });
+
+  describe('per-agent model overrides', () => {
+    function configWithAgents(agents: Record<string, string>): ReviewConfig {
+      return {
+        auto_review: true, auto_approve: false, max_diff_lines: 5000,
+        exclude_paths: [], nit_handling: 'issues',
+        reviewers: [], instructions: '', review_level: 'auto',
+        review_thresholds: { small: 200, medium: 800 },
+        memory: { enabled: false, repo: '' },
+        models: { reviewer: 'claude-sonnet-4-6', agents },
+      };
+    }
+
+    it('logs per-agent model overrides when configured', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(
+        configWithAgents({ 'Security & Safety': 'claude-opus-4-7' }),
+      );
+
+      await callRunFullReview();
+
+      expect(jest.mocked(core.info)).toHaveBeenCalledWith(
+        expect.stringContaining('Per-agent model overrides — Security & Safety=claude-opus-4-7'),
+      );
+    });
+
+    it('does not log per-agent overrides when models.agents is absent or empty', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(configWithAgents({}));
+
+      await callRunFullReview();
+
+      const infoCalls = jest.mocked(core.info).mock.calls.map(c => c[0]);
+      expect(infoCalls.some((m: string) => m?.includes('Per-agent model overrides'))).toBe(false);
+    });
+
+    it('eagerly constructs per-agent clients and surfaces failures via setFailed', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(
+        configWithAgents({ 'Security & Safety': 'bogus-model' }),
+      );
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => {
+        if (m === 'bogus-model') throw new Error('Unsupported provider for "bogus-model"');
+        return { provider: 'anthropic', model: m };
+      });
+
+      await callRunFullReview();
+
+      expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+        expect.stringContaining('Unsupported provider'),
+      );
+      expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    });
+
+    it('passes a reviewerForAgent callback that returns the override client for overridden agents', async () => {
+      const overrideClient = { sendMessage: jest.fn() };
+      jest.mocked(createLLMClient).mockImplementation((_p: unknown, model: unknown) =>
+        model === 'claude-opus-4-7' ? overrideClient : { sendMessage: jest.fn() },
+      );
+      jest.mocked(configModule.loadConfig).mockReturnValue(
+        configWithAgents({ 'Security & Safety': 'claude-opus-4-7' }),
+      );
+      const testFile = {
+        path: 'src/app.ts', changeType: 'modified' as const,
+        hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: '' }],
+      };
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [testFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+      await callRunFullReview();
+
+      const runReviewCall = jest.mocked(reviewModule.runReview).mock.calls[0];
+      expect(runReviewCall).toBeDefined();
+      const clientsArg = runReviewCall[0] as { reviewerForAgent: (n: string) => unknown };
+      expect(clientsArg.reviewerForAgent('Security & Safety')).toBe(overrideClient);
+    });
+
+    it('reviewerForAgent falls back to the default reviewer client when no override is configured', async () => {
+      const defaultClient = { sendMessage: jest.fn(), tag: 'default' };
+      jest.mocked(createLLMClient).mockReturnValue(defaultClient);
+      jest.mocked(configModule.loadConfig).mockReturnValue(configWithAgents({}));
+      const testFile = {
+        path: 'src/app.ts', changeType: 'modified' as const,
+        hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: '' }],
+      };
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [testFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+      await callRunFullReview();
+
+      const runReviewCall = jest.mocked(reviewModule.runReview).mock.calls[0];
+      const clientsArg = runReviewCall[0] as { reviewerForAgent: (n: string) => unknown; reviewer: unknown };
+      expect(clientsArg.reviewerForAgent('Architecture & Design')).toBe(clientsArg.reviewer);
+    });
+
+    it('reviewerForAgent caches per-agent clients across repeated invocations', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(
+        configWithAgents({ 'Security & Safety': 'claude-opus-4-7' }),
+      );
+      const testFile = {
+        path: 'src/app.ts', changeType: 'modified' as const,
+        hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: '' }],
+      };
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [testFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+      await callRunFullReview();
+
+      const callsBefore = jest.mocked(createLLMClient).mock.calls.length;
+      const runReviewCall = jest.mocked(reviewModule.runReview).mock.calls[0];
+      const clientsArg = runReviewCall[0] as { reviewerForAgent: (n: string) => unknown };
+      const a = clientsArg.reviewerForAgent('Security & Safety');
+      const b = clientsArg.reviewerForAgent('Security & Safety');
+      expect(a).toBe(b);
+      expect(jest.mocked(createLLMClient).mock.calls.length).toBe(callsBefore);
+    });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
-import { loadConfig, resolveModel } from './config';
+import { loadConfig, resolveAgentModel, resolveModel } from './config';
 import { buildAnthropicAuth, createLLMClient, parseModelSpec } from './providers';
 import type { LLMClient } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
@@ -393,6 +393,11 @@ async function runFullReview(
     const judgeModel = resolveModel(config, 'judge');
     const dedupModel = resolveModel(config, 'dedup');
     core.info(`Models — planner: ${plannerModel}, reviewer: ${reviewerModel}, judge: ${judgeModel}, dedup: ${dedupModel}`);
+    const agentOverrides = config.models?.agents;
+    if (agentOverrides && Object.keys(agentOverrides).length > 0) {
+      const formatted = Object.entries(agentOverrides).map(([n, m]) => `${n}=${m}`).join(', ');
+      core.info(`Per-agent model overrides — ${formatted}`);
+    }
 
     const buildClient = (model: string) => {
       const spec = parseModelSpec(model);
@@ -637,7 +642,16 @@ async function runFullReview(
     }
 
     const result = await runReview(
-      { reviewer: reviewerClient, judge: judgeClient, planner: plannerClient, dedup: dedupClient }, config, diff, rawDiff, fullContext,
+      {
+        reviewer: reviewerClient,
+        judge: judgeClient,
+        planner: plannerClient,
+        dedup: dedupClient,
+        reviewerForAgent: (agentName: string) => {
+          const model = resolveAgentModel(config, agentName, 'reviewer');
+          return model === reviewerModel ? reviewerClient : buildClient(model);
+        },
+      }, config, diff, rawDiff, fullContext,
       memory, fileContents, prContext, linkedIssues,
       (progress) => {
         if (progress.phase === 'planning') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
-import { loadConfig, resolveAgentModel, resolveModel } from './config';
+import { loadConfig, resolveModel } from './config';
 import { buildAnthropicAuth, createLLMClient, parseModelSpec } from './providers';
 import type { LLMClient } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
@@ -405,11 +405,15 @@ async function runFullReview(
     };
     let reviewerClient: LLMClient, judgeClient: LLMClient, dedupClient: LLMClient;
     let plannerClient: LLMClient | undefined;
+    const perAgentClients = new Map<string, LLMClient>();
     try {
       reviewerClient = buildClient(reviewerModel);
       judgeClient = buildClient(judgeModel);
       plannerClient = config.planner?.enabled !== false ? buildClient(plannerModel) : undefined;
       dedupClient = buildClient(dedupModel);
+      for (const [name, model] of Object.entries(config.models?.agents ?? {})) {
+        if (model !== reviewerModel) perAgentClients.set(name, buildClient(model));
+      }
     } catch (error) {
       core.setFailed(`Invalid model config: ${error instanceof Error ? error.message : error}`);
       await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId }).catch(() => {});
@@ -647,10 +651,8 @@ async function runFullReview(
         judge: judgeClient,
         planner: plannerClient,
         dedup: dedupClient,
-        reviewerForAgent: (agentName: string) => {
-          const model = resolveAgentModel(config, agentName, 'reviewer');
-          return model === reviewerModel ? reviewerClient : buildClient(model);
-        },
+        reviewerForAgent: (agentName: string) =>
+          perAgentClients.get(agentName) ?? reviewerClient,
       }, config, diff, rawDiff, fullContext,
       memory, fileContents, prContext, linkedIssues,
       (progress) => {

--- a/src/review.ts
+++ b/src/review.ts
@@ -326,6 +326,16 @@ export interface ReviewClients {
   judge: LLMClient;
   planner?: LLMClient;
   dedup?: LLMClient;
+  /**
+   * Optional resolver returning the reviewer client for a specific agent. When
+   * present, it takes precedence over `reviewer`. Used to apply per-agent
+   * model overrides from `models.agents`.
+   */
+  reviewerForAgent?: (agentName: string) => LLMClient;
+}
+
+function pickReviewerClient(clients: ReviewClients, agentName: string): LLMClient {
+  return clients.reviewerForAgent?.(agentName) ?? clients.reviewer;
 }
 
 export interface ReviewProgress {
@@ -721,7 +731,7 @@ export async function runReview(
         Array.from({ length: passes }, () => {
           const shuffledDiff = shuffleDiffFiles(diff);
           const shuffledRawDiff = rebuildRawDiff(shuffledDiff);
-          return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: agentEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap });
+          return runReviewerAgent(pickReviewerClient(clients, agent.name), config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: agentEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap });
         })
       );
 
@@ -811,7 +821,7 @@ export async function runReview(
             const shuffledDiff = shuffleDiffFiles(diff);
             const shuffledRawDiff = rebuildRawDiff(shuffledDiff);
             const retryEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-            return runReviewerAgent(clients.reviewer, config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: retryEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap });
+            return runReviewerAgent(pickReviewerClient(clients, agent.name), config, agent, shuffledRawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: retryEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap });
           })
         );
 
@@ -873,7 +883,7 @@ export async function runReview(
     const agentPromises = team.agents.map(agent => {
       const startTime = Date.now();
       const agentEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-      return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: agentEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap })
+      return runReviewerAgent(pickReviewerClient(clients, agent.name), config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: agentEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap })
         .then(agentResult => {
           completedCount++;
           agentResponseLengths.set(agent.name, agentResult.responseLength);
@@ -954,7 +964,7 @@ export async function runReview(
       const retryPromises = agentsToRetry.map(agent => {
         const startTime = Date.now();
         const retryEffort = agentEffortMap.get(agent.name) ?? defaultReviewerEffort;
-        return runReviewerAgent(clients.reviewer, config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: retryEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap })
+        return runReviewerAgent(pickReviewerClient(clients, agent.name), config, agent, rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, { effort: retryEffort, language: plannerResult?.language, context: plannerResult?.context, provenanceMap })
           .then(agentResult => ({ agent, agentResult, durationMs: Date.now() - startTime }))
           .catch(() => ({ agent, agentResult: null as AgentResult | null, durationMs: Date.now() - startTime }));
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,12 @@ export interface ReviewConfig {
     reviewer?: string;
     judge?: string;
     dedup?: string;
+    /**
+     * Per-agent model overrides. Keys are reviewer agent names (built-in or
+     * custom). When set, the resolver picks this model for the named agent
+     * instead of `models.reviewer`.
+     */
+    agents?: Record<string, string>;
   };
   planner?: {
     enabled?: boolean;


### PR DESCRIPTION
## Summary

Add `config.models.agents` map for per-agent model overrides. Resolution order: `agents[name]` then `models[stage]` then built-in default.

Validation rejects unknown agent names in `models.agents` (checked against the built-in pool plus any custom reviewers declared under `reviewers:`).

`runReview` now accepts an optional `reviewerForAgent` factory on `ReviewClients`. `src/index.ts` wires it using `resolveAgentModel(config, name, 'reviewer')` so each agent receives its own client when an override applies.

Example:

```yaml
models:
  reviewer: claude-sonnet-4-6
  judge: claude-opus-4-7
  agents:
    "Security & Safety": claude-opus-4-7
```

Closes [#488](https://github.com/manki-review/manki/issues/488)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (1580 tests pass), including new tests for resolution chain and validation errors
- [x] `npm run build` succeeds