### PR TITLE
fix: render `Force review` checkbox in round-cap notice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manki",
-  "version": "4.5.3",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manki",
-      "version": "4.5.3",
+      "version": "4.7.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3743,6 +3743,12 @@ describe('runFullReview orchestration', () => {
           body: expect.stringContaining('Automatic review is paused'),
         }),
       );
+      const capCall = jest.mocked(mockOctokitInstance.rest.issues.createComment).mock.calls
+        .find(([args]) => typeof args.body === 'string' && args.body.includes('Automatic review is paused'));
+      expect(capCall).toBeDefined();
+      const capBody = capCall![0].body as string;
+      expect(capBody).toContain(FORCE_REVIEW_MARKER);
+      expect(capBody).toContain('- [ ] Force review');
     });
 
     it('bypasses the cap when forceReview is true', async () => {
@@ -3805,6 +3811,12 @@ describe('runFullReview orchestration', () => {
       expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
         expect.objectContaining({ body: expect.stringContaining('Automatic review is paused') }),
       );
+      const capCall = jest.mocked(mockOctokitInstance.rest.issues.createComment).mock.calls
+        .find(([args]) => typeof args.body === 'string' && args.body.includes('Automatic review is paused'));
+      expect(capCall).toBeDefined();
+      const capBody = capCall![0].body as string;
+      expect(capBody).toContain(FORCE_REVIEW_MARKER);
+      expect(capBody).toContain('- [ ] Force review');
     });
 
     it('runs review normally when below cap (test-nit suppression path exercises review.ts, not index.ts)', async () => {
@@ -4325,6 +4337,30 @@ describe('force review checkbox', () => {
 
     expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 42, 'eyes',
+    );
+    // force review bypasses the isReviewInProgress check entirely
+    expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled();
+    expect(mockPullsGet).toHaveBeenCalled();
+  });
+
+  it('routes round-cap notice force review checkbox edit to handleCommentTrigger with forceReview', async () => {
+    // Simulate a round-cap notice that the author has just checked. handleCommentTrigger
+    // must run review with forceReview=true so the cap guard is bypassed.
+    const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Force another round:\n\n- [x] Force review\n\n${FORCE_REVIEW_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'user' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 99, body: capNoticeBody, author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await run();
+
+    expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
+      expect.anything(), 'test-owner', 'test-repo', 99, 'eyes',
     );
     // force review bypasses the isReviewInProgress check entirely
     expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled();

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,11 +538,19 @@ async function runFullReview(
         core.warning(`Failed to delete progress comment: ${error}`);
       }
       try {
+        const body = [
+          PROGRESS_MARKER,
+          `Manki has completed ${priorRoundCount}/${maxAutoRounds} review rounds on this PR. Automatic review is paused. Force another round:`,
+          '',
+          '- [ ] Force review',
+          '',
+          FORCE_REVIEW_MARKER,
+        ].join('\n');
         await octokit.rest.issues.createComment({
           owner,
           repo,
           issue_number: prNumber,
-          body: `${PROGRESS_MARKER}\nManki has completed ${priorRoundCount} review rounds on this PR. Automatic review is paused; comment \`@manki review\` to force another round.`,
+          body,
         });
       } catch (error) {
         core.warning(`Failed to post round-cap notice: ${error}`);


### PR DESCRIPTION
## Summary

After hitting `convergence.max_auto_rounds`, manki posted a notice telling authors to comment `@manki review` — but that comment re-hit the same round-cap guard and re-posted the notice (infinite loop).

This PR replaces the inert prose with the same `Force review` checkbox pattern used by the in-progress skip notice. Reuses the existing `forceReviewChecked` edit-detector. Zero new flags. `@manki review` semantics on PRs that have not hit the cap are unchanged.

Closes [#681](https://github.com/manki-review/manki/issues/681)