### PR TITLE
feat: Gemini provider adapter (API key + Gemini CLI OAuth)

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -47,8 +47,10 @@ jobs:
         env:
           OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
       - name: Install Gemini CLI
-        if: ${{ secrets.GEMINI_OAUTH_TOKEN != '' }}
+        if: env.GEMINI_OAUTH_TOKEN != ''
         run: npm install -g @google/gemini-cli
+        env:
+          GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
       - name: Manki Review
         uses: ./  # Use local action for self-testing
         with:

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -59,4 +59,5 @@ jobs:
           openai_oauth_token: ${{ secrets.OPENAI_OAUTH_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           gemini_oauth_token: ${{ secrets.GEMINI_OAUTH_TOKEN }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -47,10 +47,8 @@ jobs:
         env:
           OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
       - name: Install Gemini CLI
-        if: env.GEMINI_OAUTH_TOKEN != ''
+        if: ${{ secrets.GEMINI_OAUTH_TOKEN != '' }}
         run: npm install -g @google/gemini-cli
-        env:
-          GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
       - name: Manki Review
         uses: ./  # Use local action for self-testing
         with:

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -46,6 +46,11 @@ jobs:
         run: npm install -g --ignore-scripts '@openai/codex@0.129.0'
         env:
           OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
+      - name: Install Gemini CLI
+        if: env.GEMINI_OAUTH_TOKEN != ''
+        run: npm install -g @google/gemini-cli
+        env:
+          GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
       - name: Manki Review
         uses: ./  # Use local action for self-testing
         with:
@@ -53,4 +58,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           openai_oauth_token: ${{ secrets.OPENAI_OAUTH_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          gemini_oauth_token: ${{ secrets.GEMINI_OAUTH_TOKEN }}
           memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}

--- a/.manki.yml.example
+++ b/.manki.yml.example
@@ -48,6 +48,13 @@
 #   # Resolution order per agent: agents[name] -> models.reviewer -> default.
 #   agents:
 #     "Security & Safety": claude-opus-4-7
+#
+# To use Gemini, set `gemini_api_key` (or `gemini_oauth_token`) and override models:
+# models:
+#   planner: gemini-2.5-flash
+#   reviewer: gemini-2.5-flash
+#   judge: gemini-2.5-pro
+#   dedup: gemini-2.5-flash
 
 # Planner stage (default: enabled)
 # When enabled and review_level is "auto", a fast pre-review pass chooses the

--- a/.manki.yml.example
+++ b/.manki.yml.example
@@ -51,10 +51,10 @@
 #
 # To use Gemini, set `gemini_api_key` (or `gemini_oauth_token`) and override models:
 # models:
-#   planner: gemini-2.5-flash
-#   reviewer: gemini-2.5-flash
-#   judge: gemini-2.5-pro
-#   dedup: gemini-2.5-flash
+#   planner: gemini-3.1-flash-lite
+#   reviewer: gemini-3.1-flash-lite
+#   judge: gemini-3.1-pro-preview
+#   dedup: gemini-3.1-flash-lite
 
 # Planner stage (default: enabled)
 # When enabled and review_level is "auto", a fast pre-review pass chooses the

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,12 @@ inputs:
   openai_api_key:
     description: 'OpenAI API key (alternative to OAuth token)'
     required: false
+  gemini_oauth_token:
+    description: 'Gemini OAuth token for Gemini CLI (uses google-gemini/gemini-cli)'
+    required: false
+  gemini_api_key:
+    description: 'Google Generative AI API key (alternative to Gemini OAuth token)'
+    required: false
   github_token:
     description: 'GitHub token for posting reviews and comments (not required when using GitHub App auth)'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
         "@anthropic-ai/sdk": "^0.39.0",
+        "@google/generative-ai": "^0.24.1",
         "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^21.1.1",
         "minimatch": "^10.2.4",
@@ -821,6 +822,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
     "@anthropic-ai/sdk": "^0.39.0",
+    "@google/generative-ai": "^0.24.1",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^21.1.1",
     "minimatch": "^10.2.4",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -34,9 +34,11 @@ describe('config', () => {
       expect(DEFAULT_CONFIG.review_passes).toBe(1);
     });
 
-    it('defaults models.reviewer to Sonnet and models.judge to Opus', () => {
-      expect(DEFAULT_CONFIG.models?.reviewer).toBe('claude-sonnet-4-6');
-      expect(DEFAULT_CONFIG.models?.judge).toBe('claude-opus-4-7');
+    it('defaults models.reviewer to gemini-2.5-flash and models.judge to gemini-2.5-pro', () => {
+      expect(DEFAULT_CONFIG.models?.reviewer).toBe('gemini-2.5-flash');
+      expect(DEFAULT_CONFIG.models?.judge).toBe('gemini-2.5-pro');
+      expect(DEFAULT_CONFIG.models?.planner).toBe('gemini-2.5-flash');
+      expect(DEFAULT_CONFIG.models?.dedup).toBe('gemini-2.5-flash');
     });
 
     it('has no default custom reviewers', () => {
@@ -292,7 +294,7 @@ models:
 `;
       const config = loadConfigFromContent(yaml);
       expect(config.models?.reviewer).toBe('claude-sonnet-4-6');
-      expect(config.models?.judge).toBe('claude-opus-4-7');
+      expect(config.models?.judge).toBe('gemini-2.5-pro');
     });
 
     it('throws on invalid models type', () => {
@@ -357,7 +359,7 @@ models:
 `;
       const config = loadConfigFromContent(yaml);
       expect(config.models?.reviewer).toBe('claude-haiku-4-5');
-      expect(config.models?.judge).toBe('claude-opus-4-7');
+      expect(config.models?.judge).toBe('gemini-2.5-pro');
     });
 
     it('accepts valid review_passes values', () => {
@@ -395,10 +397,10 @@ models:
     };
 
     it('returns default stage-specific models from defaults', () => {
-      expect(resolveModel(baseConfig, 'reviewer')).toBe('claude-sonnet-4-6');
-      expect(resolveModel(baseConfig, 'judge')).toBe('claude-opus-4-7');
-      expect(resolveModel(baseConfig, 'dedup')).toBe('claude-haiku-4-5');
-      expect(resolveModel(baseConfig, 'planner')).toBe('claude-haiku-4-5');
+      expect(resolveModel(baseConfig, 'reviewer')).toBe('gemini-2.5-flash');
+      expect(resolveModel(baseConfig, 'judge')).toBe('gemini-2.5-pro');
+      expect(resolveModel(baseConfig, 'dedup')).toBe('gemini-2.5-flash');
+      expect(resolveModel(baseConfig, 'planner')).toBe('gemini-2.5-flash');
     });
 
     it('returns overridden stage-specific model', () => {
@@ -413,9 +415,9 @@ models:
 
     it('falls back to default models when models is undefined', () => {
       const config: ReviewConfig = { ...baseConfig, models: undefined };
-      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
-      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-7');
-      expect(resolveModel(config, 'dedup')).toBe('claude-haiku-4-5');
+      expect(resolveModel(config, 'reviewer')).toBe('gemini-2.5-flash');
+      expect(resolveModel(config, 'judge')).toBe('gemini-2.5-pro');
+      expect(resolveModel(config, 'dedup')).toBe('gemini-2.5-flash');
     });
 
     it('falls back to default model when stage key is missing', () => {
@@ -424,15 +426,15 @@ models:
         models: { reviewer: 'claude-sonnet-4-6' },
       };
       expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
-      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-7');
+      expect(resolveModel(config, 'judge')).toBe('gemini-2.5-pro');
     });
 
     it('falls back to default models when models is empty object', () => {
       const config: ReviewConfig = { ...baseConfig, models: {} };
-      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
-      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-7');
-      expect(resolveModel(config, 'dedup')).toBe('claude-haiku-4-5');
-      expect(resolveModel(config, 'planner')).toBe('claude-haiku-4-5');
+      expect(resolveModel(config, 'reviewer')).toBe('gemini-2.5-flash');
+      expect(resolveModel(config, 'judge')).toBe('gemini-2.5-pro');
+      expect(resolveModel(config, 'dedup')).toBe('gemini-2.5-flash');
+      expect(resolveModel(config, 'planner')).toBe('gemini-2.5-flash');
     });
 
     it('returns overridden planner model', () => {
@@ -471,7 +473,7 @@ models:
 
     it('falls back to built-in default when no stage override and no agent override', () => {
       const config: ReviewConfig = { ...baseConfig, models: undefined };
-      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('gemini-2.5-flash');
     });
 
     it('falls back to built-in default when models.agents is undefined', () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -34,11 +34,11 @@ describe('config', () => {
       expect(DEFAULT_CONFIG.review_passes).toBe(1);
     });
 
-    it('defaults models.reviewer to gemini-2.5-flash and models.judge to gemini-2.5-pro', () => {
-      expect(DEFAULT_CONFIG.models?.reviewer).toBe('gemini-2.5-flash');
-      expect(DEFAULT_CONFIG.models?.judge).toBe('gemini-2.5-pro');
-      expect(DEFAULT_CONFIG.models?.planner).toBe('gemini-2.5-flash');
-      expect(DEFAULT_CONFIG.models?.dedup).toBe('gemini-2.5-flash');
+    it('defaults models.reviewer to Sonnet and models.judge to Opus', () => {
+      expect(DEFAULT_CONFIG.models?.reviewer).toBe('claude-sonnet-4-6');
+      expect(DEFAULT_CONFIG.models?.judge).toBe('claude-opus-4-7');
+      expect(DEFAULT_CONFIG.models?.planner).toBe('claude-haiku-4-5');
+      expect(DEFAULT_CONFIG.models?.dedup).toBe('claude-haiku-4-5');
     });
 
     it('has no default custom reviewers', () => {
@@ -294,7 +294,7 @@ models:
 `;
       const config = loadConfigFromContent(yaml);
       expect(config.models?.reviewer).toBe('claude-sonnet-4-6');
-      expect(config.models?.judge).toBe('gemini-2.5-pro');
+      expect(config.models?.judge).toBe('claude-opus-4-7');
     });
 
     it('throws on invalid models type', () => {
@@ -359,7 +359,7 @@ models:
 `;
       const config = loadConfigFromContent(yaml);
       expect(config.models?.reviewer).toBe('claude-haiku-4-5');
-      expect(config.models?.judge).toBe('gemini-2.5-pro');
+      expect(config.models?.judge).toBe('claude-opus-4-7');
     });
 
     it('accepts valid review_passes values', () => {
@@ -397,10 +397,10 @@ models:
     };
 
     it('returns default stage-specific models from defaults', () => {
-      expect(resolveModel(baseConfig, 'reviewer')).toBe('gemini-2.5-flash');
-      expect(resolveModel(baseConfig, 'judge')).toBe('gemini-2.5-pro');
-      expect(resolveModel(baseConfig, 'dedup')).toBe('gemini-2.5-flash');
-      expect(resolveModel(baseConfig, 'planner')).toBe('gemini-2.5-flash');
+      expect(resolveModel(baseConfig, 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveModel(baseConfig, 'judge')).toBe('claude-opus-4-7');
+      expect(resolveModel(baseConfig, 'dedup')).toBe('claude-haiku-4-5');
+      expect(resolveModel(baseConfig, 'planner')).toBe('claude-haiku-4-5');
     });
 
     it('returns overridden stage-specific model', () => {
@@ -415,9 +415,9 @@ models:
 
     it('falls back to default models when models is undefined', () => {
       const config: ReviewConfig = { ...baseConfig, models: undefined };
-      expect(resolveModel(config, 'reviewer')).toBe('gemini-2.5-flash');
-      expect(resolveModel(config, 'judge')).toBe('gemini-2.5-pro');
-      expect(resolveModel(config, 'dedup')).toBe('gemini-2.5-flash');
+      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-7');
+      expect(resolveModel(config, 'dedup')).toBe('claude-haiku-4-5');
     });
 
     it('falls back to default model when stage key is missing', () => {
@@ -426,15 +426,15 @@ models:
         models: { reviewer: 'claude-sonnet-4-6' },
       };
       expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
-      expect(resolveModel(config, 'judge')).toBe('gemini-2.5-pro');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-7');
     });
 
     it('falls back to default models when models is empty object', () => {
       const config: ReviewConfig = { ...baseConfig, models: {} };
-      expect(resolveModel(config, 'reviewer')).toBe('gemini-2.5-flash');
-      expect(resolveModel(config, 'judge')).toBe('gemini-2.5-pro');
-      expect(resolveModel(config, 'dedup')).toBe('gemini-2.5-flash');
-      expect(resolveModel(config, 'planner')).toBe('gemini-2.5-flash');
+      expect(resolveModel(config, 'reviewer')).toBe('claude-sonnet-4-6');
+      expect(resolveModel(config, 'judge')).toBe('claude-opus-4-7');
+      expect(resolveModel(config, 'dedup')).toBe('claude-haiku-4-5');
+      expect(resolveModel(config, 'planner')).toBe('claude-haiku-4-5');
     });
 
     it('returns overridden planner model', () => {
@@ -473,7 +473,7 @@ models:
 
     it('falls back to built-in default when no stage override and no agent override', () => {
       const config: ReviewConfig = { ...baseConfig, models: undefined };
-      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('gemini-2.5-flash');
+      expect(resolveAgentModel(config, 'Security & Safety', 'reviewer')).toBe('claude-sonnet-4-6');
     });
 
     it('falls back to built-in default when models.agents is undefined', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,10 +16,10 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   review_level: 'auto',
   review_thresholds: { small: 200, medium: 1000 },
   models: {
-    planner: 'gemini-2.5-flash',
-    reviewer: 'gemini-2.5-flash',
-    judge: 'gemini-2.5-pro',
-    dedup: 'gemini-2.5-flash',
+    planner: 'claude-haiku-4-5',
+    reviewer: 'claude-sonnet-4-6',
+    judge: 'claude-opus-4-7',
+    dedup: 'claude-haiku-4-5',
   },
   planner: {
     enabled: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,10 +16,10 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   review_level: 'auto',
   review_thresholds: { small: 200, medium: 1000 },
   models: {
-    planner: 'claude-haiku-4-5',
-    reviewer: 'claude-sonnet-4-6',
-    judge: 'claude-opus-4-7',
-    dedup: 'claude-haiku-4-5',
+    planner: 'gemini-2.5-flash',
+    reviewer: 'gemini-2.5-flash',
+    judge: 'gemini-2.5-pro',
+    dedup: 'gemini-2.5-flash',
   },
   planner: {
     enabled: true,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4411,6 +4411,34 @@ describe('handleInteraction', () => {
       jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
     }
   });
+
+  it('proceeds when gemini_oauth_token is set and routes via gemini provider', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'gemini_oauth_token' ? 'gem-tok' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+    try {
+      setContext({
+        eventName: 'issue_comment',
+        payload: {
+          action: 'created',
+          comment: { body: '@manki help' },
+          issue: { number: 7, pull_request: { url: 'https://...' } },
+        },
+      });
+
+      await handleInteraction();
+
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'gemini',
+        expect.any(String),
+        { kind: 'oauth', token: 'gem-tok' },
+      );
+    } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
+  });
 });
 
 describe('handleIssueInteraction', () => {
@@ -4662,6 +4690,38 @@ describe('handleReviewCommentInteraction auto-approve', () => {
         'gemini',
         expect.any(String),
         { kind: 'apiKey', key: 'gem-key' },
+      );
+    } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
+  });
+
+  it('proceeds when gemini_oauth_token is set and routes via gemini provider', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'gemini_oauth_token' ? 'gem-tok' : '',
+    );
+    jest.mocked(interaction.hasBotMention).mockReturnValue(true);
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+    try {
+      setContext({
+        eventName: 'pull_request_review_comment',
+        payload: {
+          action: 'created',
+          comment: {
+            body: '@manki help',
+            user: { type: 'User' },
+          },
+          pull_request: { number: 9, base: { ref: 'main' } },
+        },
+      });
+
+      await handleReviewCommentInteraction();
+
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'gemini',
+        expect.any(String),
+        { kind: 'oauth', token: 'gem-tok' },
       );
     } finally {
       jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3804,14 +3804,15 @@ describe('runFullReview orchestration', () => {
     );
     jest.mocked(configModule.resolveModel).mockReturnValue('gemini-3.1-flash-lite');
     jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+    try {
+      await callRunFullReview();
 
-    await callRunFullReview();
-
-    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
-    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
-
-    jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
-    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+    } finally {
+      jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
   });
 
   it('proceeds when gemini_oauth_token is set', async () => {
@@ -3820,14 +3821,15 @@ describe('runFullReview orchestration', () => {
     );
     jest.mocked(configModule.resolveModel).mockReturnValue('gemini-3.1-flash-lite');
     jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+    try {
+      await callRunFullReview();
 
-    await callRunFullReview();
-
-    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
-    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
-
-    jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
-    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+    } finally {
+      jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
   });
 
 
@@ -3837,15 +3839,16 @@ describe('runFullReview orchestration', () => {
     );
     jest.mocked(configModule.resolveModel).mockReturnValue('gemini-3.1-flash-lite');
     jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+    try {
+      await callRunFullReview();
 
-    await callRunFullReview();
-
-    expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      expect.stringContaining('Invalid model config'),
-    );
-
-    jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
-    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+      expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid model config'),
+      );
+    } finally {
+      jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
   });
 
   it('posts app warning when identity is actions', async () => {
@@ -4386,25 +4389,27 @@ describe('handleInteraction', () => {
       name === 'gemini_api_key' ? 'gem-key' : '',
     );
     jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
-    setContext({
-      eventName: 'issue_comment',
-      payload: {
-        action: 'created',
-        comment: { body: '@manki help' },
-        issue: { number: 7, pull_request: { url: 'https://...' } },
-      },
-    });
+    try {
+      setContext({
+        eventName: 'issue_comment',
+        payload: {
+          action: 'created',
+          comment: { body: '@manki help' },
+          issue: { number: 7, pull_request: { url: 'https://...' } },
+        },
+      });
 
-    await handleInteraction();
+      await handleInteraction();
 
-    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
-    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
-      'gemini',
-      expect.any(String),
-      { kind: 'apiKey', key: 'gem-key' },
-    );
-
-    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'gemini',
+        expect.any(String),
+        { kind: 'apiKey', key: 'gem-key' },
+      );
+    } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
   });
 });
 
@@ -4637,29 +4642,30 @@ describe('handleReviewCommentInteraction auto-approve', () => {
     );
     jest.mocked(interaction.hasBotMention).mockReturnValue(true);
     jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
-
-    setContext({
-      eventName: 'pull_request_review_comment',
-      payload: {
-        action: 'created',
-        comment: {
-          body: '@manki help',
-          user: { type: 'User' },
+    try {
+      setContext({
+        eventName: 'pull_request_review_comment',
+        payload: {
+          action: 'created',
+          comment: {
+            body: '@manki help',
+            user: { type: 'User' },
+          },
+          pull_request: { number: 9, base: { ref: 'main' } },
         },
-        pull_request: { number: 9, base: { ref: 'main' } },
-      },
-    });
+      });
 
-    await handleReviewCommentInteraction();
+      await handleReviewCommentInteraction();
 
-    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
-    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
-      'gemini',
-      expect.any(String),
-      { kind: 'apiKey', key: 'gem-key' },
-    );
-
-    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+      expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+      expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+        'gemini',
+        expect.any(String),
+        { kind: 'apiKey', key: 'gem-key' },
+      );
+    } finally {
+      jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+    }
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1133,7 +1133,7 @@ describe('handleReviewCommentInteraction', () => {
     await handleReviewCommentInteraction();
 
     expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key',
+      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, openai_api_key, gemini_oauth_token, or gemini_api_key',
     );
     expect(jest.mocked(interaction.handleReviewCommentReply)).not.toHaveBeenCalled();
   });
@@ -3692,7 +3692,7 @@ describe('runFullReview orchestration', () => {
     await callRunFullReview();
 
     expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key',
+      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, openai_api_key, gemini_oauth_token, or gemini_api_key',
     );
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
@@ -4163,7 +4163,7 @@ describe('handleInteraction', () => {
     await handleInteraction();
 
     expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
-      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key',
+      'No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, openai_api_key, gemini_oauth_token, or gemini_api_key',
     );
     expect(jest.mocked(interaction.handlePRComment)).not.toHaveBeenCalled();
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3831,6 +3831,23 @@ describe('runFullReview orchestration', () => {
   });
 
 
+  it('fails with Invalid model config when only anthropic_api_key is set but model is gemini', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'sk-test' : '',
+    );
+    jest.mocked(configModule.resolveModel).mockReturnValue('gemini-3.1-flash-lite');
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+
+    await callRunFullReview();
+
+    expect(jest.mocked(core.setFailed)).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid model config'),
+    );
+
+    jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+  });
+
   it('posts app warning when identity is actions', async () => {
     _resetOctokitCache();
     jest.mocked(authModule.createAuthenticatedOctokit).mockResolvedValue({
@@ -4363,6 +4380,32 @@ describe('handleInteraction', () => {
     );
     expect(jest.mocked(createLLMClient)).not.toHaveBeenCalled();
   });
+
+  it('proceeds when gemini_api_key is set and routes via gemini provider', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'gemini_api_key' ? 'gem-key' : '',
+    );
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@manki help' },
+        issue: { number: 7, pull_request: { url: 'https://...' } },
+      },
+    });
+
+    await handleInteraction();
+
+    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+      'gemini',
+      expect.any(String),
+      { kind: 'apiKey', key: 'gem-key' },
+    );
+
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+  });
 });
 
 describe('handleIssueInteraction', () => {
@@ -4586,6 +4629,37 @@ describe('handleReviewCommentInteraction auto-approve', () => {
       expect.any(String),
       { kind: 'apiKey', key: 'sk-api-key' },
     );
+  });
+
+  it('proceeds when gemini_api_key is set and routes via gemini provider', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'gemini_api_key' ? 'gem-key' : '',
+    );
+    jest.mocked(interaction.hasBotMention).mockReturnValue(true);
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+
+    setContext({
+      eventName: 'pull_request_review_comment',
+      payload: {
+        action: 'created',
+        comment: {
+          body: '@manki help',
+          user: { type: 'User' },
+        },
+        pull_request: { number: 9, base: { ref: 'main' } },
+      },
+    });
+
+    await handleReviewCommentInteraction();
+
+    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+    expect(jest.mocked(createLLMClient)).toHaveBeenCalledWith(
+      'gemini',
+      expect.any(String),
+      { kind: 'apiKey', key: 'gem-key' },
+    );
+
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,6 +55,7 @@ jest.mock('./auth', () => ({
 jest.mock('./providers', () => ({
   buildAnthropicAuth: jest.requireActual('./providers').buildAnthropicAuth,
   buildOpenAIAuth: jest.requireActual('./providers').buildOpenAIAuth,
+  buildGeminiAuth: jest.requireActual('./providers').buildGeminiAuth,
   createLLMClient: jest.fn().mockImplementation(() => ({ sendMessage: jest.fn() })),
   parseModelSpec: jest.fn().mockImplementation((m: string) => ({ provider: 'anthropic', model: m })),
 }));
@@ -3796,6 +3797,39 @@ describe('runFullReview orchestration', () => {
       jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
     }
   });
+
+  it('proceeds when gemini_api_key is set and resolves auth via the gemini branch', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'gemini_api_key' ? 'gem-key' : '',
+    );
+    jest.mocked(configModule.resolveModel).mockReturnValue('gemini-3.1-flash-lite');
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+
+    await callRunFullReview();
+
+    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+
+    jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+  });
+
+  it('proceeds when gemini_oauth_token is set', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'gemini_oauth_token' ? 'gem-tok' : '',
+    );
+    jest.mocked(configModule.resolveModel).mockReturnValue('gemini-3.1-flash-lite');
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'gemini', model: m }));
+
+    await callRunFullReview();
+
+    expect(jest.mocked(core.setFailed)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+
+    jest.mocked(configModule.resolveModel).mockReturnValue('claude-sonnet-4-20250514');
+    jest.mocked(parseModelSpec).mockImplementation((m: string) => ({ provider: 'anthropic', model: m }));
+  });
+
 
   it('posts app warning when identity is actions', async () => {
     _resetOctokitCache();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
 import { loadConfig, resolveModel } from './config';
-import { buildAnthropicAuth, buildOpenAIAuth, createLLMClient, parseModelSpec } from './providers';
+import { buildAnthropicAuth, buildOpenAIAuth, buildGeminiAuth, createLLMClient, parseModelSpec } from './providers';
 import type { LLMClient, ProviderAuth, ProviderName } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
@@ -45,6 +45,8 @@ interface ProviderInputs {
   anthropicApiKey: string;
   openaiOauthToken: string;
   openaiApiKey: string;
+  geminiOauthToken: string;
+  geminiApiKey: string;
 }
 
 function buildAuthForProvider(provider: ProviderName, inputs: ProviderInputs): ProviderAuth {
@@ -53,6 +55,8 @@ function buildAuthForProvider(provider: ProviderName, inputs: ProviderInputs): P
       return buildAnthropicAuth(inputs.anthropicOauthToken, inputs.anthropicApiKey);
     case 'openai':
       return buildOpenAIAuth(inputs.openaiOauthToken, inputs.openaiApiKey);
+    case 'gemini':
+      return buildGeminiAuth(inputs.geminiOauthToken, inputs.geminiApiKey);
     default: {
       const exhaustive: never = provider;
       throw new Error(`Unsupported provider: ${exhaustive as string}`);
@@ -66,12 +70,15 @@ function readProviderInputs(): ProviderInputs {
     anthropicApiKey: core.getInput('anthropic_api_key'),
     openaiOauthToken: core.getInput('openai_oauth_token'),
     openaiApiKey: core.getInput('openai_api_key'),
+    geminiOauthToken: core.getInput('gemini_oauth_token'),
+    geminiApiKey: core.getInput('gemini_api_key'),
   };
 }
 
 function hasAnyProviderCredentials(inputs: ProviderInputs): boolean {
-  return !!(inputs.anthropicOauthToken || inputs.anthropicApiKey || inputs.openaiOauthToken || inputs.openaiApiKey);
+  return !!(inputs.anthropicOauthToken || inputs.anthropicApiKey || inputs.openaiOauthToken || inputs.openaiApiKey || inputs.geminiOauthToken || inputs.geminiApiKey);
 }
+
 
 function buildLLMClientFromInputs(opts: {
   inputs: ProviderInputs;
@@ -386,7 +393,7 @@ async function runFullReview(
   const providerInputs = readProviderInputs();
 
   if (!hasAnyProviderCredentials(providerInputs)) {
-    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key');
+    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, openai_api_key, gemini_oauth_token, or gemini_api_key');
     return;
   }
 
@@ -1147,7 +1154,7 @@ async function handleInteraction(): Promise<void> {
   const providerInputs = readProviderInputs();
 
   if (!hasAnyProviderCredentials(providerInputs)) {
-    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key');
+    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, openai_api_key, gemini_oauth_token, or gemini_api_key');
     return;
   }
 
@@ -1233,7 +1240,7 @@ async function handleReviewCommentInteraction(): Promise<void> {
   const providerInputs = readProviderInputs();
 
   if (!hasAnyProviderCredentials(providerInputs)) {
-    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, or openai_api_key');
+    core.setFailed('No API key configured — set claude_code_oauth_token, anthropic_api_key, openai_oauth_token, openai_api_key, gemini_oauth_token, or gemini_api_key');
     return;
   }
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import Anthropic from '@anthropic-ai/sdk';
 import * as core from '@actions/core';
 
-import { sanitizeLogOutput, STALE_TIMEOUT_MS } from './cli-utils';
+import { sanitizeLogOutput, STALE_TIMEOUT_MS, buildTimeoutDiagnostics } from './cli-utils';
 import { AnthropicAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
 // Re-export for backward compatibility with existing test imports.
@@ -35,15 +35,6 @@ function processJsonLine(line: string): { text: string; replace: boolean } {
   return { text: '', replace: false };
 }
 
-/** Build diagnostic snippets for timeout/stale error messages. */
-function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: string): string {
-  const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
-  const stderrSnippet = sanitizeLogOutput(stderrText.slice(0, 500));
-  const parts: string[] = [];
-  if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
-  if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
-  return parts.join('. ');
-}
 
 let cliInstallPromise: Promise<string> | null = null;
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,23 +5,18 @@ import { promisify } from 'util';
 import Anthropic from '@anthropic-ai/sdk';
 import * as core from '@actions/core';
 
+import { sanitizeLogOutput, STALE_TIMEOUT_MS } from './cli-utils';
 import { AnthropicAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
-const execFileAsync = promisify(execFile);
+// Re-export for backward compatibility with existing test imports.
+export { sanitizeLogOutput, STALE_TIMEOUT_MS };
 
-export const STALE_TIMEOUT_MS = 90_000;
+const execFileAsync = promisify(execFile);
 
 export function buildAnthropicAuth(oauthToken: string, apiKey: string): AnthropicAuth {
   if (oauthToken) return { kind: 'oauth', token: oauthToken };
   if (apiKey) return { kind: 'apiKey', key: apiKey };
   throw new Error('Either claude_code_oauth_token or anthropic_api_key must be provided');
-}
-
-/** Strip GitHub Actions workflow commands to prevent injection when logging CLI output. */
-export function sanitizeLogOutput(text: string): string {
-  // Matches any line segment starting with :: followed by a letter — covers all workflow commands
-  // regardless of parameter format (e.g. ::error file=foo.ts,line=5::message)
-  return text.replace(/::[a-z].*$/gim, '[redacted-workflow-cmd]');
 }
 
 /** Parse a single JSON-stream line emitted by Claude CLI and return a text delta or final result. */

--- a/src/providers/cli-utils.test.ts
+++ b/src/providers/cli-utils.test.ts
@@ -1,0 +1,70 @@
+import { sanitizeLogOutput, buildTimeoutDiagnostics } from './cli-utils';
+
+describe('sanitizeLogOutput', () => {
+  it('redacts a single workflow command line', () => {
+    expect(sanitizeLogOutput('::error::message')).toBe('[redacted-workflow-cmd]');
+  });
+
+  it('redacts all workflow command lines in a multiline string', () => {
+    const input = 'safe line\n::warning::secret\nanother safe line\n::set-output name=foo::bar';
+    const result = sanitizeLogOutput(input);
+    expect(result).not.toContain('::warning');
+    expect(result).not.toContain('::set-output');
+    expect(result).toContain('safe line');
+    expect(result).toContain('another safe line');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(sanitizeLogOutput('')).toBe('');
+  });
+
+  it('does not alter text without workflow commands', () => {
+    const text = 'plain output\nno commands here';
+    expect(sanitizeLogOutput(text)).toBe(text);
+  });
+
+  it('handles a chunk exactly at the 500-char boundary without truncation', () => {
+    const clean = 'a'.repeat(500);
+    expect(sanitizeLogOutput(clean)).toBe(clean);
+  });
+
+  it('redacts workflow commands case-insensitively on the command letter', () => {
+    // The regex uses /i so ::Error:: and ::ERROR:: are both matched
+    expect(sanitizeLogOutput('::Error::msg')).toBe('[redacted-workflow-cmd]');
+  });
+});
+
+describe('buildTimeoutDiagnostics', () => {
+  it('includes last stdout and stderr snippets', () => {
+    const result = buildTimeoutDiagnostics('stdout content', 'stderr content');
+    expect(result).toContain('Last stdout: stdout content');
+    expect(result).toContain('stderr: stderr content');
+  });
+
+  it('omits empty parts', () => {
+    expect(buildTimeoutDiagnostics('', '')).toBe('');
+    expect(buildTimeoutDiagnostics('only stdout', '')).toBe('Last stdout: only stdout');
+    expect(buildTimeoutDiagnostics('', 'only stderr')).toBe('stderr: only stderr');
+  });
+
+  it('truncates stdout to last 500 chars', () => {
+    const long = 'x'.repeat(600);
+    const result = buildTimeoutDiagnostics(long, '');
+    expect(result).toContain('Last stdout: ' + 'x'.repeat(500));
+    expect(result).not.toContain('x'.repeat(501));
+  });
+
+  it('truncates stderr to first 500 chars', () => {
+    const long = 'y'.repeat(600);
+    const result = buildTimeoutDiagnostics('', long);
+    expect(result).toContain('stderr: ' + 'y'.repeat(500));
+    expect(result).not.toContain('y'.repeat(501));
+  });
+
+  it('sanitizes workflow commands in both snippets', () => {
+    const result = buildTimeoutDiagnostics('::error::leaked', '::warning::secret');
+    expect(result).not.toContain('::error');
+    expect(result).not.toContain('::warning');
+    expect(result).toContain('[redacted-workflow-cmd]');
+  });
+});

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -1,0 +1,8 @@
+export const STALE_TIMEOUT_MS = 90_000;
+
+/** Strip GitHub Actions workflow commands to prevent injection when logging CLI output. */
+export function sanitizeLogOutput(text: string): string {
+  // Matches any line segment starting with :: followed by a letter — covers all workflow commands
+  // regardless of parameter format (e.g. ::error file=foo.ts,line=5::message)
+  return text.replace(/::[a-z].*$/gim, '[redacted-workflow-cmd]');
+}

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -6,3 +6,13 @@ export function sanitizeLogOutput(text: string): string {
   // regardless of parameter format (e.g. ::error file=foo.ts,line=5::message)
   return text.replace(/::[a-z].*$/gim, '[redacted-workflow-cmd]');
 }
+
+/** Build diagnostic snippets for timeout/stale error messages. */
+export function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: string): string {
+  const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
+  const stderrSnippet = sanitizeLogOutput(stderrText.slice(0, 500));
+  const parts: string[] = [];
+  if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
+  if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
+  return parts.join('. ');
+}

--- a/src/providers/factory.test.ts
+++ b/src/providers/factory.test.ts
@@ -1,11 +1,13 @@
 import * as AnthropicModule from './anthropic';
 import { AnthropicClient } from './anthropic';
 import { OpenAIClient } from './openai';
+import { GeminiClient } from './gemini';
 import { createLLMClient } from './factory';
 import { ProviderName } from './types';
 
 jest.mock('@anthropic-ai/sdk');
 jest.mock('openai');
+jest.mock('@google/generative-ai');
 
 describe('createLLMClient', () => {
   it('returns an AnthropicClient for the anthropic provider', () => {
@@ -51,6 +53,16 @@ describe('createLLMClient', () => {
   it('returns an OpenAIClient for the openai provider with oauth auth', () => {
     const client = createLLMClient('openai', 'o3', { kind: 'oauth', token: 'tok' });
     expect(client).toBeInstanceOf(OpenAIClient);
+  });
+
+  it('returns a GeminiClient for the gemini provider with apiKey auth', () => {
+    const client = createLLMClient('gemini', 'gemini-2.5-flash', { kind: 'apiKey', key: 'gem-key' });
+    expect(client).toBeInstanceOf(GeminiClient);
+  });
+
+  it('returns a GeminiClient for the gemini provider with oauth auth', () => {
+    const client = createLLMClient('gemini', 'gemini-2.5-pro', { kind: 'oauth', token: 'tok' });
+    expect(client).toBeInstanceOf(GeminiClient);
   });
 
   it('throws on unknown provider', () => {

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,5 +1,6 @@
 import { AnthropicClient } from './anthropic';
 import { OpenAIClient } from './openai';
+import { GeminiClient } from './gemini';
 import { LLMClient, ProviderAuth, ProviderName } from './types';
 
 export function createLLMClient(provider: ProviderName, model: string, auth: ProviderAuth): LLMClient {
@@ -8,6 +9,8 @@ export function createLLMClient(provider: ProviderName, model: string, auth: Pro
       return new AnthropicClient({ auth, model });
     case 'openai':
       return new OpenAIClient({ auth, model });
+    case 'gemini':
+      return new GeminiClient({ auth, model });
     default: {
       const exhaustive: never = provider;
       throw new Error(`Unsupported provider: ${exhaustive as string}`);

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -143,6 +143,22 @@ describe('sendMessage effort option (API path)', () => {
     expect(result.content).toBe('hello there');
   });
 
+  it('wraps GoogleGenerativeAIResponseError from .text() with a descriptive message', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => { throw new Error('SAFETY'); } },
+    });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
+
+    await expect(client.sendMessage('system', 'user')).rejects.toThrow('Gemini API returned no usable content: SAFETY');
+  });
+
+  it('propagates SDK errors from generateContent', async () => {
+    mockGenerateContent.mockRejectedValue(new Error('quota exceeded'));
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
+
+    await expect(client.sendMessage('system', 'user')).rejects.toThrow('quota exceeded');
+  });
+
   it('throws when SDK client is not initialized (oauth-only construction)', async () => {
     const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
 

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -286,6 +286,11 @@ describe('GeminiClient OAuth path', () => {
     process.env.CLAUDE_CODE_OAUTH_TOKEN = 'claude-tok';
     process.env.REVIEW_MEMORY_TOKEN = 'mem-tok';
     process.env.GITHUB_TOKEN = 'gh-tok';
+    process.env.GEMINI_API_KEY = 'gem-api';
+    process.env.GITHUB_APP_PRIVATE_KEY = 'pem-key';
+    process.env.INPUT_ANTHROPIC_API_KEY = 'input-sk';
+    process.env.INPUT_GEMINI_API_KEY = 'input-gem';
+    process.env.INPUT_GITHUB_TOKEN = 'input-ghtok';
     try {
       setupOAuthSpawnMock({ stdout: 'ok' });
       const client = new GeminiClient({ auth: { kind: 'oauth', token: 'gem-tok' }, model: 'gemini-3.1-flash-lite' });
@@ -297,6 +302,11 @@ describe('GeminiClient OAuth path', () => {
       expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
       expect(spawnOpts.env.REVIEW_MEMORY_TOKEN).toBeUndefined();
       expect(spawnOpts.env.GITHUB_TOKEN).toBeUndefined();
+      expect(spawnOpts.env.GEMINI_API_KEY).toBeUndefined();
+      expect(spawnOpts.env.GITHUB_APP_PRIVATE_KEY).toBeUndefined();
+      expect(spawnOpts.env.INPUT_ANTHROPIC_API_KEY).toBeUndefined();
+      expect(spawnOpts.env.INPUT_GEMINI_API_KEY).toBeUndefined();
+      expect(spawnOpts.env.INPUT_GITHUB_TOKEN).toBeUndefined();
       expect(spawnOpts.env.GOOGLE_GENAI_USE_GCA).toBe('true');
       expect(spawnOpts.env.GOOGLE_CLOUD_ACCESS_TOKEN).toBe('gem-tok');
     } finally {
@@ -304,6 +314,11 @@ describe('GeminiClient OAuth path', () => {
       delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
       delete process.env.REVIEW_MEMORY_TOKEN;
       delete process.env.GITHUB_TOKEN;
+      delete process.env.GEMINI_API_KEY;
+      delete process.env.GITHUB_APP_PRIVATE_KEY;
+      delete process.env.INPUT_ANTHROPIC_API_KEY;
+      delete process.env.INPUT_GEMINI_API_KEY;
+      delete process.env.INPUT_GITHUB_TOKEN;
     }
   });
 
@@ -348,18 +363,21 @@ describe('GeminiClient OAuth path', () => {
     warnSpy.mockRestore();
   });
 
-  it('warns and proceeds when effort > low is requested on OAuth path', async () => {
-    setupOAuthSpawnMock({ stdout: 'ok' });
-    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
-    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+  it.each(['medium', 'high', 'max'] as const)(
+    'warns and proceeds when effort is %s on OAuth path',
+    async (effort) => {
+      setupOAuthSpawnMock({ stdout: 'ok' });
+      const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+      const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
 
-    const result = await client.sendMessage('sys', 'user', { effort: 'high' });
+      const result = await client.sendMessage('sys', 'user', { effort });
 
-    expect(result.content).toBe('ok');
-    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
-    expect(allWarnings).toContain('does not support effort=high');
-    warnSpy.mockRestore();
-  });
+      expect(result.content).toBe('ok');
+      const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(allWarnings).toContain(`does not support effort=${effort}`);
+      warnSpy.mockRestore();
+    },
+  );
 
   it('does not warn when effort is low or omitted', async () => {
     setupOAuthSpawnMock({ stdout: 'ok' });

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -1,18 +1,40 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { spawn } from 'child_process';
 
-import { buildGeminiAuth, GeminiClient, geminiThinkingBudget } from './gemini';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import * as core from '@actions/core';
+
+import { buildGeminiAuth, GeminiClient, geminiThinkingBudget, resetGeminiCLIInstallPromise } from './gemini';
 import { parseModelSpec } from './model-registry';
+
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+  spawn: jest.fn(),
+}));
 
 jest.mock('@google/generative-ai');
 
+// Container for the execFileAsync mock — must be a plain object so the
+// hoisted jest.mock factory can capture a reference to it before const
+// declarations are initialized.
+const _execMock = { fn: null as jest.Mock | null };
+jest.mock('util', () => ({
+  ...jest.requireActual('util'),
+  promisify: () => (...args: unknown[]) => _execMock.fn!(...args),
+}));
+
+const mockExecFileAsync = jest.fn().mockResolvedValue({ stdout: '/usr/bin/gemini' });
+_execMock.fn = mockExecFileAsync;
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
 describe('GeminiClient', () => {
   it('accepts oauth auth', () => {
-    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
     expect(client).toBeDefined();
   });
 
   it('accepts apiKey auth', () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'key' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'key' }, model: 'gemini-3.1-flash-lite' });
     expect(client).toBeDefined();
   });
 });
@@ -56,18 +78,18 @@ describe('sendMessage effort option (API path)', () => {
   });
 
   it('passes model name and system instruction to getGenerativeModel', async () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
 
     await client.sendMessage('system', 'user');
 
     expect(mockGetGenerativeModel).toHaveBeenCalledWith({
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3.1-flash-lite',
       systemInstruction: 'system',
     });
   });
 
   it('passes user message as content with role user', async () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
 
     await client.sendMessage('system', 'hello world');
 
@@ -76,7 +98,7 @@ describe('sendMessage effort option (API path)', () => {
   });
 
   it('includes thinkingConfig when effort is high', async () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-pro' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-pro-preview' });
 
     await client.sendMessage('system', 'user', { effort: 'high' });
 
@@ -85,7 +107,7 @@ describe('sendMessage effort option (API path)', () => {
   });
 
   it('includes thinkingConfig when effort is medium', async () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
 
     await client.sendMessage('system', 'user', { effort: 'medium' });
 
@@ -94,7 +116,7 @@ describe('sendMessage effort option (API path)', () => {
   });
 
   it('omits thinkingConfig when effort is low', async () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
 
     await client.sendMessage('system', 'user', { effort: 'low' });
 
@@ -103,7 +125,7 @@ describe('sendMessage effort option (API path)', () => {
   });
 
   it('omits thinkingConfig when no options provided', async () => {
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
 
     await client.sendMessage('system', 'user');
 
@@ -115,14 +137,14 @@ describe('sendMessage effort option (API path)', () => {
     mockGenerateContent.mockResolvedValue({
       response: { text: () => 'hello there' },
     });
-    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
 
     const result = await client.sendMessage('system', 'user');
     expect(result.content).toBe('hello there');
   });
 
   it('throws when SDK client is not initialized (oauth-only construction)', async () => {
-    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-2.5-flash' });
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
 
     const sendViaAPI = (GeminiClient.prototype as unknown as Record<string, unknown>)['sendViaAPI'] as (
       systemPrompt: string,
@@ -154,15 +176,456 @@ describe('buildGeminiAuth', () => {
 });
 
 describe('parseModelSpec — gemini detection', () => {
-  it('detects gemini-2.5-flash as gemini provider', () => {
-    expect(parseModelSpec('gemini-2.5-flash')).toEqual({ provider: 'gemini', model: 'gemini-2.5-flash' });
+  it('detects gemini-3.1-flash-lite as gemini provider', () => {
+    expect(parseModelSpec('gemini-3.1-flash-lite')).toEqual({ provider: 'gemini', model: 'gemini-3.1-flash-lite' });
   });
 
-  it('detects gemini-2.5-pro as gemini provider', () => {
-    expect(parseModelSpec('gemini-2.5-pro')).toEqual({ provider: 'gemini', model: 'gemini-2.5-pro' });
+  it('detects gemini-3.1-pro-preview as gemini provider', () => {
+    expect(parseModelSpec('gemini-3.1-pro-preview')).toEqual({ provider: 'gemini', model: 'gemini-3.1-pro-preview' });
   });
 
   it('parses gemini/<model> explicit syntax', () => {
-    expect(parseModelSpec('gemini/gemini-2.5-flash')).toEqual({ provider: 'gemini', model: 'gemini-2.5-flash' });
+    expect(parseModelSpec('gemini/gemini-3.1-flash-lite')).toEqual({ provider: 'gemini', model: 'gemini-3.1-flash-lite' });
+  });
+});
+
+interface MockProc {
+  stdin: { write: jest.Mock; end: jest.Mock; on: jest.Mock };
+  stdout: { on: jest.Mock };
+  stderr: { on: jest.Mock };
+  on: jest.Mock;
+  kill: jest.Mock;
+}
+
+function setupOAuthSpawnMock(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  signal?: string | null;
+}): MockProc {
+  const proc: MockProc = {
+    stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+    stdout: { on: jest.fn() },
+    stderr: { on: jest.fn() },
+    on: jest.fn(),
+    kill: jest.fn(),
+  };
+
+  proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+    if (event === 'data' && opts.stdout) {
+      setTimeout(() => cb(Buffer.from(opts.stdout!)), 0);
+    }
+  });
+  proc.stderr.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+    if (event === 'data' && opts.stderr) {
+      setTimeout(() => cb(Buffer.from(opts.stderr!)), 0);
+    }
+  });
+  proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+    if (event === 'close') {
+      setTimeout(() => cb(opts.exitCode ?? 0, opts.signal ?? null), 5);
+    }
+  });
+
+  mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+  return proc;
+}
+
+describe('GeminiClient OAuth path', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockExecFileAsync.mockReset();
+    mockExecFileAsync.mockResolvedValue({ stdout: '/usr/bin/gemini' });
+    resetGeminiCLIInstallPromise();
+  });
+
+  it('returns trimmed stdout content on success', async () => {
+    setupOAuthSpawnMock({ stdout: '  hello there  \n' });
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+
+    const result = await client.sendMessage('system', 'user');
+    expect(result.content).toBe('hello there');
+  });
+
+  it('strips known provider secrets from forwarded env', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-anthropic';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'claude-tok';
+    process.env.REVIEW_MEMORY_TOKEN = 'mem-tok';
+    process.env.GITHUB_TOKEN = 'gh-tok';
+    try {
+      setupOAuthSpawnMock({ stdout: 'ok' });
+      const client = new GeminiClient({ auth: { kind: 'oauth', token: 'gem-tok' }, model: 'gemini-3.1-flash-lite' });
+
+      await client.sendMessage('sys', 'user');
+
+      const spawnOpts = mockSpawn.mock.calls[0][2] as { env: Record<string, string> };
+      expect(spawnOpts.env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(spawnOpts.env.REVIEW_MEMORY_TOKEN).toBeUndefined();
+      expect(spawnOpts.env.GITHUB_TOKEN).toBeUndefined();
+      expect(spawnOpts.env.GEMINI_OAUTH_TOKEN).toBe('gem-tok');
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      delete process.env.REVIEW_MEMORY_TOKEN;
+      delete process.env.GITHUB_TOKEN;
+    }
+  });
+
+  it('uses untrusted-content delimiter when concatenating prompts on stdin', async () => {
+    const proc = setupOAuthSpawnMock({ stdout: 'ok' });
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+
+    await client.sendMessage('SYS_CONTENT', 'USER_CONTENT');
+
+    const written = (proc.stdin.write.mock.calls[0][0] ?? '') as string;
+    expect(written).toContain('SYS_CONTENT');
+    expect(written).toContain('=== USER CONTENT (untrusted) ===');
+    expect(written).toContain('USER_CONTENT');
+    expect(written).toContain('=== END USER CONTENT ===');
+  });
+
+  it('warns when CLI fails with non-zero exit and sanitizes stderr', async () => {
+    setupOAuthSpawnMock({
+      stderr: '::error::leaked\nplain error',
+      exitCode: 2,
+    });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Gemini CLI invocation failed/);
+
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('[redacted-workflow-cmd]');
+    expect(allWarnings).not.toContain('::error::leaked');
+    warnSpy.mockRestore();
+  });
+
+  it('warns and proceeds when effort > low is requested on OAuth path', async () => {
+    setupOAuthSpawnMock({ stdout: 'ok' });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+
+    const result = await client.sendMessage('sys', 'user', { effort: 'high' });
+
+    expect(result.content).toBe('ok');
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('does not support effort=high');
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn when effort is low or omitted', async () => {
+    setupOAuthSpawnMock({ stdout: 'ok' });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+
+    await client.sendMessage('sys', 'user', { effort: 'low' });
+    const lowWarnings = warnSpy.mock.calls.filter((c) => String(c[0]).includes('does not support effort'));
+    expect(lowWarnings).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to npm install when `which` fails', async () => {
+    mockExecFileAsync.mockReset();
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/gemini' });
+    setupOAuthSpawnMock({ stdout: 'installed-ok' });
+
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    const result = await client.sendMessage('sys', 'user');
+
+    expect(result.content).toBe('installed-ok');
+    const installCall = mockExecFileAsync.mock.calls.find((c) => c[0] === 'npm');
+    expect(installCall).toBeDefined();
+  });
+
+  it('rejects when the CLI install ultimately fails', async () => {
+    mockExecFileAsync.mockReset();
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockRejectedValueOnce(new Error('which still fails'));
+
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Failed to install Gemini CLI/);
+  });
+
+  it('rejects with stderr details when CLI fails on stale timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const proc: MockProc = {
+        stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn(),
+        kill: jest.fn(),
+      };
+      const handlers: Record<string, (code: number | null, signal: string | null) => void> = {};
+      proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+        handlers[event] = cb;
+      });
+      // Emit some stdout first, then go stale.
+      proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') setTimeout(() => cb(Buffer.from('partial output')), 1);
+      });
+      proc.stderr.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') setTimeout(() => cb(Buffer.from('some stderr')), 2);
+      });
+      mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+      const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+      const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+      const promise = client.sendMessage('sys', 'user');
+
+      await jest.advanceTimersByTimeAsync(5);
+      // STALE_TIMEOUT_MS is 90s; advance past it to fire handleStale.
+      await jest.advanceTimersByTimeAsync(91_000);
+      // Now invoke close handler with SIGTERM signal as if kill('SIGTERM') landed.
+      handlers.close?.(null, 'SIGTERM');
+
+      await expect(promise).rejects.toThrow(/Gemini CLI stale/);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(allWarnings).toContain('Gemini CLI stale');
+      warnSpy.mockRestore();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('rejects with timeout message when overall timer fires', async () => {
+    jest.useFakeTimers();
+    try {
+      const proc: MockProc = {
+        stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn(),
+        kill: jest.fn(),
+      };
+      const handlers: Record<string, (code: number | null, signal: string | null) => void> = {};
+      proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+        handlers[event] = cb;
+      });
+      // Keep emitting stdout to bypass the stale timer until the overall timer fires.
+      proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') {
+          for (let i = 0; i < 30; i++) setTimeout(() => cb(Buffer.from(`keepalive-${i}`)), i * 60_000);
+        }
+      });
+      proc.stderr.on.mockImplementation(() => {});
+      mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+      const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+      const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+      const promise = client.sendMessage('sys', 'user');
+
+      await jest.advanceTimersByTimeAsync(1_201_000);
+      handlers.close?.(null, 'SIGTERM');
+
+      await expect(promise).rejects.toThrow(/Gemini CLI timed out after 1200s/);
+      warnSpy.mockRestore();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('rejects when child emits a spawn error before settle', async () => {
+    const proc: MockProc = {
+      stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    proc.stdout.on.mockImplementation(() => {});
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation((event: string, cb: (arg: unknown) => void) => {
+      if (event === 'error') {
+        setTimeout(() => cb(new Error('ENOENT')), 1);
+      }
+    });
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Gemini CLI spawn failed: ENOENT/);
+  });
+
+  it('handles stdin backpressure by waiting for drain before ending', async () => {
+    const proc: MockProc = {
+      stdin: { write: jest.fn().mockReturnValue(false), end: jest.fn(), on: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data') setTimeout(() => cb(Buffer.from('ok')), 0);
+    });
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+      if (event === 'close') setTimeout(() => cb(0, null), 10);
+    });
+
+    const drainCallbacks: Array<() => void> = [];
+    const stdinOnce = jest.fn((event: string, cb: () => void) => {
+      if (event === 'drain') drainCallbacks.push(cb);
+    });
+    (proc.stdin as unknown as { once: jest.Mock }).once = stdinOnce;
+
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    const promise = client.sendMessage('sys', 'user');
+
+    // Allow microtasks to register the drain listener, then fire it.
+    await new Promise((r) => setTimeout(r, 1));
+    expect(stdinOnce).toHaveBeenCalledWith('drain', expect.any(Function));
+    drainCallbacks.forEach((cb) => cb());
+
+    const result = await promise;
+    expect(result.content).toBe('ok');
+    expect(proc.stdin.end).toHaveBeenCalled();
+  });
+
+  it('rejects when stdin.write throws synchronously', async () => {
+    const proc: MockProc = {
+      stdin: {
+        write: jest.fn().mockImplementation(() => { throw new Error('EPIPE'); }),
+        end: jest.fn(),
+        on: jest.fn(),
+      },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    proc.stdout.on.mockImplementation(() => {});
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation(() => {});
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/stdin write failed: EPIPE/);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    warnSpy.mockRestore();
+  });
+
+  it('rejects when output exceeds the 50MB limit', async () => {
+    const proc: MockProc = {
+      stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    const closeHandlers: Array<(code: number | null, signal: string | null) => void> = [];
+    proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+      if (event === 'close') closeHandlers.push(cb);
+    });
+    // Emit a 51MB stdout chunk to trip the limit, then close.
+    const big = Buffer.alloc(51 * 1024 * 1024, 'a');
+    proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data') {
+        setTimeout(() => {
+          cb(big);
+          closeHandlers.forEach((h) => h(null, 'SIGTERM'));
+        }, 0);
+      }
+    });
+    proc.stderr.on.mockImplementation(() => {});
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/exceeded 50MB limit/);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('truncates lastStdoutChunk when a single chunk exceeds 500 chars (used in stale diagnostics)', async () => {
+    jest.useFakeTimers();
+    try {
+      const proc: MockProc = {
+        stdin: { write: jest.fn().mockReturnValue(true), end: jest.fn(), on: jest.fn() },
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn(),
+        kill: jest.fn(),
+      };
+      const handlers: Record<string, (code: number | null, signal: string | null) => void> = {};
+      proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+        handlers[event] = cb;
+      });
+      // Send a single chunk longer than 500 chars to exercise the slice(-500) branch.
+      const longChunk = 'A'.repeat(600) + 'TAIL';
+      proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') setTimeout(() => cb(Buffer.from(longChunk)), 1);
+      });
+      proc.stderr.on.mockImplementation(() => {});
+      mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+      const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+      const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+      const promise = client.sendMessage('sys', 'user');
+      await jest.advanceTimersByTimeAsync(2);
+      await jest.advanceTimersByTimeAsync(91_000);
+      handlers.close?.(null, 'SIGTERM');
+
+      await expect(promise).rejects.toThrow(/Gemini CLI stale/);
+      const warnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warnings).toContain('TAIL');
+      warnSpy.mockRestore();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('logs a warning when stdin emits an async error event', async () => {
+    const stdinHandlers: Record<string, (err: Error) => void> = {};
+    const proc: MockProc = {
+      stdin: {
+        write: jest.fn().mockReturnValue(true),
+        end: jest.fn(),
+        on: jest.fn().mockImplementation((event: string, cb: (err: Error) => void) => {
+          stdinHandlers[event] = cb;
+        }),
+      },
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+      kill: jest.fn(),
+    };
+    proc.stdout.on.mockImplementation((event: string, cb: (data: Buffer) => void) => {
+      if (event === 'data') setTimeout(() => cb(Buffer.from('ok')), 0);
+    });
+    proc.stderr.on.mockImplementation(() => {});
+    proc.on.mockImplementation((event: string, cb: (code: number | null, signal: string | null) => void) => {
+      if (event === 'close') setTimeout(() => cb(0, null), 5);
+    });
+    mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    const promise = client.sendMessage('sys', 'user');
+    await new Promise((r) => setTimeout(r, 1));
+    stdinHandlers.error?.(new Error('broken pipe'));
+    await promise;
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('stdin write error: broken pipe'))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('uses cached CLI path on second invocation', async () => {
+    setupOAuthSpawnMock({ stdout: 'first' });
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    await client.sendMessage('sys', 'user');
+
+    mockExecFileAsync.mockClear();
+    setupOAuthSpawnMock({ stdout: 'second' });
+    const result = await client.sendMessage('sys', 'user');
+    expect(result.content).toBe('second');
+    // No additional `which`/`npm` calls — path is cached on the instance.
+    expect(mockExecFileAsync).not.toHaveBeenCalled();
   });
 });

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -1,0 +1,168 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+import { buildGeminiAuth, GeminiClient, geminiThinkingBudget } from './gemini';
+import { parseModelSpec } from './model-registry';
+
+jest.mock('@google/generative-ai');
+
+describe('GeminiClient', () => {
+  it('accepts oauth auth', () => {
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-2.5-flash' });
+    expect(client).toBeDefined();
+  });
+
+  it('accepts apiKey auth', () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'key' }, model: 'gemini-2.5-flash' });
+    expect(client).toBeDefined();
+  });
+});
+
+describe('geminiThinkingBudget', () => {
+  it('returns undefined for low (no thinking)', () => {
+    expect(geminiThinkingBudget('low')).toBeUndefined();
+  });
+
+  it('returns undefined when effort is omitted', () => {
+    expect(geminiThinkingBudget(undefined)).toBeUndefined();
+  });
+
+  it('returns 5000 for medium', () => {
+    expect(geminiThinkingBudget('medium')).toBe(5000);
+  });
+
+  it('returns 10000 for high', () => {
+    expect(geminiThinkingBudget('high')).toBe(10000);
+  });
+
+  it('returns 10000 for max (clamped to high)', () => {
+    expect(geminiThinkingBudget('max')).toBe(10000);
+  });
+});
+
+describe('sendMessage effort option (API path)', () => {
+  let mockGenerateContent: jest.Mock;
+  let mockGetGenerativeModel: jest.Mock;
+
+  beforeEach(() => {
+    mockGenerateContent = jest.fn().mockResolvedValue({
+      response: { text: () => 'response text' },
+    });
+    mockGetGenerativeModel = jest.fn().mockReturnValue({
+      generateContent: mockGenerateContent,
+    });
+    (GoogleGenerativeAI as unknown as jest.Mock).mockImplementation(() => ({
+      getGenerativeModel: mockGetGenerativeModel,
+    }));
+  });
+
+  it('passes model name and system instruction to getGenerativeModel', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+
+    await client.sendMessage('system', 'user');
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({
+      model: 'gemini-2.5-flash',
+      systemInstruction: 'system',
+    });
+  });
+
+  it('passes user message as content with role user', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+
+    await client.sendMessage('system', 'hello world');
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.contents).toEqual([{ role: 'user', parts: [{ text: 'hello world' }] }]);
+  });
+
+  it('includes thinkingConfig when effort is high', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-pro' });
+
+    await client.sendMessage('system', 'user', { effort: 'high' });
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 10000 });
+  });
+
+  it('includes thinkingConfig when effort is medium', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+
+    await client.sendMessage('system', 'user', { effort: 'medium' });
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 5000 });
+  });
+
+  it('omits thinkingConfig when effort is low', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+
+    await client.sendMessage('system', 'user', { effort: 'low' });
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.generationConfig.thinkingConfig).toBeUndefined();
+  });
+
+  it('omits thinkingConfig when no options provided', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+
+    await client.sendMessage('system', 'user');
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.generationConfig.thinkingConfig).toBeUndefined();
+  });
+
+  it('returns the response text', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => 'hello there' },
+    });
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-2.5-flash' });
+
+    const result = await client.sendMessage('system', 'user');
+    expect(result.content).toBe('hello there');
+  });
+
+  it('throws when SDK client is not initialized (oauth-only construction)', async () => {
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-2.5-flash' });
+
+    const sendViaAPI = (GeminiClient.prototype as unknown as Record<string, unknown>)['sendViaAPI'] as (
+      systemPrompt: string,
+      userMessage: string,
+    ) => Promise<unknown>;
+
+    await expect(sendViaAPI.call(client, 'sys', 'user')).rejects.toThrow('Gemini client not initialized');
+  });
+});
+
+describe('buildGeminiAuth', () => {
+  it('throws when neither token is present', () => {
+    expect(() => buildGeminiAuth('', '')).toThrow(
+      'Either gemini_oauth_token or gemini_api_key must be provided',
+    );
+  });
+
+  it('returns oauth kind when only oauth token is present', () => {
+    expect(buildGeminiAuth('oauth-tok', '')).toEqual({ kind: 'oauth', token: 'oauth-tok' });
+  });
+
+  it('returns apiKey kind when only api key is present', () => {
+    expect(buildGeminiAuth('', 'gem-key')).toEqual({ kind: 'apiKey', key: 'gem-key' });
+  });
+
+  it('oauth wins when both tokens are present', () => {
+    expect(buildGeminiAuth('oauth-tok', 'gem-key')).toEqual({ kind: 'oauth', token: 'oauth-tok' });
+  });
+});
+
+describe('parseModelSpec — gemini detection', () => {
+  it('detects gemini-2.5-flash as gemini provider', () => {
+    expect(parseModelSpec('gemini-2.5-flash')).toEqual({ provider: 'gemini', model: 'gemini-2.5-flash' });
+  });
+
+  it('detects gemini-2.5-pro as gemini provider', () => {
+    expect(parseModelSpec('gemini-2.5-pro')).toEqual({ provider: 'gemini', model: 'gemini-2.5-pro' });
+  });
+
+  it('parses gemini/<model> explicit syntax', () => {
+    expect(parseModelSpec('gemini/gemini-2.5-flash')).toEqual({ provider: 'gemini', model: 'gemini-2.5-flash' });
+  });
+});

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -133,6 +133,24 @@ describe('sendMessage effort option (API path)', () => {
     expect(params.generationConfig.thinkingConfig).toBeUndefined();
   });
 
