### PR TITLE
feat: OpenAI provider adapter (API key + Codex CLI OAuth)

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install Codex CLI
         if: env.OPENAI_OAUTH_TOKEN != ''
         # Pin and `--ignore-scripts` mirror the runtime fallback in `src/providers/openai.ts`.
+        # If you update `CODEX_CLI_VERSION` in `src/providers/openai.ts`, update the version here too.
         run: npm install -g --ignore-scripts '@openai/codex@0.129.0'
         env:
           OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -41,7 +41,8 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - name: Install Codex CLI
         if: env.OPENAI_OAUTH_TOKEN != ''
-        run: npm install -g @openai/codex
+        # Pin and `--ignore-scripts` mirror the runtime fallback in `src/providers/openai.ts`.
+        run: npm install -g --ignore-scripts '@openai/codex@0.129.0'
         env:
           OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
       - name: Manki Review
@@ -50,4 +51,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           openai_oauth_token: ${{ secrets.OPENAI_OAUTH_TOKEN }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -39,9 +39,15 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      - name: Install Codex CLI
+        if: env.OPENAI_OAUTH_TOKEN != ''
+        run: npm install -g @openai/codex
+        env:
+          OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
       - name: Manki Review
         uses: ./  # Use local action for self-testing
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          openai_oauth_token: ${{ secrets.OPENAI_OAUTH_TOKEN }}
           memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ inputs:
   anthropic_api_key:
     description: 'Anthropic API key (alternative to OAuth token)'
     required: false
+  openai_oauth_token:
+    description: 'OpenAI Codex CLI OAuth token (for Plus/Pro subscription authentication via the Codex CLI)'
+    required: false
+  openai_api_key:
+    description: 'OpenAI API key (alternative to OAuth token)'
+    required: false
   github_token:
     description: 'GitHub token for posting reviews and comments (not required when using GitHub App auth)'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^21.1.1",
         "minimatch": "^10.2.4",
+        "openai": "^6.37.0",
         "parse-diff": "^0.11.1",
         "yaml": "^2.8.3"
       },
@@ -5403,6 +5404,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+      "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^21.1.1",
     "minimatch": "^10.2.4",
+    "openai": "^6.37.0",
     "parse-diff": "^0.11.1",
     "yaml": "^2.8.3"
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -54,6 +54,7 @@ jest.mock('./auth', () => ({
 
 jest.mock('./providers', () => ({
   buildAnthropicAuth: jest.requireActual('./providers').buildAnthropicAuth,
+  buildOpenAIAuth: jest.requireActual('./providers').buildOpenAIAuth,
   createLLMClient: jest.fn().mockImplementation(() => ({ sendMessage: jest.fn() })),
   parseModelSpec: jest.fn().mockImplementation((m: string) => ({ provider: 'anthropic', model: m })),
 }));
@@ -4083,6 +4084,52 @@ describe('handleInteraction', () => {
       'anthropic',
       expect.any(String),
       { kind: 'apiKey', key: 'sk-api-key' },
+    );
+  });
+
+  it('routes openai-prefixed models to OpenAI auth dispatch', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'openai_api_key' ? 'sk-openai-key' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementationOnce((m: string) => ({ provider: 'openai', model: m }));
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help' },
+        issue: { number: 7, pull_request: { url: 'https://...' } },
+      },
+    });
+
+    await handleInteraction();
+
+    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+      'openai',
+      expect.any(String),
+      { kind: 'apiKey', key: 'sk-openai-key' },
+    );
+  });
+
+  it('uses oauth auth when openai_oauth_token is set', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'openai_oauth_token' ? 'codex-oauth-tok' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementationOnce((m: string) => ({ provider: 'openai', model: m }));
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help' },
+        issue: { number: 7, pull_request: { url: 'https://...' } },
+      },
+    });
+
+    await handleInteraction();
+
+    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+      'openai',
+      expect.any(String),
+      { kind: 'oauth', token: 'codex-oauth-tok' },
     );
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1132,7 +1132,7 @@ describe('handleReviewCommentInteraction', () => {
     await handleReviewCommentInteraction();
 
     expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      'No API key configured — set claude_code_oauth_token or anthropic_api_key',
+      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key',
     );
     expect(jest.mocked(interaction.handleReviewCommentReply)).not.toHaveBeenCalled();
   });
@@ -3593,7 +3593,7 @@ describe('runFullReview orchestration', () => {
     await callRunFullReview();
 
     expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      'No API key configured — set claude_code_oauth_token or anthropic_api_key',
+      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key',
     );
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
@@ -3987,7 +3987,7 @@ describe('handleInteraction', () => {
     await handleInteraction();
 
     expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      'No API key configured — set claude_code_oauth_token or anthropic_api_key',
+      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key',
     );
     expect(jest.mocked(interaction.handlePRComment)).not.toHaveBeenCalled();
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3622,6 +3622,42 @@ describe('runFullReview orchestration', () => {
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
   });
 
+  it('routes openai models to OpenAI auth in buildClient', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'openai_api_key' ? 'sk-openai-key' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'openai', model: m }));
+    try {
+      await callRunFullReview();
+
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'openai',
+        expect.any(String),
+        { kind: 'apiKey', key: 'sk-openai-key' },
+      );
+    } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
+  });
+
+  it('fails fast when an openai model is selected but only anthropic credentials are set', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'sk-anthropic' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'openai', model: m }));
+    try {
+      await callRunFullReview();
+
+      expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+        expect.stringContaining('Either openai_oauth_token or openai_api_key must be provided'),
+      );
+      expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
+  });
+
   it('posts app warning when identity is actions', async () => {
     _resetOctokitCache();
     jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
@@ -4131,6 +4167,28 @@ describe('handleInteraction', () => {
       expect.any(String),
       { kind: 'oauth', token: 'codex-oauth-tok' },
     );
+  });
+
+  it('sets failed when openai model is selected but only anthropic credentials are configured', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'sk-anthropic' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementationOnce((m: string) => ({ provider: 'openai', model: m }));
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help' },
+        issue: { number: 7, pull_request: { url: 'https://...' } },
+      },
+    });
+
+    await handleInteraction();
+
+    expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+      expect.stringContaining('Either openai_oauth_token or openai_api_key must be provided'),
+    );
+    expect(jest.mocked(createLLMClient)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1164,6 +1164,80 @@ describe('handleReviewCommentInteraction', () => {
     expect(jest.mocked(interaction.handleReviewCommentReply)).not.toHaveBeenCalled();
     expect(jest.mocked(interaction.handleReviewCommentCommand)).not.toHaveBeenCalled();
   });
+
+  it('routes openai-prefixed models to OpenAI apiKey auth dispatch', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'openai_api_key' ? 'sk-openai-key' : '',
+    );
+    jest.mocked(interaction.hasBotMention).mockReturnValue(true);
+    jest.mocked(parseModelSpec).mockImplementationOnce((m: string) => ({ provider: 'openai', model: m }));
+
+    setContext({
+      eventName: 'pull_request_review_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help', user: { type: 'User' } },
+        pull_request: { base: { ref: 'main' }, number: 42 },
+      },
+    });
+
+    await handleReviewCommentInteraction();
+
+    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+      'openai',
+      expect.any(String),
+      { kind: 'apiKey', key: 'sk-openai-key' },
+    );
+  });
+
+  it('uses oauth auth when openai_oauth_token is set', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'openai_oauth_token' ? 'codex-oauth-tok' : '',
+    );
+    jest.mocked(interaction.hasBotMention).mockReturnValue(true);
+    jest.mocked(parseModelSpec).mockImplementationOnce((m: string) => ({ provider: 'openai', model: m }));
+
+    setContext({
+      eventName: 'pull_request_review_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help', user: { type: 'User' } },
+        pull_request: { base: { ref: 'main' }, number: 42 },
+      },
+    });
+
+    await handleReviewCommentInteraction();
+
+    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+      'openai',
+      expect.any(String),
+      { kind: 'oauth', token: 'codex-oauth-tok' },
+    );
+  });
+
+  it('sets failed when openai model is selected but only anthropic credentials are configured', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'sk-anthropic' : '',
+    );
+    jest.mocked(interaction.hasBotMention).mockReturnValue(true);
+    jest.mocked(parseModelSpec).mockImplementationOnce((m: string) => ({ provider: 'openai', model: m }));
+
+    setContext({
+      eventName: 'pull_request_review_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help', user: { type: 'User' } },
+        pull_request: { base: { ref: 'main' }, number: 42 },
+      },
+    });
+
+    await handleReviewCommentInteraction();
+
+    expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+      expect.stringContaining('Either openai_oauth_token or openai_api_key must be provided'),
+    );
+    expect(jest.mocked(createLLMClient)).not.toHaveBeenCalled();
+  });
 });
 
 describe('handleReviewStateCheck', () => {
@@ -3654,6 +3728,47 @@ describe('runFullReview orchestration', () => {
       );
       expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
     } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
+  });
+
+  it('routes each stage to its own provider when planner/reviewer/judge models cross provider boundaries', async () => {
+    // Mixed-provider scenario: planner on anthropic, reviewer on openai, judge on anthropic.
+    // Both credential sets are set so each stage can resolve.
+    jest.mocked(core.getInput).mockImplementation((name: string) => {
+      if (name === 'anthropic_api_key') return 'sk-anthropic';
+      if (name === 'openai_api_key') return 'sk-openai';
+      return '';
+    });
+    jest.mocked(configModule.resolveModel).mockImplementation((_cfg, stage: string) => {
+      if (stage === 'planner') return 'claude-sonnet-4-20250514';
+      if (stage === 'reviewer') return 'gpt-4o';
+      if (stage === 'judge') return 'claude-opus-4-7';
+      return 'claude-sonnet-4-20250514'; // dedup
+    });
+    jest.mocked(parseModelSpec).mockImplementation((m: string) =>
+      m.startsWith('gpt-') || /^o\d/.test(m)
+        ? { provider: 'openai', model: m }
+        : { provider: 'anthropic', model: m },
+    );
+    try {
+      await callRunFullReview();
+
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      // Reviewer stage routed to OpenAI with apiKey auth.
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'openai', 'gpt-4o', { kind: 'apiKey', key: 'sk-openai' },
+      );
+      // Judge stage routed to Anthropic with apiKey auth.
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'anthropic', 'claude-opus-4-7', { kind: 'apiKey', key: 'sk-anthropic' },
+      );
+      // Planner stage routed to Anthropic.
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'anthropic', 'claude-sonnet-4-20250514', { kind: 'apiKey', key: 'sk-anthropic' },
+      );
+    } finally {
+      jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
       jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
     }
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1238,6 +1238,30 @@ describe('handleReviewCommentInteraction', () => {
     );
     expect(jest.mocked(createLLMClient)).not.toHaveBeenCalled();
   });