+  it('sets maxOutputTokens to 16384 when thinking is disabled', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-flash-lite' });
+
+    await client.sendMessage('system', 'user', { effort: 'low' });
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.generationConfig.maxOutputTokens).toBe(16384);
+  });
+
+  it('sets maxOutputTokens to 32768 when thinking is enabled', async () => {
+    const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'k' }, model: 'gemini-3.1-pro-preview' });
+
+    await client.sendMessage('system', 'user', { effort: 'high' });
+
+    const params = mockGenerateContent.mock.calls[0][0];
+    expect(params.generationConfig.maxOutputTokens).toBe(32768);
+  });
+
   it('returns the response text', async () => {
     mockGenerateContent.mockResolvedValue({
       response: { text: () => 'hello there' },

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -263,7 +263,8 @@ describe('GeminiClient OAuth path', () => {
       expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
       expect(spawnOpts.env.REVIEW_MEMORY_TOKEN).toBeUndefined();
       expect(spawnOpts.env.GITHUB_TOKEN).toBeUndefined();
-      expect(spawnOpts.env.GEMINI_OAUTH_TOKEN).toBe('gem-tok');
+      expect(spawnOpts.env.GOOGLE_GENAI_USE_GCA).toBe('true');
+      expect(spawnOpts.env.GOOGLE_CLOUD_ACCESS_TOKEN).toBe('gem-tok');
     } finally {
       delete process.env.ANTHROPIC_API_KEY;
       delete process.env.CLAUDE_CODE_OAUTH_TOKEN;

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -307,6 +307,18 @@ describe('GeminiClient OAuth path', () => {
     }
   });
 
+  it('passes --model flag with the configured model name to the CLI', async () => {
+    setupOAuthSpawnMock({ stdout: 'ok' });
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-pro-preview' });
+
+    await client.sendMessage('sys', 'user');
+
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    const idx = args.indexOf('--model');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('gemini-3.1-pro-preview');
+  });
+
   it('uses untrusted-content delimiter when concatenating prompts on stdin', async () => {
     const proc = setupOAuthSpawnMock({ stdout: 'ok' });
     const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -313,7 +313,12 @@ export class GeminiClient implements LLMClient {
       generationConfig,
     });
 
-    const content = response.response.text();
+    let content: string;
+    try {
+      content = response.response.text();
+    } catch (err) {
+      throw new Error(`Gemini API returned no usable content: ${(err as Error).message}`);
+    }
     core.debug(sanitizeLogOutput(content.slice(0, 200)));
 
     return { content };

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -128,7 +128,10 @@ export class GeminiClient implements LLMClient {
       const child = spawn(cliPath, args, {
         env: {
           ...safeEnv,
-          ...(oauthToken ? { GEMINI_OAUTH_TOKEN: oauthToken } : {}),
+          // The Gemini CLI reads GOOGLE_CLOUD_ACCESS_TOKEN when GOOGLE_GENAI_USE_GCA
+          // is set to authenticate with an existing OAuth access token, per
+          // @google/gemini-cli bundle/chunk-6DSAZLFF.js.
+          ...(oauthToken ? { GOOGLE_GENAI_USE_GCA: 'true', GOOGLE_CLOUD_ACCESS_TOKEN: oauthToken } : {}),
         },
         stdio: ['pipe', 'pipe', 'pipe'],
       });

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -20,7 +20,8 @@ export function buildGeminiAuth(oauthToken: string, apiKey: string): GeminiAuth 
 export function geminiThinkingBudget(effort: SendMessageOptions['effort']): number | undefined {
   if (!effort || effort === 'low') return undefined;
   if (effort === 'medium') return 5000;
-  // 'high' and 'max' both map to the maximum supported budget for Gemini 2.5
+  // 'high' and 'max' both map to the maximum thinking budget supported across
+  // Gemini 2.5/3.x families.
   return 10000;
 }
 
@@ -52,7 +53,7 @@ export class GeminiClient implements LLMClient {
 
   async sendMessage(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
     if (this.auth.kind === 'oauth') {
-      return this.sendViaOAuth(systemPrompt, userMessage);
+      return this.sendViaOAuth(systemPrompt, userMessage, options);
     }
     return this.sendViaAPI(systemPrompt, userMessage, options);
   }
@@ -91,23 +92,42 @@ export class GeminiClient implements LLMClient {
     }
   }
 
-  private async sendViaOAuth(systemPrompt: string, userMessage: string): Promise<LLMResponse> {
-    const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
+  private async sendViaOAuth(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
+    // The Gemini CLI does not currently expose a thinking-budget flag, so any
+    // requested effort beyond `low` is silently unsupported on this path. Surface
+    // it as a warning instead of dropping the option without a trace.
+    if (options?.effort && options.effort !== 'low') {
+      core.warning(
+        `Gemini CLI (OAuth) path does not support effort=${options.effort}; thinking budget is not applied. Use API key auth for thinking-budget control.`,
+      );
+    }
+    // Use a structural delimiter that is harder to spoof from inside diff content
+    // than a bare `---` markdown rule, and explicitly mark the user content as untrusted.
+    const fullPrompt = `${systemPrompt}\n\n=== USER CONTENT (untrusted) ===\n\n${userMessage}\n\n=== END USER CONTENT ===`;
     const cliPath = await this.ensureCLI();
     const oauthToken = this.auth.kind === 'oauth' ? this.auth.token : undefined;
 
     return new Promise((resolve, reject) => {
-      // -p / --prompt enables non-interactive mode reading from stdin via the prompt argument.
+      // Prompt is written to stdin; the CLI reads until EOF and responds on stdout.
       // We pass the full prompt on stdin to avoid argv length limits.
       const args = [
         '--model', this.model,
       ];
 
+      // Strip other providers' secrets from the forwarded env so a compromised
+      // Gemini CLI cannot exfiltrate them. PATH/HOME etc. flow through `safeEnv`.
+      const {
+        ANTHROPIC_API_KEY: _anthropicApiKey,
+        CLAUDE_CODE_OAUTH_TOKEN: _claudeOauthToken,
+        REVIEW_MEMORY_TOKEN: _memoryToken,
+        GITHUB_TOKEN: _githubToken,
+        ...safeEnv
+      } = process.env;
+      void _anthropicApiKey; void _claudeOauthToken; void _memoryToken; void _githubToken;
+
       const child = spawn(cliPath, args, {
         env: {
-          // process.env is spread intentionally — Gemini CLI requires PATH, HOME, and other system vars.
-          // GEMINI_OAUTH_TOKEN is added conditionally. Secrets should be managed via GitHub Actions secret masking.
-          ...process.env,
+          ...safeEnv,
           ...(oauthToken ? { GEMINI_OAUTH_TOKEN: oauthToken } : {}),
         },
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -125,6 +145,7 @@ export class GeminiClient implements LLMClient {
       let stdinKillTimer: NodeJS.Timeout | undefined;
       let lastStdoutChunk = '';
       let rawBytes = 0;
+      let rawStderrBytes = 0;
 
       const clearAllTimers = (): void => {
         clearTimeout(timer);
@@ -174,7 +195,7 @@ export class GeminiClient implements LLMClient {
         staleTimer.unref();
 
         rawBytes += data.length;
-        if (rawBytes + stderr.length > MAX_OUTPUT) { killOnOutputExceeded(); return; }
+        if (rawBytes + rawStderrBytes > MAX_OUTPUT) { killOnOutputExceeded(); return; }
 
         const chunk = stdoutDecoder.write(data);
         if (chunk.length >= 500) {
@@ -187,8 +208,9 @@ export class GeminiClient implements LLMClient {
       });
       child.stderr.on('data', (data: Buffer) => {
         if (outputExceeded || settled) return;
+        rawStderrBytes += data.length;
         stderr += stderrDecoder.write(data);
-        if (rawBytes + stderr.length > MAX_OUTPUT) killOnOutputExceeded();
+        if (rawBytes + rawStderrBytes > MAX_OUTPUT) killOnOutputExceeded();
       });
 
       child.on('close', (code, signal) => {
@@ -227,7 +249,8 @@ export class GeminiClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderr.slice(0, 500)}`;
+          const stderrSnippet = sanitizeLogOutput(stderr.slice(0, 500));
+          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderrSnippet}`;
           core.warning(`Gemini CLI failed (${msg})`);
           reject(new Error(`Gemini CLI invocation failed (${msg})`));
           return;

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -298,7 +298,9 @@ export class GeminiClient implements LLMClient {
     // The underlying REST API accepts `thinkingConfig.thinkingBudget` — pass it
     // through with a cast so we don't have to wait for the SDK types to catch up.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const generationConfig: any = {};
+    const generationConfig: any = {
+      maxOutputTokens: thinkingBudget !== undefined ? 32768 : 16384,
+    };
     if (thinkingBudget !== undefined) {
       generationConfig.thinkingConfig = { thinkingBudget };
     }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -114,16 +114,19 @@ export class GeminiClient implements LLMClient {
         '--model', this.model,
       ];
 
-      // Strip other providers' secrets from the forwarded env so a compromised
-      // Gemini CLI cannot exfiltrate them. PATH/HOME etc. flow through `safeEnv`.
-      const {
-        ANTHROPIC_API_KEY: _anthropicApiKey,
-        CLAUDE_CODE_OAUTH_TOKEN: _claudeOauthToken,
-        REVIEW_MEMORY_TOKEN: _memoryToken,
-        GITHUB_TOKEN: _githubToken,
-        ...safeEnv
-      } = process.env;
-      void _anthropicApiKey; void _claudeOauthToken; void _memoryToken; void _githubToken;
+      // Strip other providers' secrets and all INPUT_* vars (GitHub Actions delivers
+      // every action input as INPUT_<NAME>, which would otherwise bypass bare-name
+      // stripping) from the forwarded env. PATH/HOME etc. flow through `safeEnv`.
+      const BLOCKED_BARE = new Set([
+        'ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN',
+        'REVIEW_MEMORY_TOKEN', 'GITHUB_TOKEN',
+        'GEMINI_API_KEY', 'GITHUB_APP_PRIVATE_KEY',
+      ]);
+      const safeEnv = Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([k]) => !BLOCKED_BARE.has(k) && !/^INPUT_/i.test(k),
+        ),
+      ) as NodeJS.ProcessEnv;
 
       const child = spawn(cliPath, args, {
         env: {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,0 +1,305 @@
+import { execFile, spawn } from 'child_process';
+import { StringDecoder } from 'string_decoder';
+import { promisify } from 'util';
+
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import * as core from '@actions/core';
+
+import { GeminiAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
+import { sanitizeLogOutput, STALE_TIMEOUT_MS } from './anthropic';
+
+const execFileAsync = promisify(execFile);
+
+export function buildGeminiAuth(oauthToken: string, apiKey: string): GeminiAuth {
+  if (oauthToken) return { kind: 'oauth', token: oauthToken };
+  if (apiKey) return { kind: 'apiKey', key: apiKey };
+  throw new Error('Either gemini_oauth_token or gemini_api_key must be provided');
+}
+
+/** Map effort level to Gemini thinking budget. `low` disables thinking entirely. */
+export function geminiThinkingBudget(effort: SendMessageOptions['effort']): number | undefined {
+  if (!effort || effort === 'low') return undefined;
+  if (effort === 'medium') return 5000;
+  // 'high' and 'max' both map to the maximum supported budget for Gemini 2.5
+  return 10000;
+}
+
+let cliInstallPromise: Promise<string> | null = null;
+
+export function resetGeminiCLIInstallPromise(): void {
+  cliInstallPromise = null;
+}
+
+export interface GeminiClientOptions {
+  auth: GeminiAuth;
+  model: string;
+}
+
+export class GeminiClient implements LLMClient {
+  private readonly auth: GeminiAuth;
+  private genAI?: GoogleGenerativeAI;
+  private readonly model: string;
+  private cachedCLIPath?: string;
+
+  constructor(options: GeminiClientOptions) {
+    this.auth = options.auth;
+    this.model = options.model;
+
+    if (this.auth.kind === 'apiKey') {
+      this.genAI = new GoogleGenerativeAI(this.auth.key);
+    }
+  }
+
+  async sendMessage(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
+    if (this.auth.kind === 'oauth') {
+      return this.sendViaOAuth(systemPrompt, userMessage);
+    }
+    return this.sendViaAPI(systemPrompt, userMessage, options);
+  }
+
+  private async ensureCLI(): Promise<string> {
+    if (this.cachedCLIPath) {
+      return this.cachedCLIPath;
+    }
+
+    try {
+      const { stdout } = await execFileAsync('which', ['gemini']);
+      this.cachedCLIPath = stdout.trim();
+      return this.cachedCLIPath;
+    } catch {
+      if (!cliInstallPromise) {
+        cliInstallPromise = (async () => {
+          core.info('Gemini CLI not found, installing via npm...');
+          await execFileAsync('npm', ['install', '-g', '@google/gemini-cli'], {
+            timeout: 120000,
+          });
+          try {
+            const { stdout } = await execFileAsync('which', ['gemini']);
+            return stdout.trim();
+          } catch {
+            throw new Error('Failed to install Gemini CLI');
+          }
+        })();
+      }
+      try {
+        this.cachedCLIPath = await cliInstallPromise;
+        return this.cachedCLIPath;
+      } catch (error) {
+        cliInstallPromise = null;
+        throw error;
+      }
+    }
+  }
+
+  private async sendViaOAuth(systemPrompt: string, userMessage: string): Promise<LLMResponse> {
+    const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
+    const cliPath = await this.ensureCLI();
+    const oauthToken = this.auth.kind === 'oauth' ? this.auth.token : undefined;
+
+    return new Promise((resolve, reject) => {
+      // -p / --prompt enables non-interactive mode reading from stdin via the prompt argument.
+      // We pass the full prompt on stdin to avoid argv length limits.
+      const args = [
+        '--model', this.model,
+      ];
+
+      const child = spawn(cliPath, args, {
+        env: {
+          // process.env is spread intentionally — Gemini CLI requires PATH, HOME, and other system vars.
+          // GEMINI_OAUTH_TOKEN is added conditionally. Secrets should be managed via GitHub Actions secret masking.
+          ...process.env,
+          ...(oauthToken ? { GEMINI_OAUTH_TOKEN: oauthToken } : {}),
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let output = '';
+      let stderr = '';
+      let timedOut = false;
+      let stale = false;
+      let outputExceeded = false;
+      let settled = false;
+      let killTimer: NodeJS.Timeout | undefined;
+      let staleKillTimer: NodeJS.Timeout | undefined;
+      let outputKillTimer: NodeJS.Timeout | undefined;
+      let stdinKillTimer: NodeJS.Timeout | undefined;
+      let lastStdoutChunk = '';
+      let rawBytes = 0;
+
+      const clearAllTimers = (): void => {
+        clearTimeout(timer);
+        clearTimeout(staleTimer);
+        if (killTimer) clearTimeout(killTimer);
+        if (staleKillTimer) clearTimeout(staleKillTimer);
+        if (outputKillTimer) clearTimeout(outputKillTimer);
+        if (stdinKillTimer) clearTimeout(stdinKillTimer);
+      };
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        clearTimeout(staleTimer);
+        child.kill('SIGTERM');
+        killTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        killTimer.unref();
+      }, 1200000);
+      timer.unref();
+
+      const handleStale = (): void => {
+        if (outputExceeded || timedOut) return;
+        stale = true;
+        clearTimeout(timer);
+        child.kill('SIGTERM');
+        staleKillTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        staleKillTimer.unref();
+      };
+      let staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
+      staleTimer.unref();
+
+      const MAX_OUTPUT = 50 * 1024 * 1024; // 50 MB
+      const killOnOutputExceeded = (): void => {
+        if (outputExceeded) return;
+        outputExceeded = true;
+        clearTimeout(timer);
+        clearTimeout(staleTimer);
+        child.kill('SIGTERM');
+        outputKillTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        outputKillTimer.unref();
+      };
+      const stdoutDecoder = new StringDecoder('utf8');
+      const stderrDecoder = new StringDecoder('utf8');
+      child.stdout.on('data', (data: Buffer) => {
+        if (outputExceeded || settled || stale) return;
+        clearTimeout(staleTimer);
+        staleTimer = setTimeout(handleStale, STALE_TIMEOUT_MS);
+        staleTimer.unref();
+
+        rawBytes += data.length;
+        if (rawBytes + stderr.length > MAX_OUTPUT) { killOnOutputExceeded(); return; }
+
+        const chunk = stdoutDecoder.write(data);
+        if (chunk.length >= 500) {
+          lastStdoutChunk = chunk.slice(-500);
+        } else {
+          lastStdoutChunk = (lastStdoutChunk + chunk).slice(-500);
+        }
+        // Gemini CLI emits plain text on stdout — concatenate verbatim.
+        output += chunk;
+      });
+      child.stderr.on('data', (data: Buffer) => {
+        if (outputExceeded || settled) return;
+        stderr += stderrDecoder.write(data);
+        if (rawBytes + stderr.length > MAX_OUTPUT) killOnOutputExceeded();
+      });
+
+      child.on('close', (code, signal) => {
+        clearAllTimers();
+        if (settled) return;
+        settled = true;
+        const remaining = stdoutDecoder.end();
+        if (remaining) output += remaining;
+        stderr += stderrDecoder.end();
+        if (stale) {
+          const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
+          const stderrSnippet = sanitizeLogOutput(stderr.slice(0, 500));
+          const parts: string[] = [];
+          if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
+          if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
+          const details = parts.join('. ');
+          const msg = `Gemini CLI stale — no output for ${STALE_TIMEOUT_MS / 1000}s${details ? `. ${details}` : ''}`;
+          core.warning(msg);
+          reject(new Error(msg));
+          return;
+        }
+        if (timedOut) {
+          const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
+          const stderrSnippet = sanitizeLogOutput(stderr.slice(0, 500));
+          const parts: string[] = [];
+          if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
+          if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
+          const details = parts.join('. ');
+          const msg = `Gemini CLI timed out after 1200s${details ? `. ${details}` : ''}`;
+          core.warning(msg);
+          reject(new Error(msg));
+          return;
+        }
+        if (outputExceeded) {
+          reject(new Error('Gemini CLI output exceeded 50MB limit'));
+          return;
+        }
+        if (code !== 0) {
+          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderr.slice(0, 500)}`;
+          core.warning(`Gemini CLI failed (${msg})`);
+          reject(new Error(`Gemini CLI invocation failed (${msg})`));
+          return;
+        }
+        const content = output.trim();
+        core.debug(sanitizeLogOutput(content.slice(0, 200)));
+        resolve({ content });
+      });
+
+      child.on('error', (error) => {
+        clearAllTimers();
+        if (settled) return;
+        settled = true;
+        reject(new Error(`Gemini CLI spawn failed: ${error.message}`));
+      });
+
+      child.stdin.on('error', (err) => {
+        core.warning(`stdin write error: ${err.message}`);
+      });
+
+      try {
+        const canWrite = child.stdin.write(fullPrompt);
+        if (!canWrite) {
+          child.stdin.once('drain', () => {
+            if (!settled) {
+              try { child.stdin.end(); } catch { /* stream already destroyed */ }
+            }
+          });
+        } else {
+          try { child.stdin.end(); } catch { /* stream may be destroyed */ }
+        }
+      } catch (err) {
+        core.warning(`stdin write failed: ${(err as Error).message}`);
+        if (!settled) {
+          settled = true;
+          clearAllTimers();
+          reject(new Error(`stdin write failed: ${(err as Error).message}`));
+        }
+        try { child.kill('SIGTERM'); } catch { /* already dead */ }
+        stdinKillTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 5000);
+        stdinKillTimer.unref();
+      }
+    });
+  }
+
+  private async sendViaAPI(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse> {
+    if (!this.genAI) throw new Error('Gemini client not initialized');
+
+    const thinkingBudget = geminiThinkingBudget(options?.effort);
+
+    // The SDK type for GenerationConfig predates Gemini 2.5 thinking config.
+    // The underlying REST API accepts `thinkingConfig.thinkingBudget` — pass it
+    // through with a cast so we don't have to wait for the SDK types to catch up.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const generationConfig: any = {};
+    if (thinkingBudget !== undefined) {
+      generationConfig.thinkingConfig = { thinkingBudget };
+    }
+
+    const model = this.genAI.getGenerativeModel({
+      model: this.model,
+      systemInstruction: systemPrompt,
+    });
+
+    const response = await model.generateContent({
+      contents: [{ role: 'user', parts: [{ text: userMessage }] }],
+      generationConfig,
+    });
+
+    const content = response.response.text();
+    core.debug(sanitizeLogOutput(content.slice(0, 200)));
+
+    return { content };
+  }
+}

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -5,8 +5,8 @@ import { promisify } from 'util';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import * as core from '@actions/core';
 
+import { sanitizeLogOutput, STALE_TIMEOUT_MS } from './cli-utils';
 import { GeminiAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
-import { sanitizeLogOutput, STALE_TIMEOUT_MS } from './anthropic';
 
 const execFileAsync = promisify(execFile);
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import * as core from '@actions/core';
 
-import { sanitizeLogOutput, STALE_TIMEOUT_MS } from './cli-utils';
+import { sanitizeLogOutput, STALE_TIMEOUT_MS, buildTimeoutDiagnostics } from './cli-utils';
 import { GeminiAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -221,24 +221,14 @@ export class GeminiClient implements LLMClient {
         if (remaining) output += remaining;
         stderr += stderrDecoder.end();
         if (stale) {
-          const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
-          const stderrSnippet = sanitizeLogOutput(stderr.slice(0, 500));
-          const parts: string[] = [];
-          if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
-          if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
-          const details = parts.join('. ');
+          const details = buildTimeoutDiagnostics(lastStdoutChunk, stderr);
           const msg = `Gemini CLI stale — no output for ${STALE_TIMEOUT_MS / 1000}s${details ? `. ${details}` : ''}`;
           core.warning(msg);
           reject(new Error(msg));
           return;
         }
         if (timedOut) {
-          const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
-          const stderrSnippet = sanitizeLogOutput(stderr.slice(0, 500));
-          const parts: string[] = [];
-          if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
-          if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
-          const details = parts.join('. ');
+          const details = buildTimeoutDiagnostics(lastStdoutChunk, stderr);
           const msg = `Gemini CLI timed out after 1200s${details ? `. ${details}` : ''}`;
           core.warning(msg);
           reject(new Error(msg));

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,10 +1,12 @@
 export { buildAnthropicAuth } from './anthropic';
 export { buildOpenAIAuth } from './openai';
+export { buildGeminiAuth } from './gemini';
 export { createLLMClient } from './factory';
 export { parseModelSpec } from './model-registry';
 export type { ModelSpec } from './model-registry';
 export type {
   AnthropicAuth,
+  GeminiAuth,
   LLMClient,
   LLMResponse,
   OpenAIAuth,

--- a/src/providers/model-registry.test.ts
+++ b/src/providers/model-registry.test.ts
@@ -30,6 +30,14 @@ describe('parseModelSpec', () => {
     expect(parseModelSpec('openai/o3')).toEqual({ provider: 'openai', model: 'o3' });
   });
 
+  it('parses bare gemini model with known prefix', () => {
+    expect(parseModelSpec('gemini-2.5-flash')).toEqual({ provider: 'gemini', model: 'gemini-2.5-flash' });
+  });
+
+  it('parses gemini provider/model syntax', () => {
+    expect(parseModelSpec('gemini/gemini-2.5-pro')).toEqual({ provider: 'gemini', model: 'gemini-2.5-pro' });
+  });
+
   it('throws on bare model with unknown prefix', () => {
     expect(() => parseModelSpec('mistral-large')).toThrow(/Unknown model "mistral-large"/);
   });

--- a/src/providers/model-registry.ts
+++ b/src/providers/model-registry.ts
@@ -5,18 +5,19 @@ export interface ModelSpec {
   model: string;
 }
 
-const KNOWN_PROVIDERS: ReadonlySet<ProviderName> = new Set<ProviderName>(['anthropic', 'openai']);
+const KNOWN_PROVIDERS: ReadonlySet<ProviderName> = new Set<ProviderName>(['anthropic', 'openai', 'gemini']);
 
 const KNOWN_PREFIXES: ReadonlyArray<readonly [RegExp, ProviderName]> = [
   [/^claude-/, 'anthropic'],
   [/^gpt-/, 'openai'],
   [/^o\d/, 'openai'],
+  [/^gemini-/, 'gemini'],
 ];
 
 export function parseModelSpec(input: string): ModelSpec {
   input = input.trim();
   if (!input) {
-    throw new Error('Unknown model "". Use a known prefix (e.g., "claude-...", "gpt-...", "o3...") or "provider/model" syntax.');
+    throw new Error('Unknown model "". Use a known prefix (e.g., "claude-...", "gpt-...", "o3...", "gemini-...") or "provider/model" syntax.');
   }
   const slash = input.indexOf('/');
   if (slash !== -1) {
@@ -37,5 +38,5 @@ export function parseModelSpec(input: string): ModelSpec {
     }
   }
 
-  throw new Error(`Unknown model "${input}". Use a known prefix (e.g., "claude-...", "gpt-...", "o3...") or "provider/model" syntax.`);
+  throw new Error(`Unknown model "${input}". Use a known prefix (e.g., "claude-...", "gpt-...", "o3...", "gemini-...") or "provider/model" syntax.`);
 }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,4 @@
-export type ProviderName = 'anthropic' | 'openai';
+export type ProviderName = 'anthropic' | 'openai' | 'gemini';
 
 export interface LLMResponse {
   content: string;
@@ -20,4 +20,8 @@ export type OpenAIAuth =
   | { kind: 'oauth'; token: string }
   | { kind: 'apiKey'; key: string };
 
-export type ProviderAuth = AnthropicAuth | OpenAIAuth;
+export type GeminiAuth =
+  | { kind: 'oauth'; token: string }
+  | { kind: 'apiKey'; key: string };
+
+export type ProviderAuth = AnthropicAuth | OpenAIAuth | GeminiAuth;


### PR DESCRIPTION
## Summary

Adds Gemini as the third supported provider:

- `GeminiClient` implements `LLMClient` with both API-key (`@google/generative-ai` SDK) and Gemini CLI OAuth transport paths.
- Effort mapping: `low` → no thinking, `medium` → `thinkingBudget: 5000`, `high` → `thinkingBudget: 10000`.
- Model-registry detects `gemini-*`; factory dispatches to `GeminiClient`.
- New action inputs: `gemini_api_key`, `gemini_oauth_token`.

Closes #490