+
+  it('sets failed when createLLMClient throws after valid model spec and auth', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'claude_code_oauth_token' ? 'oauth-tok' : '',
+    );
+    jest.mocked(interaction.hasBotMention).mockReturnValue(true);
+    jest.mocked(createLLMClient).mockImplementationOnce(() => { throw new Error('unsupported model variant'); });
+
+    setContext({
+      eventName: 'pull_request_review_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help', user: { type: 'User' } },
+        pull_request: { base: { ref: 'main' }, number: 42 },
+      },
+    });
+
+    await handleReviewCommentInteraction();
+
+    expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid model config'),
+    );
+    expect(jest.mocked(interaction.handleReviewCommentReply)).not.toHaveBeenCalled();
+  });
 });
 
 describe('handleReviewStateCheck', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,21 @@ function buildLLMClientFromInputs(opts: {
   inputs: ProviderInputs;
   model: string;
 }): { client: LLMClient } | null {
+  let spec: ReturnType<typeof parseModelSpec>;
   try {
-    const spec = parseModelSpec(opts.model);
-    const auth = buildAuthForProvider(spec.provider, opts.inputs);
+    spec = parseModelSpec(opts.model);
+  } catch (error) {
+    core.setFailed(`Invalid model config: ${error instanceof Error ? error.message : error}`);
+    return null;
+  }
+  let auth: ProviderAuth;
+  try {
+    auth = buildAuthForProvider(spec.provider, opts.inputs);
+  } catch (error) {
+    core.setFailed(`Missing credentials for provider "${spec.provider}": ${error instanceof Error ? error.message : error}`);
+    return null;
+  }
+  try {
     return { client: createLLMClient(spec.provider, spec.model, auth) };
   } catch (error) {
     core.setFailed(`Invalid model config: ${error instanceof Error ? error.message : error}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
 import { loadConfig, resolveModel } from './config';
-import { buildAnthropicAuth, createLLMClient, parseModelSpec } from './providers';
-import type { LLMClient } from './providers';
+import { buildAnthropicAuth, buildOpenAIAuth, createLLMClient, parseModelSpec } from './providers';
+import type { LLMClient, ProviderAuth, ProviderName } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention, parseCommand, isLLMAccessAllowed } from './interaction';
@@ -40,14 +40,46 @@ import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
+interface ProviderInputs {
+  anthropicOauthToken: string;
+  anthropicApiKey: string;
+  openaiOauthToken: string;
+  openaiApiKey: string;
+}
+
+function buildAuthForProvider(provider: ProviderName, inputs: ProviderInputs): ProviderAuth {
+  switch (provider) {
+    case 'anthropic':
+      return buildAnthropicAuth(inputs.anthropicOauthToken, inputs.anthropicApiKey);
+    case 'openai':
+      return buildOpenAIAuth(inputs.openaiOauthToken, inputs.openaiApiKey);
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unsupported provider: ${exhaustive as string}`);
+    }
+  }
+}
+
+function readProviderInputs(): ProviderInputs {
+  return {
+    anthropicOauthToken: core.getInput('claude_code_oauth_token'),
+    anthropicApiKey: core.getInput('anthropic_api_key'),
+    openaiOauthToken: core.getInput('openai_oauth_token'),
+    openaiApiKey: core.getInput('openai_api_key'),
+  };
+}
+
+function hasAnyProviderCredentials(inputs: ProviderInputs): boolean {
+  return !!(inputs.anthropicOauthToken || inputs.anthropicApiKey || inputs.openaiOauthToken || inputs.openaiApiKey);
+}
+
 function buildLLMClientFromInputs(opts: {
-  oauthToken: string;
-  apiKey: string;
+  inputs: ProviderInputs;
   model: string;
 }): { client: LLMClient } | null {
-  const auth = buildAnthropicAuth(opts.oauthToken, opts.apiKey);
   try {
     const spec = parseModelSpec(opts.model);
+    const auth = buildAuthForProvider(spec.provider, opts.inputs);
     return { client: createLLMClient(spec.provider, spec.model, auth) };
   } catch (error) {
     core.setFailed(`Invalid model config: ${error instanceof Error ? error.message : error}`);
@@ -339,11 +371,10 @@ async function runFullReview(
 ): Promise<void> {
   core.info(`Starting review for ${owner}/${repo}#${prNumber}`);
 
-  const oauthToken = core.getInput('claude_code_oauth_token');
-  const apiKey = core.getInput('anthropic_api_key');
+  const providerInputs = readProviderInputs();
 
-  if (!oauthToken && !apiKey) {
-    core.setFailed('No API key configured — set claude_code_oauth_token or anthropic_api_key');
+  if (!hasAnyProviderCredentials(providerInputs)) {
+    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key');
     return;
   }
 
@@ -387,7 +418,6 @@ async function runFullReview(
       return;
     }
 
-    const anthropicAuth = buildAnthropicAuth(oauthToken, apiKey);
     const plannerModel = resolveModel(config, 'planner');
     const reviewerModel = resolveModel(config, 'reviewer');
     const judgeModel = resolveModel(config, 'judge');
@@ -401,7 +431,8 @@ async function runFullReview(
 
     const buildClient = (model: string) => {
       const spec = parseModelSpec(model);
-      return createLLMClient(spec.provider, spec.model, anthropicAuth);
+      const auth = buildAuthForProvider(spec.provider, providerInputs);
+      return createLLMClient(spec.provider, spec.model, auth);
     };
     let reviewerClient: LLMClient, judgeClient: LLMClient, dedupClient: LLMClient;
     let plannerClient: LLMClient | undefined;
@@ -1101,11 +1132,10 @@ async function handleReviewStateCheck(): Promise<void> {
 
 
 async function handleInteraction(): Promise<void> {
-  const oauthToken = core.getInput('claude_code_oauth_token');
-  const apiKey = core.getInput('anthropic_api_key');
+  const providerInputs = readProviderInputs();
 
-  if (!oauthToken && !apiKey) {
-    core.setFailed('No API key configured — set claude_code_oauth_token or anthropic_api_key');
+  if (!hasAnyProviderCredentials(providerInputs)) {
+    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key');
     return;
   }
 
@@ -1129,7 +1159,7 @@ async function handleInteraction(): Promise<void> {
   }
   const config = loadConfig(configContent ?? undefined);
 
-  const built = buildLLMClientFromInputs({ oauthToken, apiKey, model: resolveModel(config, 'judge') });
+  const built = buildLLMClientFromInputs({ inputs: providerInputs, model: resolveModel(config, 'judge') });
   if (!built) return;
   const { client: claude } = built;
 
@@ -1188,11 +1218,10 @@ async function handleReviewCommentInteraction(): Promise<void> {
     return;
   }
 
-  const oauthToken = core.getInput('claude_code_oauth_token');
-  const apiKey = core.getInput('anthropic_api_key');
+  const providerInputs = readProviderInputs();
 
-  if (!oauthToken && !apiKey) {
-    core.setFailed('No API key configured — set claude_code_oauth_token or anthropic_api_key');
+  if (!hasAnyProviderCredentials(providerInputs)) {
+    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key');
     return;
   }
 
@@ -1210,7 +1239,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
   }
   const config = loadConfig(configContent ?? undefined);
 
-  const built = buildLLMClientFromInputs({ oauthToken, apiKey, model: resolveModel(config, 'judge') });
+  const built = buildLLMClientFromInputs({ inputs: providerInputs, model: resolveModel(config, 'judge') });
   if (!built) return;
   const { client: claude } = built;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1173,12 +1173,12 @@ async function handleInteraction(): Promise<void> {
 
   const built = buildLLMClientFromInputs({ inputs: providerInputs, model: resolveModel(config, 'judge') });
   if (!built) return;
-  const { client: claude } = built;
+  const { client } = built;
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
   const memoryToken = config.memory?.enabled ? getMemoryToken(octokitCache.resolvedToken) ?? undefined : undefined;
 
-  await handlePRComment(octokit, claude, owner, repo, prNumber, memoryConfig, memoryToken, config);
+  await handlePRComment(octokit, client, owner, repo, prNumber, memoryConfig, memoryToken, config);
 }
 
 async function handleIssueInteraction(): Promise<void> {
@@ -1253,7 +1253,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
 
   const built = buildLLMClientFromInputs({ inputs: providerInputs, model: resolveModel(config, 'judge') });
   if (!built) return;
-  const { client: claude } = built;
+  const { client } = built;
 
   const memoryConfig = config.memory?.enabled ? config.memory : undefined;
   const memoryToken = config.memory?.enabled ? getMemoryToken(octokitCache.resolvedToken) ?? undefined : undefined;
@@ -1272,7 +1272,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
       core.warning('Cannot handle reply — pull request number not available');
       return;
     }
-    await handleReviewCommentReply(octokit, claude, owner, repo, prNumber, memoryConfig, memoryToken);
+    await handleReviewCommentReply(octokit, client, owner, repo, prNumber, memoryConfig, memoryToken);
   }
 
   // Check if all review threads are now resolved (e.g. the reply resolved the last conversation)

--- a/src/providers/factory.test.ts
+++ b/src/providers/factory.test.ts
@@ -1,9 +1,11 @@
 import * as AnthropicModule from './anthropic';
 import { AnthropicClient } from './anthropic';
+import { OpenAIClient } from './openai';
 import { createLLMClient } from './factory';
 import { ProviderName } from './types';
 
 jest.mock('@anthropic-ai/sdk');
+jest.mock('openai');
 
 describe('createLLMClient', () => {
   it('returns an AnthropicClient for the anthropic provider', () => {
@@ -41,8 +43,18 @@ describe('createLLMClient', () => {
     expect(client).toBeInstanceOf(AnthropicClient);
   });
 
+  it('returns an OpenAIClient for the openai provider with apiKey auth', () => {
+    const client = createLLMClient('openai', 'gpt-4o', { kind: 'apiKey', key: 'sk-test' });
+    expect(client).toBeInstanceOf(OpenAIClient);
+  });
+
+  it('returns an OpenAIClient for the openai provider with oauth auth', () => {
+    const client = createLLMClient('openai', 'o3', { kind: 'oauth', token: 'tok' });
+    expect(client).toBeInstanceOf(OpenAIClient);
+  });
+
   it('throws on unknown provider', () => {
-    const bogus = 'openai' as unknown as ProviderName;
-    expect(() => createLLMClient(bogus, 'gpt-4o', { kind: 'apiKey', key: 'sk' })).toThrow(/Unsupported provider/);
+    const bogus = 'mistral' as unknown as ProviderName;
+    expect(() => createLLMClient(bogus, 'mistral-large', { kind: 'apiKey', key: 'sk' })).toThrow(/Unsupported provider/);
   });
 });

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,10 +1,13 @@
 import { AnthropicClient } from './anthropic';
+import { OpenAIClient } from './openai';
 import { LLMClient, ProviderAuth, ProviderName } from './types';
 
 export function createLLMClient(provider: ProviderName, model: string, auth: ProviderAuth): LLMClient {
   switch (provider) {
     case 'anthropic':
       return new AnthropicClient({ auth, model });
+    case 'openai':
+      return new OpenAIClient({ auth, model });
     default: {
       const exhaustive: never = provider;
       throw new Error(`Unsupported provider: ${exhaustive as string}`);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,5 @@
 export { buildAnthropicAuth } from './anthropic';
-export { buildOpenAIAuth, isReasoningModel } from './openai';
+export { buildOpenAIAuth } from './openai';
 export { createLLMClient } from './factory';
 export { parseModelSpec } from './model-registry';
 export type { ModelSpec } from './model-registry';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 export { buildAnthropicAuth } from './anthropic';
+export { buildOpenAIAuth, isReasoningModel } from './openai';
 export { createLLMClient } from './factory';
 export { parseModelSpec } from './model-registry';
 export type { ModelSpec } from './model-registry';
@@ -6,6 +7,7 @@ export type {
   AnthropicAuth,
   LLMClient,
   LLMResponse,
+  OpenAIAuth,
   ProviderAuth,
   ProviderName,
   SendMessageOptions,

--- a/src/providers/model-registry.test.ts
+++ b/src/providers/model-registry.test.ts
@@ -13,12 +13,29 @@ describe('parseModelSpec', () => {
     expect(parseModelSpec('anthropic/claude-opus-4-6/v1')).toEqual({ provider: 'anthropic', model: 'claude-opus-4-6/v1' });
   });
 
+  it('parses gpt- prefix as openai', () => {
+    expect(parseModelSpec('gpt-4o')).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    expect(parseModelSpec('gpt-4.1')).toEqual({ provider: 'openai', model: 'gpt-4.1' });
+    expect(parseModelSpec('gpt-4o-mini')).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
+  });
+
+  it('parses o-series (o3/o4) prefix as openai', () => {
+    expect(parseModelSpec('o3')).toEqual({ provider: 'openai', model: 'o3' });
+    expect(parseModelSpec('o3-mini')).toEqual({ provider: 'openai', model: 'o3-mini' });
+    expect(parseModelSpec('o4-mini')).toEqual({ provider: 'openai', model: 'o4-mini' });
+  });
+
+  it('parses openai/model syntax', () => {
+    expect(parseModelSpec('openai/gpt-4o')).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    expect(parseModelSpec('openai/o3')).toEqual({ provider: 'openai', model: 'o3' });
+  });
+
   it('throws on bare model with unknown prefix', () => {
-    expect(() => parseModelSpec('gpt-4o')).toThrow(/Unknown model "gpt-4o"/);
+    expect(() => parseModelSpec('mistral-large')).toThrow(/Unknown model "mistral-large"/);
   });
 
   it('throws on explicit unknown provider', () => {
-    expect(() => parseModelSpec('openai/gpt-4o')).toThrow(/Unknown provider "openai"/);
+    expect(() => parseModelSpec('mistral/mistral-large')).toThrow(/Unknown provider "mistral"/);
   });
 
   it('throws on empty model after slash', () => {

--- a/src/providers/model-registry.ts
+++ b/src/providers/model-registry.ts
@@ -5,16 +5,18 @@ export interface ModelSpec {
   model: string;
 }
 
-const KNOWN_PROVIDERS: ReadonlySet<ProviderName> = new Set<ProviderName>(['anthropic']);
+const KNOWN_PROVIDERS: ReadonlySet<ProviderName> = new Set<ProviderName>(['anthropic', 'openai']);
 
 const KNOWN_PREFIXES: ReadonlyArray<readonly [RegExp, ProviderName]> = [
   [/^claude-/, 'anthropic'],
+  [/^gpt-/i, 'openai'],
+  [/^o\d/i, 'openai'],
 ];
 
 export function parseModelSpec(input: string): ModelSpec {
   input = input.trim();
   if (!input) {
-    throw new Error('Unknown model "". Use a known prefix (e.g., "claude-...") or "provider/model" syntax.');
+    throw new Error('Unknown model "". Use a known prefix (e.g., "claude-...", "gpt-...", "o3...") or "provider/model" syntax.');
   }
   const slash = input.indexOf('/');
   if (slash !== -1) {
@@ -35,5 +37,5 @@ export function parseModelSpec(input: string): ModelSpec {
     }
   }
 
-  throw new Error(`Unknown model "${input}". Use a known prefix (e.g., "claude-...") or "provider/model" syntax.`);
+  throw new Error(`Unknown model "${input}". Use a known prefix (e.g., "claude-...", "gpt-...", "o3...") or "provider/model" syntax.`);
 }

--- a/src/providers/model-registry.ts
+++ b/src/providers/model-registry.ts
@@ -9,8 +9,8 @@ const KNOWN_PROVIDERS: ReadonlySet<ProviderName> = new Set<ProviderName>(['anthr
 
 const KNOWN_PREFIXES: ReadonlyArray<readonly [RegExp, ProviderName]> = [
   [/^claude-/, 'anthropic'],
-  [/^gpt-/i, 'openai'],
-  [/^o\d/i, 'openai'],
+  [/^gpt-/, 'openai'],
+  [/^o\d/, 'openai'],
 ];
 
 export function parseModelSpec(input: string): ModelSpec {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -7,7 +7,7 @@ import {
   isReasoningModel,
   OpenAIClient,
   resetCLIInstallPromise,
-  resolveCLIEffort,
+  resolveEffortTier,
   sanitizeLogOutput,
   STALE_TIMEOUT_MS,
 } from './openai';
@@ -364,19 +364,19 @@ describe('sanitizeLogOutput', () => {
   });
 });
 
-describe('resolveCLIEffort', () => {
+describe('resolveEffortTier', () => {
   it('passes through low/medium/high unchanged', () => {
-    expect(resolveCLIEffort('low')).toBe('low');
-    expect(resolveCLIEffort('medium')).toBe('medium');
-    expect(resolveCLIEffort('high')).toBe('high');
+    expect(resolveEffortTier('low')).toBe('low');
+    expect(resolveEffortTier('medium')).toBe('medium');
+    expect(resolveEffortTier('high')).toBe('high');
   });
 
   it('collapses max to high', () => {
-    expect(resolveCLIEffort('max')).toBe('high');
+    expect(resolveEffortTier('max')).toBe('high');
   });
 
   it('falls back to high for unknown inputs', () => {
-    expect(resolveCLIEffort('extreme')).toBe('high');
+    expect(resolveEffortTier('extreme')).toBe('high');
   });
 });
 

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -628,6 +628,13 @@ describe('ensureCLI auto-install', () => {
 
     const spawnPath = mockSpawn.mock.calls[0][0];
     expect(spawnPath).toBe('/usr/local/bin/codex');
+
+    // Pinning + `--ignore-scripts` are the supply-chain hardening for the auto-install path.
+    const npmCall = mockExecFileAsync.mock.calls.find((c) => c[0] === 'npm');
+    expect(npmCall).toBeDefined();
+    const npmArgs = npmCall![1] as string[];
+    expect(npmArgs).toContain('--ignore-scripts');
+    expect(npmArgs.some((a) => /^@openai\/codex@\d+\.\d+\.\d+/.test(a))).toBe(true);
   });
 
   it('rejects when npm install succeeds but codex still cannot be located', async () => {
@@ -638,6 +645,29 @@ describe('ensureCLI auto-install', () => {
 
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
     await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Failed to locate Codex CLI on PATH');
+  });
+
+  it('deduplicates concurrent installs so npm install runs once for parallel callers', async () => {
+    let resolveInstall!: () => void;
+    const installBarrier = new Promise<void>((r) => { resolveInstall = r; });
+
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found')) // which codex — client A
+      .mockRejectedValueOnce(new Error('not found')) // which codex — client B
+      .mockImplementationOnce(() => installBarrier.then(() => ({ stdout: '' }))) // npm install (shared)
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/codex\n' }); // post-install which
+    setupSpawnSuccess();
+
+    const clientA = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const clientB = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+
+    const p1 = clientA.sendMessage('s', 'u');
+    const p2 = clientB.sendMessage('s', 'u');
+    resolveInstall();
+    await Promise.all([p1, p2]);
+
+    const npmCalls = mockExecFileAsync.mock.calls.filter((c) => c[0] === 'npm');
+    expect(npmCalls).toHaveLength(1);
   });
 
   it('clears the cached install promise on failure so retries can succeed', async () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -555,7 +555,7 @@ describe('sendViaOAuth — extended coverage', () => {
     await promise;
   });
 
-  it('preserves last 500 bytes of stdout for diagnostic snippets', async () => {
+  it('accumulates multi-chunk stdout and returns trimmed content on success', async () => {
     const wiring = makeProc();
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
     const promise = client.sendMessage('sys', 'user');
@@ -568,6 +568,25 @@ describe('sendViaOAuth — extended coverage', () => {
     wiring.procHandlers['close']?.(0, null);
     const result = await promise;
     expect(result.content).toContain('A');
+  });
+
+  it('includes last 500 bytes of stdout in stale error message', async () => {
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask', 'nextTick'] });
+    try {
+      const wiring = makeProc();
+      const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+      const promise = client.sendMessage('sys', 'user');
+      promise.catch(() => {});
+
+      await waitForListeners(wiring);
+      wiring.stdoutHandlers['data']?.(Buffer.from('UNIQUE_DIAGNOSTIC_MARKER'));
+      jest.advanceTimersByTime(STALE_TIMEOUT_MS + 100);
+      wiring.procHandlers['close']?.(null, 'SIGTERM');
+
+      await expect(promise).rejects.toThrow(/UNIQUE_DIAGNOSTIC_MARKER/);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -390,6 +390,7 @@ describe('sendViaOAuth — extended coverage', () => {
     proc: MockProc;
     procHandlers: Record<string, (...a: unknown[]) => void>;
     stdoutHandlers: Record<string, (data: Buffer) => void>;
+    stderrHandlers: Record<string, (data: Buffer) => void>;
     stdinHandlers: Record<string, (...a: unknown[]) => void>;
   }
 
@@ -425,7 +426,7 @@ describe('sendViaOAuth — extended coverage', () => {
       kill: jest.fn(),
     };
     mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
-    return { proc, procHandlers, stdoutHandlers, stdinHandlers };
+    return { proc, procHandlers, stdoutHandlers, stderrHandlers, stdinHandlers };
   }
 
   // Wait for the OpenAIClient to finish ensureCLI() and wire up its listeners on the mock proc.

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -579,7 +579,7 @@ describe('ensureCLI auto-install', () => {
       .mockRejectedValueOnce(new Error('still not found'));
 
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
-    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Failed to install Codex CLI');
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Failed to locate Codex CLI on PATH');
   });
 
   it('clears the cached install promise on failure so retries can succeed', async () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -194,6 +194,8 @@ describe('sendViaOAuth (Codex CLI path)', () => {
   beforeEach(() => {
     mockSpawn.mockReset();
     resetCLIInstallPromise();
+    mockExecFileAsync.mockReset();
+    mockExecFileAsync.mockResolvedValue({ stdout: '/usr/bin/codex' });
   });
 
   function setupSpawnMock(stdout: string, opts: { exitCode?: number; stderr?: string } = {}): void {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -698,8 +698,10 @@ describe('ensureCLI auto-install', () => {
     const p1 = clientA.sendMessage('s', 'u');
     const p2 = clientB.sendMessage('s', 'u');
     resolveInstall();
-    await Promise.all([p1, p2]);
+    const [r1, r2] = await Promise.all([p1, p2]);
 
+    expect(r1.content).toBe('ok');
+    expect(r2.content).toBe('ok');
     const npmCalls = mockExecFileAsync.mock.calls.filter((c) => c[0] === 'npm');
     expect(npmCalls).toHaveLength(1);
   });

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -246,7 +246,7 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
     const overrideIdx = spawnArgs.findIndex(a => a.startsWith('model_reasoning_effort'));
     expect(overrideIdx).toBeGreaterThan(-1);
-    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort="high"');
+    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort=high');
   });
 
   it('warns and skips reasoning override on non-reasoning models', async () => {
@@ -276,7 +276,7 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     expect(spawnOpts.env.OPENAI_API_KEY).not.toBe('my-tok');
   });
 
-  it('maps max effort to model_reasoning_effort="high" on o-series CLI invocation', async () => {
+  it('maps max effort to model_reasoning_effort=high on o-series CLI invocation', async () => {
     setupSpawnMock('ok\n');
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o4-mini' });
 
@@ -284,7 +284,7 @@ describe('sendViaOAuth (Codex CLI path)', () => {
 
     const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
     const overrideIdx = spawnArgs.findIndex(a => a.startsWith('model_reasoning_effort'));
-    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort="high"');
+    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort=high');
   });
 
   it('returns trimmed stdout content on success', async () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -2,7 +2,15 @@ import { spawn } from 'child_process';
 import OpenAI from 'openai';
 import * as core from '@actions/core';
 
-import { buildOpenAIAuth, isReasoningModel, OpenAIClient, resetCLIInstallPromise } from './openai';
+import {
+  buildOpenAIAuth,
+  isReasoningModel,
+  OpenAIClient,
+  resetCLIInstallPromise,
+  resolveCLIEffort,
+  sanitizeLogOutput,
+  STALE_TIMEOUT_MS,
+} from './openai';
 
 jest.mock('child_process', () => ({
   execFile: jest.fn(),
@@ -254,7 +262,7 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     warnSpy.mockRestore();
   });
 
-  it('sets CODEX_OAUTH_TOKEN in spawn env', async () => {
+  it('sets CODEX_OAUTH_TOKEN and OPENAI_OAUTH_TOKEN in spawn env', async () => {
     setupSpawnMock('ok\n');
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'my-tok' }, model: 'gpt-4o' });
 
@@ -262,6 +270,21 @@ describe('sendViaOAuth (Codex CLI path)', () => {
 
     const spawnOpts = mockSpawn.mock.calls[0][2] as { env: Record<string, string> };
     expect(spawnOpts.env.CODEX_OAUTH_TOKEN).toBe('my-tok');
+    expect(spawnOpts.env.OPENAI_OAUTH_TOKEN).toBe('my-tok');
+    // Aliasing an OAuth subscription token as OPENAI_API_KEY would cause
+    // credential type confusion inside the CLI's bundled OpenAI SDK.
+    expect(spawnOpts.env.OPENAI_API_KEY).not.toBe('my-tok');
+  });
+
+  it('maps max effort to model_reasoning_effort="high" on o-series CLI invocation', async () => {
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o4-mini' });
+
+    await client.sendMessage('sys', 'user', { effort: 'max' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    const overrideIdx = spawnArgs.findIndex(a => a.startsWith('model_reasoning_effort'));
+    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort="high"');
   });
 
   it('returns trimmed stdout content on success', async () => {
@@ -296,5 +319,278 @@ describe('sendViaOAuth (Codex CLI path)', () => {
 
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
     await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Codex CLI spawn failed: ENOENT');
+  });
+});
+
+describe('sanitizeLogOutput', () => {
+  it('redacts workflow commands', () => {
+    expect(sanitizeLogOutput('::set-env name=X::val')).toBe('[redacted-workflow-cmd]');
+    expect(sanitizeLogOutput('::add-mask::secret')).toBe('[redacted-workflow-cmd]');
+    expect(sanitizeLogOutput('::error file=foo.ts,line=5::message')).toBe('[redacted-workflow-cmd]');
+  });
+
+  it('does not touch regular text', () => {
+    expect(sanitizeLogOutput('hello world')).toBe('hello world');
+    expect(sanitizeLogOutput('A line :: with double colons mid-text')).toBe('A line :: with double colons mid-text');
+  });
+
+  it('redacts per line in multiline input', () => {
+    const input = 'safe line\n::set-env name=X::val\nother safe';
+    expect(sanitizeLogOutput(input)).toBe('safe line\n[redacted-workflow-cmd]\nother safe');
+  });
+
+  it('redacts case-insensitively', () => {
+    expect(sanitizeLogOutput('::SET-ENV name=X::val')).toBe('[redacted-workflow-cmd]');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(sanitizeLogOutput('')).toBe('');
+  });
+});
+
+describe('resolveCLIEffort', () => {
+  it('passes through low/medium/high unchanged', () => {
+    expect(resolveCLIEffort('low')).toBe('low');
+    expect(resolveCLIEffort('medium')).toBe('medium');
+    expect(resolveCLIEffort('high')).toBe('high');
+  });
+
+  it('collapses max to high', () => {
+    expect(resolveCLIEffort('max')).toBe('high');
+  });
+
+  it('falls back to high for unknown inputs', () => {
+    expect(resolveCLIEffort('extreme')).toBe('high');
+  });
+});
+
+describe('sendViaOAuth — extended coverage', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    resetCLIInstallPromise();
+    mockExecFileAsync.mockReset();
+    mockExecFileAsync.mockResolvedValue({ stdout: '/usr/bin/codex' });
+  });
+
+  interface MockProc {
+    stdin: { write: jest.Mock; end: jest.Mock; on: jest.Mock; once: jest.Mock };
+    stdout: { on: jest.Mock };
+    stderr: { on: jest.Mock };
+    on: jest.Mock;
+    kill: jest.Mock;
+  }
+  interface MockProcWiring {
+    proc: MockProc;
+    procHandlers: Record<string, (...a: unknown[]) => void>;
+    stdoutHandlers: Record<string, (data: Buffer) => void>;
+    stdinHandlers: Record<string, (...a: unknown[]) => void>;
+  }
+
+  function makeProc(): MockProcWiring {
+    const procHandlers: Record<string, (...a: unknown[]) => void> = {};
+    const stdoutHandlers: Record<string, (data: Buffer) => void> = {};
+    const stderrHandlers: Record<string, (data: Buffer) => void> = {};
+    const stdinHandlers: Record<string, (...a: unknown[]) => void> = {};
+    const proc: MockProc = {
+      stdin: {
+        write: jest.fn().mockReturnValue(true),
+        end: jest.fn(),
+        on: jest.fn().mockImplementation((event: string, cb: (...a: unknown[]) => void) => {
+          stdinHandlers[event] = cb;
+        }),
+        once: jest.fn().mockImplementation((event: string, cb: (...a: unknown[]) => void) => {
+          stdinHandlers[event] = cb;
+        }),
+      },
+      stdout: {
+        on: jest.fn().mockImplementation((event: string, cb: (data: Buffer) => void) => {
+          stdoutHandlers[event] = cb;
+        }),
+      },
+      stderr: {
+        on: jest.fn().mockImplementation((event: string, cb: (data: Buffer) => void) => {
+          stderrHandlers[event] = cb;
+        }),
+      },
+      on: jest.fn().mockImplementation((event: string, cb: (...a: unknown[]) => void) => {
+        procHandlers[event] = cb;
+      }),
+      kill: jest.fn(),
+    };
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+    return { proc, procHandlers, stdoutHandlers, stdinHandlers };
+  }
+
+  // Wait for the OpenAIClient to finish ensureCLI() and wire up its listeners on the mock proc.
+  // Uses setImmediate so it stays alive when fake timers are active (callers keep setImmediate real).
+  async function waitForListeners(wiring: MockProcWiring): Promise<void> {
+    for (let i = 0; i < 50; i++) {
+      if (wiring.procHandlers['close']) return;
+      await new Promise(r => setImmediate(r));
+    }
+    throw new Error('Listeners were never wired up');
+  }
+
+  it('rejects with stale error when no stdout for STALE_TIMEOUT_MS', async () => {
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask', 'nextTick'] });
+    try {
+      const wiring = makeProc();
+      const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+      const promise = client.sendMessage('sys', 'user');
+      promise.catch(() => {});
+
+      await waitForListeners(wiring);
+      jest.advanceTimersByTime(STALE_TIMEOUT_MS + 100);
+      wiring.procHandlers['close']?.(null, 'SIGTERM');
+
+      await expect(promise).rejects.toThrow(/stale/);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('rejects when output exceeds the 50 MB cap', async () => {
+    const wiring = makeProc();
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const promise = client.sendMessage('sys', 'user');
+    promise.catch(() => {});
+
+    await waitForListeners(wiring);
+    const chunk = Buffer.alloc(30 * 1024 * 1024, 0x61);
+    wiring.stdoutHandlers['data']?.(chunk);
+    wiring.stdoutHandlers['data']?.(chunk);
+    wiring.procHandlers['close']?.(null, 'SIGTERM');
+
+    await expect(promise).rejects.toThrow(/exceeded 50MB/);
+  });
+
+  it('warns and continues on stdin error event', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const wiring = makeProc();
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const promise = client.sendMessage('sys', 'user');
+    promise.catch(() => {});
+
+    await waitForListeners(wiring);
+    wiring.stdinHandlers['error']?.(new Error('EPIPE'));
+    wiring.procHandlers['close']?.(0, null);
+
+    await promise;
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('stdin write error'));
+    warnSpy.mockRestore();
+  });
+
+  it('rejects when stdin.write throws synchronously', async () => {
+    const wiring = makeProc();
+    wiring.proc.stdin.write.mockImplementation(() => { throw new Error('EBADF'); });
+
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const promise = client.sendMessage('sys', 'user');
+
+    await expect(promise).rejects.toThrow(/stdin write failed: EBADF/);
+    // close still arriving must be tolerated as a no-op
+    wiring.procHandlers['close']?.(0, null);
+  });
+
+  it('waits for drain before ending stdin when write returns false', async () => {
+    const wiring = makeProc();
+    wiring.proc.stdin.write.mockReturnValueOnce(false);
+
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const promise = client.sendMessage('sys', 'user');
+    promise.catch(() => {});
+
+    await waitForListeners(wiring);
+    expect(wiring.proc.stdin.end).not.toHaveBeenCalled();
+    wiring.stdinHandlers['drain']?.();
+    expect(wiring.proc.stdin.end).toHaveBeenCalled();
+
+    wiring.procHandlers['close']?.(0, null);
+    await promise;
+  });
+
+  it('preserves last 500 bytes of stdout for diagnostic snippets', async () => {
+    const wiring = makeProc();
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const promise = client.sendMessage('sys', 'user');
+    promise.catch(() => {});
+
+    await waitForListeners(wiring);
+    // Small chunk exercises the < 500 branch; large chunk exercises the >= 500 branch.
+    wiring.stdoutHandlers['data']?.(Buffer.from('short '));
+    wiring.stdoutHandlers['data']?.(Buffer.from('A'.repeat(600)));
+    wiring.procHandlers['close']?.(0, null);
+    const result = await promise;
+    expect(result.content).toContain('A');
+  });
+});
+
+describe('ensureCLI auto-install', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    resetCLIInstallPromise();
+    mockExecFileAsync.mockReset();
+  });
+
+  function setupSpawnSuccess(): void {
+    const proc = {
+      stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn(), once: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data') setTimeout(() => cb(Buffer.from('ok\n')), 0);
+    });
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation((event: string, cb: (...a: unknown[]) => void) => {
+      if (event === 'close') setTimeout(() => cb(0, null), 5);
+    });
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+  }
+
+  it('installs codex CLI via npm when not found, then caches the path', async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found')) // initial `which codex`
+      .mockResolvedValueOnce({ stdout: '' }) // npm install -g
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/codex\n' }); // post-install `which`
+    setupSpawnSuccess();
+
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    const result = await client.sendMessage('sys', 'user');
+    expect(result.content).toBe('ok');
+
+    const spawnPath = mockSpawn.mock.calls[0][0];
+    expect(spawnPath).toBe('/usr/local/bin/codex');
+  });
+
+  it('rejects when npm install succeeds but codex still cannot be located', async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockRejectedValueOnce(new Error('still not found'));
+
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Failed to install Codex CLI');
+  });
+
+  it('clears the cached install promise on failure so retries can succeed', async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error('npm fail'));
+
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow();
+
+    // Second call: install path now succeeds → must not re-use the cached failed promise
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/codex\n' });
+    setupSpawnSuccess();
+
+    const result = await client.sendMessage('sys', 'user');
+    expect(result.content).toBe('ok');
   });
 });

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -273,16 +273,20 @@ describe('sendViaOAuth (Codex CLI path)', () => {
 
   it('sets CODEX_OAUTH_TOKEN and OPENAI_OAUTH_TOKEN in spawn env', async () => {
     setupSpawnMock('ok\n');
-    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'my-tok' }, model: 'gpt-4o' });
+    const savedKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
 
-    await client.sendMessage('sys', 'user');
+    try {
+      const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'my-tok' }, model: 'gpt-4o' });
+      await client.sendMessage('sys', 'user');
 
-    const spawnOpts = mockSpawn.mock.calls[0][2] as { env: Record<string, string> };
-    expect(spawnOpts.env.CODEX_OAUTH_TOKEN).toBe('my-tok');
-    expect(spawnOpts.env.OPENAI_OAUTH_TOKEN).toBe('my-tok');
-    // Aliasing an OAuth subscription token as OPENAI_API_KEY would cause
-    // credential type confusion inside the CLI's bundled OpenAI SDK.
-    expect(spawnOpts.env.OPENAI_API_KEY).not.toBe('my-tok');
+      const spawnOpts = mockSpawn.mock.calls[0][2] as { env: Record<string, string> };
+      expect(spawnOpts.env.CODEX_OAUTH_TOKEN).toBe('my-tok');
+      expect(spawnOpts.env.OPENAI_OAUTH_TOKEN).toBe('my-tok');
+      expect(spawnOpts.env.OPENAI_API_KEY).toBeUndefined();
+    } finally {
+      if (savedKey !== undefined) process.env.OPENAI_API_KEY = savedKey;
+    }
   });
 
   it('maps low effort to model_reasoning_effort=low on o-series CLI invocation', async () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -399,9 +399,6 @@ describe('resolveEffortTier', () => {
     expect(resolveEffortTier('max')).toBe('high');
   });
 
-  it('falls back to high for unknown inputs', () => {
-    expect(resolveEffortTier('extreme')).toBe('high');
-  });
 });
 
 describe('sendViaOAuth — extended coverage', () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -285,6 +285,30 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     expect(spawnOpts.env.OPENAI_API_KEY).not.toBe('my-tok');
   });
 
+  it('maps low effort to model_reasoning_effort=low on o-series CLI invocation', async () => {
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o3' });
+
+    await client.sendMessage('sys', 'user', { effort: 'low' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    const overrideIdx = spawnArgs.findIndex(a => a.startsWith('model_reasoning_effort'));
+    expect(overrideIdx).toBeGreaterThan(-1);
+    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort=low');
+  });
+
+  it('maps medium effort to model_reasoning_effort=medium on o-series CLI invocation', async () => {
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o3' });
+
+    await client.sendMessage('sys', 'user', { effort: 'medium' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    const overrideIdx = spawnArgs.findIndex(a => a.startsWith('model_reasoning_effort'));
+    expect(overrideIdx).toBeGreaterThan(-1);
+    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort=medium');
+  });
+
   it('maps max effort to model_reasoning_effort=high on o-series CLI invocation', async () => {
     setupSpawnMock('ok\n');
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o4-mini' });
@@ -508,6 +532,7 @@ describe('sendViaOAuth — extended coverage', () => {
     wiring.procHandlers['close']?.(null, 'SIGTERM');
 
     await expect(promise).rejects.toThrow(/exceeded 50MB/);
+    expect(wiring.proc.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
   it('warns and continues on stdin error event', async () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -178,6 +178,14 @@ describe('sendMessage (API path)', () => {
     expect(result.content).toBe('');
   });
 
+  it('returns empty string when choices array is empty', async () => {
+    mockCreate.mockResolvedValueOnce({ choices: [] });
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+
+    const result = await client.sendMessage('sys', 'user');
+    expect(result.content).toBe('');
+  });
+
   it('throws when client is not initialized (oauth path called via API method)', async () => {
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
 

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -188,6 +188,13 @@ describe('sendMessage (API path)', () => {
 
     await expect(sendViaAPI.call(client, 'sys', 'user')).rejects.toThrow('OpenAI client not initialized');
   });
+
+  it('propagates SDK errors from chat.completions.create to the caller', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('rate limited'));
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('rate limited');
+  });
 });
 
 describe('sendViaOAuth (Codex CLI path)', () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -466,6 +466,35 @@ describe('sendViaOAuth — extended coverage', () => {
     }
   });
 
+  it('rejects with hard timeout error after 1200s even with periodic stdout', async () => {
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask', 'nextTick'] });
+    try {
+      const wiring = makeProc();
+      const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+      const promise = client.sendMessage('sys', 'user');
+      promise.catch(() => {});
+
+      await waitForListeners(wiring);
+      // Emit stdout periodically so the stale timer keeps resetting; only the hard
+      // 1200s deadline should fire. Step strictly shorter than STALE_TIMEOUT_MS, with
+      // a final stdout chunk after the loop so stale always has > step time remaining.
+      const step = STALE_TIMEOUT_MS - 10_000;
+      let elapsed = 0;
+      while (elapsed + step < 1_200_000) {
+        wiring.stdoutHandlers['data']?.(Buffer.from('partial'));
+        jest.advanceTimersByTime(step);
+        elapsed += step;
+      }
+      wiring.stdoutHandlers['data']?.(Buffer.from('partial'));
+      jest.advanceTimersByTime(1_200_000 - elapsed + 100);
+      wiring.procHandlers['close']?.(null, 'SIGTERM');
+
+      await expect(promise).rejects.toThrow(/timed out after 1200s/);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('rejects when output exceeds the 50 MB cap', async () => {
     const wiring = makeProc();
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -334,6 +334,13 @@ describe('sanitizeLogOutput', () => {
     expect(sanitizeLogOutput('A line :: with double colons mid-text')).toBe('A line :: with double colons mid-text');
   });
 
+  it('does not redact `::identifier` patterns mid-line', () => {
+    // `^` anchor (with multiline flag) ensures `std::io::Error` and similar
+    // namespace syntax in code output is preserved.
+    expect(sanitizeLogOutput('error: std::io::Error at module::path')).toBe('error: std::io::Error at module::path');
+    expect(sanitizeLogOutput('caller foo::bar::baz failed')).toBe('caller foo::bar::baz failed');
+  });
+
   it('redacts per line in multiline input', () => {
     const input = 'safe line\n::set-env name=X::val\nother safe';
     expect(sanitizeLogOutput(input)).toBe('safe line\n[redacted-workflow-cmd]\nother safe');

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -1,0 +1,300 @@
+import { spawn } from 'child_process';
+import OpenAI from 'openai';
+import * as core from '@actions/core';
+
+import { buildOpenAIAuth, isReasoningModel, OpenAIClient, resetCLIInstallPromise } from './openai';
+
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+  spawn: jest.fn(),
+}));
+
+jest.mock('openai');
+
+// Container for the execFileAsync mock — must be a plain object so the
+// hoisted jest.mock factory can capture a reference before const initialization.
+const _execMock = { fn: null as jest.Mock | null };
+jest.mock('util', () => ({
+  ...jest.requireActual('util'),
+  promisify: () => (...args: unknown[]) => _execMock.fn!(...args),
+}));
+
+const mockExecFileAsync = jest.fn().mockResolvedValue({ stdout: '/usr/bin/codex' });
+_execMock.fn = mockExecFileAsync;
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+describe('buildOpenAIAuth', () => {
+  it('throws when neither token is present', () => {
+    expect(() => buildOpenAIAuth('', '')).toThrow(
+      'Either openai_oauth_token or openai_api_key must be provided',
+    );
+  });
+
+  it('returns oauth kind when only oauth token is present', () => {
+    expect(buildOpenAIAuth('oauth-tok', '')).toEqual({ kind: 'oauth', token: 'oauth-tok' });
+  });
+
+  it('returns apiKey kind when only api key is present', () => {
+    expect(buildOpenAIAuth('', 'sk-key')).toEqual({ kind: 'apiKey', key: 'sk-key' });
+  });
+
+  it('oauth wins when both tokens are present', () => {
+    expect(buildOpenAIAuth('oauth-tok', 'sk-key')).toEqual({ kind: 'oauth', token: 'oauth-tok' });
+  });
+});
+
+describe('isReasoningModel', () => {
+  it('detects o-series models', () => {
+    expect(isReasoningModel('o1')).toBe(true);
+    expect(isReasoningModel('o3')).toBe(true);
+    expect(isReasoningModel('o3-mini')).toBe(true);
+    expect(isReasoningModel('o4-mini')).toBe(true);
+  });
+
+  it('rejects gpt-family models', () => {
+    expect(isReasoningModel('gpt-4o')).toBe(false);
+    expect(isReasoningModel('gpt-4.1')).toBe(false);
+    expect(isReasoningModel('gpt-4o-mini')).toBe(false);
+  });
+
+  it('rejects unrelated names', () => {
+    expect(isReasoningModel('claude-opus-4-6')).toBe(false);
+    expect(isReasoningModel('overlord')).toBe(false);
+  });
+});
+
+describe('OpenAIClient', () => {
+  it('accepts oauth auth', () => {
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    expect(client).toBeDefined();
+  });
+
+  it('accepts apiKey auth', () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk-key' }, model: 'gpt-4o' });
+    expect(client).toBeDefined();
+  });
+});
+
+describe('sendMessage (API path)', () => {
+  let mockCreate: jest.Mock;
+
+  beforeEach(() => {
+    mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: 'response text' } }],
+    });
+    (OpenAI as unknown as jest.Mock).mockImplementation(() => ({
+      chat: { completions: { create: mockCreate } },
+    }));
+  });
+
+  it('sends model, system message, and user message in chat completions request', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+    await client.sendMessage('sys-prompt', 'user-msg');
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.model).toBe('gpt-4o');
+    expect(params.messages).toEqual([
+      { role: 'system', content: 'sys-prompt' },
+      { role: 'user', content: 'user-msg' },
+    ]);
+  });
+
+  it('omits reasoning_effort for non-reasoning models', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+    await client.sendMessage('sys', 'user');
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.reasoning_effort).toBeUndefined();
+  });
+
+  it('warns and ignores effort on non-reasoning models', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+
+    await client.sendMessage('sys', 'user', { effort: 'high' });
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.reasoning_effort).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
+    warnSpy.mockRestore();
+  });
+
+  it('maps low effort to reasoning_effort=low for o3', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'o3' });
+    await client.sendMessage('sys', 'user', { effort: 'low' });
+
+    expect(mockCreate.mock.calls[0][0].reasoning_effort).toBe('low');
+  });
+
+  it('maps medium effort to reasoning_effort=medium for o3', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'o3' });
+    await client.sendMessage('sys', 'user', { effort: 'medium' });
+
+    expect(mockCreate.mock.calls[0][0].reasoning_effort).toBe('medium');
+  });
+
+  it('maps high effort to reasoning_effort=high for o3', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'o3' });
+    await client.sendMessage('sys', 'user', { effort: 'high' });
+
+    expect(mockCreate.mock.calls[0][0].reasoning_effort).toBe('high');
+  });
+
+  it('maps max effort to reasoning_effort=high (the highest tier the API exposes)', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'o4-mini' });
+    await client.sendMessage('sys', 'user', { effort: 'max' });
+
+    expect(mockCreate.mock.calls[0][0].reasoning_effort).toBe('high');
+  });
+
+  it('omits reasoning_effort when no effort is provided on a reasoning model', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'o3' });
+    await client.sendMessage('sys', 'user');
+
+    expect(mockCreate.mock.calls[0][0].reasoning_effort).toBeUndefined();
+  });
+
+  it('returns the assistant content from the first choice', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+    const result = await client.sendMessage('sys', 'user');
+
+    expect(result.content).toBe('response text');
+  });
+
+  it('returns empty string when the response has no content', async () => {
+    mockCreate.mockResolvedValueOnce({ choices: [{ message: {} }] });
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+
+    const result = await client.sendMessage('sys', 'user');
+    expect(result.content).toBe('');
+  });
+
+  it('throws when client is not initialized (oauth path called via API method)', async () => {
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+
+    const sendViaAPI = (OpenAIClient.prototype as unknown as Record<string, unknown>)['sendViaAPI'] as (
+      systemPrompt: string,
+      userMessage: string,
+    ) => Promise<unknown>;
+
+    await expect(sendViaAPI.call(client, 'sys', 'user')).rejects.toThrow('OpenAI client not initialized');
+  });
+});
+
+describe('sendViaOAuth (Codex CLI path)', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    resetCLIInstallPromise();
+  });
+
+  function setupSpawnMock(stdout: string, opts: { exitCode?: number; stderr?: string } = {}): void {
+    const proc = {
+      stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+
+    proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data' && stdout) {
+        setTimeout(() => cb(Buffer.from(stdout)), 0);
+      }
+    });
+    proc.stderr.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data' && opts.stderr) {
+        setTimeout(() => cb(Buffer.from(opts.stderr!)), 0);
+      }
+    });
+    proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+      if (event === 'close') {
+        setTimeout(() => cb(opts.exitCode ?? 0, null), 5);
+      }
+    });
+
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+  }
+
+  it('passes --model and exec subcommand to codex CLI', async () => {
+    setupSpawnMock('hello\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o3' });
+
+    await client.sendMessage('sys', 'user');
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs[0]).toBe('exec');
+    const modelIdx = spawnArgs.indexOf('--model');
+    expect(modelIdx).toBeGreaterThan(-1);
+    expect(spawnArgs[modelIdx + 1]).toBe('o3');
+  });
+
+  it('passes model_reasoning_effort override when effort is set on o-series model', async () => {
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o3' });
+
+    await client.sendMessage('sys', 'user', { effort: 'high' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    const overrideIdx = spawnArgs.findIndex(a => a.startsWith('model_reasoning_effort'));
+    expect(overrideIdx).toBeGreaterThan(-1);
+    expect(spawnArgs[overrideIdx]).toBe('model_reasoning_effort="high"');
+  });
+
+  it('warns and skips reasoning override on non-reasoning models', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+
+    await client.sendMessage('sys', 'user', { effort: 'high' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs.find(a => a.startsWith('model_reasoning_effort'))).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
+    warnSpy.mockRestore();
+  });
+
+  it('sets CODEX_OAUTH_TOKEN in spawn env', async () => {
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'my-tok' }, model: 'gpt-4o' });
+
+    await client.sendMessage('sys', 'user');
+
+    const spawnOpts = mockSpawn.mock.calls[0][2] as { env: Record<string, string> };
+    expect(spawnOpts.env.CODEX_OAUTH_TOKEN).toBe('my-tok');
+  });
+
+  it('returns trimmed stdout content on success', async () => {
+    setupSpawnMock('  hello world  \n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+
+    const result = await client.sendMessage('sys', 'user');
+    expect(result.content).toBe('hello world');
+  });
+
+  it('rejects on non-zero exit code', async () => {
+    setupSpawnMock('', { exitCode: 1, stderr: 'something broke' });
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Codex CLI invocation failed');
+  });
+
+  it('rejects on spawn error', async () => {
+    const proc = {
+      stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    proc.stdout.on.mockImplementation(() => {});
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+      if (event === 'error') setTimeout(() => cb(new Error('ENOENT')), 0);
+    });
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Codex CLI spawn failed: ENOENT');
+  });
+});

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,0 +1,323 @@
+import { execFile, spawn } from 'child_process';
+import { StringDecoder } from 'string_decoder';
+import { promisify } from 'util';
+
+import OpenAI from 'openai';
+import * as core from '@actions/core';
+
+import { LLMClient, LLMResponse, OpenAIAuth, SendMessageOptions } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export const STALE_TIMEOUT_MS = 90_000;
+
+export function buildOpenAIAuth(oauthToken: string, apiKey: string): OpenAIAuth {
+  if (oauthToken) return { kind: 'oauth', token: oauthToken };
+  if (apiKey) return { kind: 'apiKey', key: apiKey };
+  throw new Error('Either openai_oauth_token or openai_api_key must be provided');
+}
+
+/** Strip GitHub Actions workflow commands to prevent injection when logging CLI output. */
+export function sanitizeLogOutput(text: string): string {
+  return text.replace(/::[a-z].*$/gim, '[redacted-workflow-cmd]');
+}
+
+/**
+ * o-series reasoning models (o1, o3, o4, ...) accept the `reasoning_effort`
+ * parameter on the chat completions API; GPT-family models (gpt-4o, gpt-4.1,
+ * gpt-5, ...) do not and will reject the field.
+ */
+export function isReasoningModel(model: string): boolean {
+  return /^o\d/i.test(model);
+}
+
+/** Build diagnostic snippets for timeout/stale error messages. */
+function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: string): string {
+  const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
+  const stderrSnippet = sanitizeLogOutput(stderrText.slice(0, 500));
+  const parts: string[] = [];
+  if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
+  if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
+  return parts.join('. ');
+}
+
+let cliInstallPromise: Promise<string> | null = null;
+
+export function resetCLIInstallPromise(): void {
+  cliInstallPromise = null;
+}
+
+export interface OpenAIClientOptions {
+  auth: OpenAIAuth;
+  model: string;
+}
+
+export class OpenAIClient implements LLMClient {
+  private readonly auth: OpenAIAuth;
+  private openai?: OpenAI;
+  private readonly model: string;
+  private cachedCLIPath?: string;
+
+  constructor(options: OpenAIClientOptions) {
+    this.auth = options.auth;
+    this.model = options.model;
+
+    if (this.auth.kind === 'apiKey') {
+      this.openai = new OpenAI({ apiKey: this.auth.key });
+    }
+  }
+
+  async sendMessage(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
+    if (this.auth.kind === 'oauth') {
+      return this.sendViaOAuth(systemPrompt, userMessage, options);
+    }
+    return this.sendViaAPI(systemPrompt, userMessage, options);
+  }
+
+  private async ensureCLI(): Promise<string> {
+    if (this.cachedCLIPath) {
+      return this.cachedCLIPath;
+    }
+
+    try {
+      const { stdout } = await execFileAsync('which', ['codex']);
+      this.cachedCLIPath = stdout.trim();
+      return this.cachedCLIPath;
+    } catch {
+      if (!cliInstallPromise) {
+        cliInstallPromise = (async () => {
+          core.info('Codex CLI not found, installing via npm...');
+          await execFileAsync('npm', ['install', '-g', '@openai/codex'], {
+            timeout: 120000,
+          });
+          try {
+            const { stdout } = await execFileAsync('which', ['codex']);
+            return stdout.trim();
+          } catch {
+            throw new Error('Failed to install Codex CLI');
+          }
+        })();
+      }
+      try {
+        this.cachedCLIPath = await cliInstallPromise;
+        return this.cachedCLIPath;
+      } catch (error) {
+        cliInstallPromise = null;
+        throw error;
+      }
+    }
+  }
+
+  private async sendViaOAuth(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
+    const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
+    const cliPath = await this.ensureCLI();
+    const oauthToken = this.auth.kind === 'oauth' ? this.auth.token : undefined;
+
+    return new Promise((resolve, reject) => {
+      // `codex exec` runs a non-interactive completion, reading the prompt from stdin
+      // when invoked with `-` as the prompt argument. `--model` selects the model.
+      const args = ['exec', '--model', this.model];
+
+      if (options?.effort && isReasoningModel(this.model)) {
+        args.push('-c', `model_reasoning_effort="${options.effort}"`);
+      } else if (options?.effort) {
+        core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
+      }
+
+      // Read prompt from stdin
+      args.push('-');
+
+      const child = spawn(cliPath, args, {
+        env: {
+          // process.env spread intentionally — Codex CLI requires PATH, HOME, and other system vars.
+          // OPENAI_API_KEY (when in OAuth mode the CLI uses its own session, but some versions accept
+          // OPENAI_OAUTH_TOKEN). We pass the OAuth token via CODEX_OAUTH_TOKEN, mirroring the
+          // CLAUDE_CODE_OAUTH_TOKEN convention.
+          ...process.env,
+          ...(oauthToken ? { CODEX_OAUTH_TOKEN: oauthToken, OPENAI_API_KEY: oauthToken } : {}),
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let output = '';
+      let stderr = '';
+      let timedOut = false;
+      let stale = false;
+      let outputExceeded = false;
+      let settled = false;
+      let killTimer: NodeJS.Timeout | undefined;
+      let staleKillTimer: NodeJS.Timeout | undefined;
+      let outputKillTimer: NodeJS.Timeout | undefined;
+      let stdinKillTimer: NodeJS.Timeout | undefined;
+      let lastStdoutChunk = '';
+      let rawBytes = 0;
+
+      const clearAllTimers = (): void => {
+        clearTimeout(timer);
+        clearTimeout(staleTimer);
+        if (killTimer) clearTimeout(killTimer);
+        if (staleKillTimer) clearTimeout(staleKillTimer);
+        if (outputKillTimer) clearTimeout(outputKillTimer);
+        if (stdinKillTimer) clearTimeout(stdinKillTimer);
+      };
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        clearTimeout(staleTimer);
+        child.kill('SIGTERM');
+        killTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        killTimer.unref();
+      }, 1200000);
+      timer.unref();
+
+      const handleStale = (): void => {
+        if (outputExceeded || timedOut) return;
+        stale = true;
+        clearTimeout(timer);
+        child.kill('SIGTERM');
+        staleKillTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        staleKillTimer.unref();
+      };
+      let staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
+      staleTimer.unref();
+
+      const MAX_OUTPUT = 50 * 1024 * 1024; // 50 MB
+      const killOnOutputExceeded = (): void => {
+        if (outputExceeded) return;
+        outputExceeded = true;
+        clearTimeout(timer);
+        clearTimeout(staleTimer);
+        child.kill('SIGTERM');
+        outputKillTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        outputKillTimer.unref();
+      };
+      const stdoutDecoder = new StringDecoder('utf8');
+      const stderrDecoder = new StringDecoder('utf8');
+      child.stdout.on('data', (data: Buffer) => {
+        if (outputExceeded || settled || stale) return;
+        clearTimeout(staleTimer);
+        staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
+        staleTimer.unref();
+
+        rawBytes += data.length;
+        if (rawBytes + stderr.length > MAX_OUTPUT) { killOnOutputExceeded(); return; }
+
+        const chunk = stdoutDecoder.write(data);
+        if (chunk.length >= 500) {
+          lastStdoutChunk = chunk.slice(-500);
+        } else {
+          lastStdoutChunk = (lastStdoutChunk + chunk).slice(-500);
+        }
+        output += chunk;
+      });
+      child.stderr.on('data', (data: Buffer) => {
+        if (outputExceeded || settled) return;
+        stderr += stderrDecoder.write(data);
+        if (rawBytes + stderr.length > MAX_OUTPUT) killOnOutputExceeded();
+      });
+
+      child.on('close', (code, signal) => {
+        clearAllTimers();
+        if (settled) return;
+        settled = true;
+        const remaining = stdoutDecoder.end();
+        if (remaining) output += remaining;
+        stderr += stderrDecoder.end();
+        if (stale) {
+          const details = buildTimeoutDiagnostics(lastStdoutChunk, stderr);
+          const msg = `Codex CLI stale — no output for ${STALE_TIMEOUT_MS / 1000}s${details ? `. ${details}` : ''}`;
+          core.warning(msg);
+          reject(new Error(msg));
+          return;
+        }
+        if (timedOut) {
+          const details = buildTimeoutDiagnostics(lastStdoutChunk, stderr);
+          const msg = `Codex CLI timed out after 1200s${details ? `. ${details}` : ''}`;
+          core.warning(msg);
+          reject(new Error(msg));
+          return;
+        }
+        if (outputExceeded) {
+          reject(new Error('Codex CLI output exceeded 50MB limit'));
+          return;
+        }
+        if (code !== 0) {
+          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderr.slice(0, 500)}`;
+          core.warning(`Codex CLI failed (${msg})`);
+          reject(new Error(`Codex CLI invocation failed (${msg})`));
+          return;
+        }
+        const content = output.trim();
+        core.debug(sanitizeLogOutput(content.slice(0, 200)));
+        resolve({ content });
+      });
+
+      child.on('error', (error) => {
+        clearAllTimers();
+        if (settled) return;
+        settled = true;
+        reject(new Error(`Codex CLI spawn failed: ${error.message}`));
+      });
+
+      child.stdin.on('error', (err) => {
+        core.warning(`stdin write error: ${err.message}`);
+      });
+
+      try {
+        const canWrite = child.stdin.write(fullPrompt);
+        if (!canWrite) {
+          child.stdin.once('drain', () => {
+            if (!settled) {
+              try { child.stdin.end(); } catch { /* stream already destroyed */ }
+            }
+          });
+        } else {
+          try { child.stdin.end(); } catch { /* stream may be destroyed */ }
+        }
+      } catch (err) {
+        core.warning(`stdin write failed: ${(err as Error).message}`);
+        if (!settled) {
+          settled = true;
+          clearAllTimers();
+          reject(new Error(`stdin write failed: ${(err as Error).message}`));
+        }
+        try { child.kill('SIGTERM'); } catch { /* already dead */ }
+        stdinKillTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        stdinKillTimer.unref();
+      }
+    });
+  }
+
+  private async sendViaAPI(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
+    if (!this.openai) throw new Error('OpenAI client not initialized');
+
+    const reasoning = isReasoningModel(this.model);
+    if (options?.effort && !reasoning) {
+      core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params: any = {
+      model: this.model,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userMessage },
+      ],
+    };
+
+    if (reasoning && options?.effort) {
+      // OpenAI's reasoning_effort param accepts 'low' | 'medium' | 'high'.
+      // Manki's 'max' maps to 'high' (the highest tier the API exposes).
+      const map: Record<string, 'low' | 'medium' | 'high'> = {
+        low: 'low', medium: 'medium', high: 'high', max: 'high',
+      };
+      params.reasoning_effort = map[options.effort];
+    }
+
+    const response = await this.openai.chat.completions.create(params);
+    const content = response.choices?.[0]?.message?.content ?? '';
+    core.debug(sanitizeLogOutput(content.slice(0, 200)));
+
+    return { content };
+  }
+}

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -19,7 +19,7 @@ export function buildOpenAIAuth(oauthToken: string, apiKey: string): OpenAIAuth 
 
 /** Strip GitHub Actions workflow commands to prevent injection when logging CLI output. */
 export function sanitizeLogOutput(text: string): string {
-  return text.replace(/::[a-z].*$/gim, '[redacted-workflow-cmd]');
+  return text.replace(/^::[a-z].*$/gim, '[redacted-workflow-cmd]');
 }
 
 /**

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -42,11 +42,9 @@ export function isReasoningModel(model: string): boolean {
  * stack accepts. Both the chat completions API and the Codex CLI cap reasoning
  * effort at `'high'`, so manki's `'max'` collapses to `'high'` on both paths.
  */
-export function resolveEffortTier(effort: string): 'low' | 'medium' | 'high' {
-  const map: Record<string, 'low' | 'medium' | 'high'> = {
-    low: 'low', medium: 'medium', high: 'high', max: 'high',
-  };
-  return map[effort] ?? 'high';
+export function resolveEffortTier(effort: 'low' | 'medium' | 'high' | 'max'): 'low' | 'medium' | 'high' {
+  if (effort === 'max') return 'high';
+  return effort;
 }
 
 /** Build diagnostic snippets for timeout/stale error messages. */

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -143,7 +143,9 @@ export class OpenAIClient implements LLMClient {
       const args = ['exec', '--model', this.model];
 
       if (options?.effort && isReasoningModel(this.model)) {
-        args.push('-c', `model_reasoning_effort="${resolveCLIEffort(options.effort)}"`);
+        // Codex CLI's `-c` accepts bare `key=value` overrides; embedded double-quotes
+        // here would be passed as literal characters because `spawn` bypasses the shell.
+        args.push('-c', `model_reasoning_effort=${resolveCLIEffort(options.effort)}`);
       } else if (options?.effort) {
         core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
       }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -326,7 +326,14 @@ export class OpenAIClient implements LLMClient {
       core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
     }
 
-    const params: ChatCompletionCreateParamsNonStreaming = {
+    // `reasoning_effort` is only valid on o-series chat completions and the SDK's
+    // non-streaming union doesn't always surface it on every model branch. Intersecting
+    // with a narrow `{ reasoning_effort?: ... }` keeps the rest of the call site fully
+    // typed while letting us assign the field with compile-time checking.
+    type ParamsWithReasoningEffort = ChatCompletionCreateParamsNonStreaming & {
+      reasoning_effort?: 'low' | 'medium' | 'high';
+    };
+    const params: ParamsWithReasoningEffort = {
       model: this.model,
       messages: [
         { role: 'system', content: systemPrompt },
@@ -335,10 +342,7 @@ export class OpenAIClient implements LLMClient {
     };
 
     if (reasoning && options?.effort) {
-      // `reasoning_effort` is only valid on o-series chat completions; the SDK type
-      // for the non-streaming union doesn't always surface it on every model branch,
-      // so write through a record cast to keep the rest of the call site fully typed.
-      (params as unknown as Record<string, unknown>).reasoning_effort = resolveCLIEffort(options.effort);
+      params.reasoning_effort = resolveCLIEffort(options.effort);
     }
 
     const response = await this.openai.chat.completions.create(params);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -12,6 +12,11 @@ const execFileAsync = promisify(execFile);
 
 export const STALE_TIMEOUT_MS = 90_000;
 
+// Pin Codex CLI to a known-good version and disable lifecycle scripts on install
+// to mitigate supply-chain risk if a compromised release is published. Keep this
+// in sync with the explicit install step in `.github/workflows/manki.yml`.
+export const CODEX_CLI_VERSION = '0.129.0';
+
 export function buildOpenAIAuth(oauthToken: string, apiKey: string): OpenAIAuth {
   if (oauthToken) return { kind: 'oauth', token: oauthToken };
   if (apiKey) return { kind: 'apiKey', key: apiKey };
@@ -222,7 +227,7 @@ export class OpenAIClient implements LLMClient {
       const stdoutDecoder = new StringDecoder('utf8');
       const stderrDecoder = new StringDecoder('utf8');
       child.stdout.on('data', (data: Buffer) => {
-        if (outputExceeded || settled || stale) return;
+        if (outputExceeded || settled || stale || timedOut) return;
         clearTimeout(staleTimer);
         staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
         staleTimer.unref();

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -130,11 +130,11 @@ export class OpenAIClient implements LLMClient {
       const child = spawn(cliPath, args, {
         env: {
           // process.env spread intentionally — Codex CLI requires PATH, HOME, and other system vars.
-          // OPENAI_API_KEY (when in OAuth mode the CLI uses its own session, but some versions accept
-          // OPENAI_OAUTH_TOKEN). We pass the OAuth token via CODEX_OAUTH_TOKEN, mirroring the
-          // CLAUDE_CODE_OAUTH_TOKEN convention.
+          // The OAuth token is passed via CODEX_OAUTH_TOKEN (mirroring the CLAUDE_CODE_OAUTH_TOKEN
+          // convention) and OPENAI_OAUTH_TOKEN as a fallback for CLI versions that read it. Aliasing
+          // an OAuth subscription token as OPENAI_API_KEY would be a credential type confusion.
           ...process.env,
-          ...(oauthToken ? { CODEX_OAUTH_TOKEN: oauthToken, OPENAI_API_KEY: oauthToken } : {}),
+          ...(oauthToken ? { CODEX_OAUTH_TOKEN: oauthToken, OPENAI_OAUTH_TOKEN: oauthToken } : {}),
         },
         stdio: ['pipe', 'pipe', 'pipe'],
       });

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -176,7 +176,8 @@ export class OpenAIClient implements LLMClient {
       let outputKillTimer: NodeJS.Timeout | undefined;
       let stdinKillTimer: NodeJS.Timeout | undefined;
       let lastStdoutChunk = '';
-      let rawBytes = 0;
+      let rawStdoutBytes = 0;
+      let rawStderrBytes = 0;
 
       const clearAllTimers = (): void => {
         clearTimeout(timer);
@@ -225,8 +226,8 @@ export class OpenAIClient implements LLMClient {
         staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
         staleTimer.unref();
 
-        rawBytes += data.length;
-        if (rawBytes + stderr.length > MAX_OUTPUT) { killOnOutputExceeded(); return; }
+        rawStdoutBytes += data.length;
+        if (rawStdoutBytes + rawStderrBytes > MAX_OUTPUT) { killOnOutputExceeded(); return; }
 
         const chunk = stdoutDecoder.write(data);
         if (chunk.length >= 500) {
@@ -238,8 +239,9 @@ export class OpenAIClient implements LLMClient {
       });
       child.stderr.on('data', (data: Buffer) => {
         if (outputExceeded || settled) return;
+        rawStderrBytes += data.length;
         stderr += stderrDecoder.write(data);
-        if (rawBytes + stderr.length > MAX_OUTPUT) killOnOutputExceeded();
+        if (rawStdoutBytes + rawStderrBytes > MAX_OUTPUT) killOnOutputExceeded();
       });
 
       child.on('close', (code, signal) => {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -37,7 +37,7 @@ export function isReasoningModel(model: string): boolean {
  * stack accepts. Both the chat completions API and the Codex CLI cap reasoning
  * effort at `'high'`, so manki's `'max'` collapses to `'high'` on both paths.
  */
-export function resolveCLIEffort(effort: string): 'low' | 'medium' | 'high' {
+export function resolveEffortTier(effort: string): 'low' | 'medium' | 'high' {
   const map: Record<string, 'low' | 'medium' | 'high'> = {
     low: 'low', medium: 'medium', high: 'high', max: 'high',
   };
@@ -146,7 +146,7 @@ export class OpenAIClient implements LLMClient {
       if (options?.effort && isReasoningModel(this.model)) {
         // Codex CLI's `-c` accepts bare `key=value` overrides; embedded double-quotes
         // here would be passed as literal characters because `spawn` bypasses the shell.
-        args.push('-c', `model_reasoning_effort=${resolveCLIEffort(options.effort)}`);
+        args.push('-c', `model_reasoning_effort=${resolveEffortTier(options.effort)}`);
       } else if (options?.effort) {
         core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
       }
@@ -342,7 +342,7 @@ export class OpenAIClient implements LLMClient {
     };
 
     if (reasoning && options?.effort) {
-      params.reasoning_effort = resolveCLIEffort(options.effort);
+      params.reasoning_effort = resolveEffortTier(options.effort);
     }
 
     const response = await this.openai.chat.completions.create(params);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -111,7 +111,7 @@ export class OpenAIClient implements LLMClient {
           try {
             const { stdout: npmStdout, stderr: npmStderr } = await execFileAsync(
               'npm',
-              ['install', '-g', '@openai/codex'],
+              ['install', '-g', '--ignore-scripts', `@openai/codex@${CODEX_CLI_VERSION}`],
               { timeout: 120000 },
             );
             npmOutput = [npmStdout, npmStderr].filter(Boolean).join(' | ').trim();
@@ -244,7 +244,12 @@ export class OpenAIClient implements LLMClient {
         output += chunk;
       });
       child.stderr.on('data', (data: Buffer) => {
-        if (outputExceeded || settled) return;
+        if (outputExceeded || settled || stale || timedOut) return;
+        // Stderr counts as forward progress: long-running CLI invocations may write
+        // diagnostics exclusively to stderr while still actively making progress.
+        clearTimeout(staleTimer);
+        staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
+        staleTimer.unref();
         rawStderrBytes += data.length;
         stderr += stderrDecoder.write(data);
         if (rawStdoutBytes + rawStderrBytes > MAX_OUTPUT) killOnOutputExceeded();

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -63,7 +63,9 @@ export class OpenAIClient implements LLMClient {
     this.model = options.model;
 
     if (this.auth.kind === 'apiKey') {
-      this.openai = new OpenAI({ apiKey: this.auth.key });
+      // Explicit timeout makes the bound visible and consistent with the OAuth/CLI path's
+      // 1200s hard deadline. The SDK default (600s) leaves the action hanging on slow calls.
+      this.openai = new OpenAI({ apiKey: this.auth.key, timeout: 300_000 });
     }
   }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -31,6 +31,18 @@ export function isReasoningModel(model: string): boolean {
   return /^o\d/i.test(model);
 }
 
+/**
+ * Map manki's effort tiers (`low|medium|high|max`) to the values the OpenAI
+ * stack accepts. Both the chat completions API and the Codex CLI cap reasoning
+ * effort at `'high'`, so manki's `'max'` collapses to `'high'` on both paths.
+ */
+export function resolveCLIEffort(effort: string): 'low' | 'medium' | 'high' {
+  const map: Record<string, 'low' | 'medium' | 'high'> = {
+    low: 'low', medium: 'medium', high: 'high', max: 'high',
+  };
+  return map[effort] ?? 'high';
+}
+
 /** Build diagnostic snippets for timeout/stale error messages. */
 function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: string): string {
   const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
@@ -121,7 +133,7 @@ export class OpenAIClient implements LLMClient {
       const args = ['exec', '--model', this.model];
 
       if (options?.effort && isReasoningModel(this.model)) {
-        args.push('-c', `model_reasoning_effort="${options.effort}"`);
+        args.push('-c', `model_reasoning_effort="${resolveCLIEffort(options.effort)}"`);
       } else if (options?.effort) {
         core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
       }
@@ -308,12 +320,7 @@ export class OpenAIClient implements LLMClient {
     };
 
     if (reasoning && options?.effort) {
-      // OpenAI's reasoning_effort param accepts 'low' | 'medium' | 'high'.
-      // Manki's 'max' maps to 'high' (the highest tier the API exposes).
-      const map: Record<string, 'low' | 'medium' | 'high'> = {
-        low: 'low', medium: 'medium', high: 'high', max: 'high',
-      };
-      params.reasoning_effort = map[options.effort];
+      params.reasoning_effort = resolveCLIEffort(options.effort);
     }
 
     const response = await this.openai.chat.completions.create(params);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -101,14 +101,24 @@ export class OpenAIClient implements LLMClient {
       if (!cliInstallPromise) {
         cliInstallPromise = (async () => {
           core.info('Codex CLI not found, installing via npm...');
-          await execFileAsync('npm', ['install', '-g', '@openai/codex'], {
-            timeout: 120000,
-          });
+          let npmOutput = '';
+          try {
+            const { stdout: npmStdout, stderr: npmStderr } = await execFileAsync(
+              'npm',
+              ['install', '-g', '@openai/codex'],
+              { timeout: 120000 },
+            );
+            npmOutput = [npmStdout, npmStderr].filter(Boolean).join(' | ').trim();
+          } catch (npmErr) {
+            const message = (npmErr as Error).message;
+            throw new Error(`Failed to install Codex CLI via npm: ${message}`);
+          }
           try {
             const { stdout } = await execFileAsync('which', ['codex']);
             return stdout.trim();
           } catch {
-            throw new Error('Failed to install Codex CLI');
+            const suffix = npmOutput ? ` (npm output: ${sanitizeLogOutput(npmOutput).slice(0, 500)})` : '';
+            throw new Error(`Failed to locate Codex CLI on PATH after npm install${suffix}`);
           }
         })();
       }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -3,6 +3,7 @@ import { StringDecoder } from 'string_decoder';
 import { promisify } from 'util';
 
 import OpenAI from 'openai';
+import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions';
 import * as core from '@actions/core';
 
 import { LLMClient, LLMResponse, OpenAIAuth, SendMessageOptions } from './types';
@@ -324,8 +325,7 @@ export class OpenAIClient implements LLMClient {
       core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const params: any = {
+    const params: ChatCompletionCreateParamsNonStreaming = {
       model: this.model,
       messages: [
         { role: 'system', content: systemPrompt },
@@ -334,7 +334,10 @@ export class OpenAIClient implements LLMClient {
     };
 
     if (reasoning && options?.effort) {
-      params.reasoning_effort = resolveCLIEffort(options.effort);
+      // `reasoning_effort` is only valid on o-series chat completions; the SDK type
+      // for the non-streaming union doesn't always surface it on every model branch,
+      // so write through a record cast to keep the rest of the call site fully typed.
+      (params as unknown as Record<string, unknown>).reasoning_effort = resolveCLIEffort(options.effort);
     }
 
     const response = await this.openai.chat.completions.create(params);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -271,7 +271,8 @@ export class OpenAIClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderr.slice(0, 500)}`;
+          const sanitizedStderr = sanitizeLogOutput(stderr.slice(0, 500));
+          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${sanitizedStderr}`;
           core.warning(`Codex CLI failed (${msg})`);
           reject(new Error(`Codex CLI invocation failed (${msg})`));
           return;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,4 @@
-export type ProviderName = 'anthropic';
+export type ProviderName = 'anthropic' | 'openai';
 
 export interface LLMResponse {
   content: string;
@@ -16,4 +16,8 @@ export type AnthropicAuth =
   | { kind: 'oauth'; token: string }
   | { kind: 'apiKey'; key: string };
 
-export type ProviderAuth = AnthropicAuth;
+export type OpenAIAuth =
+  | { kind: 'oauth'; token: string }
+  | { kind: 'apiKey'; key: string };
+
+export type ProviderAuth = AnthropicAuth | OpenAIAuth;


### PR DESCRIPTION
## Summary

Adds OpenAI as the second supported provider:

- `OpenAIClient` implements `LLMClient` with both API-key (via `openai` SDK) and Codex CLI OAuth transport paths.
- Effort mapping: `low`/`medium`/`high` → `reasoning_effort` for o-series; ignored (with warning) for GPT models. `max` maps to `high` (the highest tier the API exposes).
- Model-registry detects `gpt-*`, `o3*`, `o4*` prefixes; factory dispatches to `OpenAIClient`.
- New action inputs: `openai_api_key`, `openai_oauth_token`. The auth selected for each LLM client is derived from the parsed provider, so mixing providers across stages (e.g. reviewer on `gpt-4o`, judge on `claude-opus-4-7`) works as long as both sets of credentials are configured.
- Self-test workflow installs the Codex CLI when an OpenAI OAuth token is set, parallel to the existing Claude CLI install step.

Closes [#489](https://github.com/manki-review/manki/issues/489)

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (1629 tests pass; 37 added)
- [x] `npm run build`