### PR TITLE
test: provider smoke harness with CI matrix

### DIFF
--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -13,16 +13,20 @@ jobs:
   smoke:
     name: ${{ matrix.provider }} (${{ matrix.model }})
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         include:
           - provider: anthropic
             model: claude-haiku-4-5
+            effort: low
           - provider: openai
             model: o4-mini
+            effort: low
           - provider: gemini
             model: gemini-2.5-flash
+            effort: low
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +41,7 @@ jobs:
         shell: bash
         env:
           MODEL: ${{ matrix.model }}
+          EFFORT: ${{ matrix.effort }}
           PROVIDER: ${{ matrix.provider }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -46,7 +51,7 @@ jobs:
           GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
         run: |
           set +e
-          npm run smoke -- --model "${MODEL}"
+          npm run smoke -- --model "${MODEL}" --effort "${EFFORT}"
           rc=$?
           if [ $rc -eq 2 ]; then
             echo "::notice title=Smoke skipped::No credentials configured for ${PROVIDER}"

--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -1,0 +1,55 @@
+name: Provider smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays at 09:00 UTC
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: ${{ matrix.provider }} (${{ matrix.model }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: anthropic
+            model: claude-haiku-4-5
+          - provider: openai
+            model: o4-mini
+          - provider: gemini
+            model: gemini-2.5-flash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run smoke
+        shell: bash
+        env:
+          MODEL: ${{ matrix.model }}
+          PROVIDER: ${{ matrix.provider }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
+        run: |
+          set +e
+          npm run smoke -- --model "${MODEL}"
+          rc=$?
+          if [ $rc -eq 2 ]; then
+            echo "::notice title=Smoke skipped::No credentials configured for ${PROVIDER}"
+            exit 0
+          fi
+          exit $rc

--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -51,7 +51,9 @@ jobs:
           GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
         run: |
           set +e
-          npm run smoke -- --model "${MODEL}" --effort "${EFFORT}"
+          EFFORT_ARG=""
+          [ -n "${EFFORT}" ] && EFFORT_ARG="--effort ${EFFORT}"
+          npm run smoke -- --model "${MODEL}" ${EFFORT_ARG}
           rc=$?
           if [ $rc -eq 2 ]; then
             echo "::notice title=Smoke skipped::No credentials configured for ${PROVIDER}"

--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -43,12 +43,12 @@ jobs:
           MODEL: ${{ matrix.model }}
           EFFORT: ${{ matrix.effort }}
           PROVIDER: ${{ matrix.provider }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_OAUTH_TOKEN: ${{ secrets.OPENAI_OAUTH_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_OAUTH_TOKEN: ${{ secrets.GEMINI_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || '' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ matrix.provider == 'anthropic' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          OPENAI_API_KEY: ${{ matrix.provider == 'openai' && secrets.OPENAI_API_KEY || '' }}
+          OPENAI_OAUTH_TOKEN: ${{ matrix.provider == 'openai' && secrets.OPENAI_OAUTH_TOKEN || '' }}
+          GEMINI_API_KEY: ${{ matrix.provider == 'gemini' && secrets.GEMINI_API_KEY || '' }}
+          GEMINI_OAUTH_TOKEN: ${{ matrix.provider == 'gemini' && secrets.GEMINI_OAUTH_TOKEN || '' }}
         run: |
           set +e
           EFFORT_ARG=""

--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -28,9 +28,9 @@ jobs:
             model: gemini-2.5-flash
             effort: low
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: 24
           cache: npm

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,12 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src', '<rootDir>/scripts'],
   testMatch: ['**/*.test.ts'],
-  collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.test.ts',
-    'scripts/**/*.ts',
-    '!scripts/**/*.test.ts',
-  ],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts'],
   moduleNameMapper: {
     '^@octokit/auth-app$': '<rootDir>/src/__mocks__/@octokit/auth-app.ts',
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,12 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src', '<rootDir>/scripts'],
   testMatch: ['**/*.test.ts'],
-  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.test.ts',
+    'scripts/**/*.ts',
+    '!scripts/**/*.test.ts',
+  ],
   moduleNameMapper: {
     '^@octokit/auth-app$': '<rootDir>/src/__mocks__/@octokit/auth-app.ts',
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/scripts'],
   testMatch: ['**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts'],
   moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.0",
+        "tsx": "^4.20.6",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.0.0"
       }
@@ -608,6 +609,448 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -3406,6 +3849,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3942,6 +4427,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -5821,6 +6319,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -6259,6 +6767,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "jest --passWithNoTests",
+    "smoke": "tsx scripts/smoke.ts",
     "all": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "repository": {
@@ -36,6 +37,7 @@
     "eslint": "^9.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.0",
+    "tsx": "^4.20.6",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.0.0"
   }

--- a/scripts/smoke.test.ts
+++ b/scripts/smoke.test.ts
@@ -1,0 +1,65 @@
+import { parseArgs } from './smoke';
+
+describe('parseArgs', () => {
+  describe('--model', () => {
+    it('parses a model flag', () => {
+      expect(parseArgs(['--model', 'claude-haiku-4-5'])).toMatchObject({ model: 'claude-haiku-4-5' });
+    });
+
+    it('throws when --model is missing a value', () => {
+      expect(() => parseArgs(['--model'])).toThrow('--model requires a value.');
+    });
+
+    it('throws when --model is an empty string', () => {
+      expect(() => parseArgs(['--model', ''])).toThrow('--model requires a value.');
+    });
+
+    it('throws when --model is omitted entirely', () => {
+      expect(() => parseArgs([])).toThrow('--model is required');
+    });
+  });
+
+  describe('--effort', () => {
+    it.each(['low', 'medium', 'high', 'max'] as const)('accepts effort=%s', (effort) => {
+      expect(parseArgs(['--model', 'm', '--effort', effort])).toMatchObject({ effort });
+    });
+
+    it('throws on invalid effort value', () => {
+      expect(() => parseArgs(['--model', 'm', '--effort', 'turbo'])).toThrow('Invalid --effort');
+    });
+
+    it('throws when --effort is missing a value', () => {
+      expect(() => parseArgs(['--model', 'm', '--effort'])).toThrow('--effort requires a value.');
+    });
+
+    it('omits effort from result when flag is absent', () => {
+      const result = parseArgs(['--model', 'm']);
+      expect(result.effort).toBeUndefined();
+    });
+  });
+
+  describe('--prompt', () => {
+    it('parses a custom prompt', () => {
+      expect(parseArgs(['--model', 'm', '--prompt', 'hello'])).toMatchObject({ prompt: 'hello' });
+    });
+
+    it('uses the default prompt when --prompt is omitted', () => {
+      const result = parseArgs(['--model', 'm']);
+      expect(result.prompt).toBe('Reply with the single word: OK');
+    });
+
+    it('throws when --prompt is missing a value', () => {
+      expect(() => parseArgs(['--model', 'm', '--prompt'])).toThrow('--prompt requires a non-empty value.');
+    });
+
+    it('throws when --prompt is an empty string', () => {
+      expect(() => parseArgs(['--model', 'm', '--prompt', ''])).toThrow('--prompt requires a non-empty value.');
+    });
+  });
+
+  describe('unknown arguments', () => {
+    it('throws on unrecognised flags', () => {
+      expect(() => parseArgs(['--model', 'm', '--unknown'])).toThrow('Unknown argument: --unknown');
+    });
+  });
+});

--- a/scripts/smoke.test.ts
+++ b/scripts/smoke.test.ts
@@ -62,6 +62,23 @@ describe('parseArgs', () => {
       expect(() => parseArgs(['--model', 'm', '--unknown'])).toThrow('Unknown argument: --unknown');
     });
   });
+
+  describe('--help / -h', () => {
+    it.each(['--help', '-h'])('prints help and exits 0 for %s', (flag) => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        expect(() => parseArgs([flag])).toThrow('process.exit');
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('--model'));
+        expect(exitSpy).toHaveBeenCalledWith(0);
+      } finally {
+        exitSpy.mockRestore();
+        logSpy.mockRestore();
+      }
+    });
+  });
 });
 
 describe('readProviderInputsFromEnv', () => {

--- a/scripts/smoke.test.ts
+++ b/scripts/smoke.test.ts
@@ -1,4 +1,4 @@
-import { parseArgs } from './smoke';
+import { parseArgs, readProviderInputsFromEnv } from './smoke';
 
 describe('parseArgs', () => {
   describe('--model', () => {
@@ -60,6 +60,45 @@ describe('parseArgs', () => {
   describe('unknown arguments', () => {
     it('throws on unrecognised flags', () => {
       expect(() => parseArgs(['--model', 'm', '--unknown'])).toThrow('Unknown argument: --unknown');
+    });
+  });
+});
+
+describe('readProviderInputsFromEnv', () => {
+  const origEnv = process.env;
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('maps each env var to the correct ProviderInputs field', () => {
+    process.env = {
+      CLAUDE_CODE_OAUTH_TOKEN: 'a',
+      ANTHROPIC_API_KEY: 'b',
+      OPENAI_OAUTH_TOKEN: 'c',
+      OPENAI_API_KEY: 'd',
+      GEMINI_OAUTH_TOKEN: 'e',
+      GEMINI_API_KEY: 'f',
+    };
+    expect(readProviderInputsFromEnv()).toEqual({
+      anthropicOauthToken: 'a',
+      anthropicApiKey: 'b',
+      openaiOauthToken: 'c',
+      openaiApiKey: 'd',
+      geminiOauthToken: 'e',
+      geminiApiKey: 'f',
+    });
+  });
+
+  it('returns empty strings when env vars are absent', () => {
+    process.env = {};
+    expect(readProviderInputsFromEnv()).toEqual({
+      anthropicOauthToken: '',
+      anthropicApiKey: '',
+      openaiOauthToken: '',
+      openaiApiKey: '',
+      geminiOauthToken: '',
+      geminiApiKey: '',
     });
   });
 });

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,157 @@
+/* eslint-disable no-console */
+/**
+ * Provider smoke harness. Reuses the production `createLLMClient` + auth
+ * resolution path. Reads credentials from environment variables matching the
+ * action's secret names.
+ *
+ * Usage:
+ *   npm run smoke -- --model <id> [--effort low|medium|high|max] [--prompt <text>]
+ *
+ * Exit codes:
+ *   0  parseable response received
+ *   1  transport / API error / bad arguments
+ *   2  missing credentials for the chosen model's provider
+ */
+
+import {
+  buildAuthForProvider,
+  createLLMClient,
+  parseModelSpec,
+  type ProviderInputs,
+  type SendMessageOptions,
+} from '../src/providers';
+
+interface SmokeArgs {
+  model: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  prompt: string;
+}
+
+const DEFAULT_PROMPT = 'Reply with the single word: OK';
+const SYSTEM_PROMPT = 'You are a smoke-test agent. Reply succinctly.';
+
+function printHelp(): void {
+  console.log(`Usage: npm run smoke -- --model <id> [--effort low|medium|high|max] [--prompt <text>]
+
+Arguments:
+  --model    Required. Any model ID recognised by parseModelSpec.
+             Examples: claude-haiku-4-5, gpt-4o-mini, o4-mini, gemini-2.5-flash.
+             Or use provider/model syntax: anthropic/claude-..., openai/gpt-..., gemini/gemini-...
+  --effort   Optional. low | medium | high | max. Provider behaviour varies.
+  --prompt   Optional. Override the default test prompt.
+  --help     Print this message.
+
+Environment:
+  ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
+  OPENAI_API_KEY, OPENAI_OAUTH_TOKEN
+  GEMINI_API_KEY, GEMINI_OAUTH_TOKEN
+
+Exit codes:
+  0  parseable response received
+  1  transport / API error / bad arguments
+  2  missing credentials for the chosen model's provider
+`);
+}
+
+function parseArgs(): SmokeArgs {
+  const argv = process.argv.slice(2);
+  let model: string | undefined;
+  let effort: SmokeArgs['effort'];
+  let prompt: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--model') {
+      model = argv[++i];
+    } else if (arg === '--effort') {
+      const val = argv[++i];
+      if (val !== 'low' && val !== 'medium' && val !== 'high' && val !== 'max') {
+        throw new Error(`Invalid --effort "${val}". Use: low | medium | high | max.`);
+      }
+      effort = val;
+    } else if (arg === '--prompt') {
+      prompt = argv[++i];
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!model) {
+    throw new Error('--model is required. Run with --help for usage.');
+  }
+  return { model, effort, prompt: prompt ?? DEFAULT_PROMPT };
+}
+
+function readProviderInputsFromEnv(): ProviderInputs {
+  return {
+    anthropicOauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN ?? '',
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? '',
+    openaiOauthToken: process.env.OPENAI_OAUTH_TOKEN ?? '',
+    openaiApiKey: process.env.OPENAI_API_KEY ?? '',
+    geminiOauthToken: process.env.GEMINI_OAUTH_TOKEN ?? '',
+    geminiApiKey: process.env.GEMINI_API_KEY ?? '',
+  };
+}
+
+async function main(): Promise<number> {
+  let args: SmokeArgs;
+  try {
+    args = parseArgs();
+  } catch (err) {
+    console.error((err as Error).message);
+    return 1;
+  }
+
+  let spec: ReturnType<typeof parseModelSpec>;
+  try {
+    spec = parseModelSpec(args.model);
+  } catch (err) {
+    console.error((err as Error).message);
+    return 1;
+  }
+
+  const inputs = readProviderInputsFromEnv();
+  let auth;
+  try {
+    auth = buildAuthForProvider(spec.provider, inputs);
+  } catch (err) {
+    console.error(`No credentials found for provider "${spec.provider}": ${(err as Error).message}`);
+    return 2;
+  }
+
+  const client = createLLMClient(spec.provider, spec.model, auth);
+  const opts: SendMessageOptions = args.effort ? { effort: args.effort } : {};
+
+  console.log(`provider=${spec.provider} model=${spec.model} effort=${args.effort ?? 'default'}`);
+  console.log(`prompt=${JSON.stringify(args.prompt)}`);
+
+  const t0 = Date.now();
+  let response;
+  try {
+    response = await client.sendMessage(SYSTEM_PROMPT, args.prompt, opts);
+  } catch (err) {
+    const ms = Date.now() - t0;
+    console.error(`transport error after ${ms}ms: ${(err as Error).message}`);
+    return 1;
+  }
+  const ms = Date.now() - t0;
+
+  if (typeof response.content !== 'string' || response.content.length === 0) {
+    console.error(`response shape unexpected after ${ms}ms: content=${JSON.stringify(response.content).slice(0, 200)}`);
+    return 1;
+  }
+
+  console.log(`ok latency_ms=${ms} response_chars=${response.content.length}`);
+  console.log('---');
+  console.log(response.content);
+  console.log('---');
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -72,7 +72,7 @@ function parseArgs(): SmokeArgs {
       effort = val;
     } else if (arg === '--prompt') {
       const val = argv[++i];
-      if (val === undefined) throw new Error('--prompt requires a value.');
+      if (!val) throw new Error('--prompt requires a non-empty value.');
       prompt = val;
     } else if (arg === '--help' || arg === '-h') {
       printHelp();

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -17,10 +17,10 @@ import {
   buildAuthForProvider,
   createLLMClient,
   parseModelSpec,
+  sanitizeLogOutput,
   type ProviderInputs,
   type SendMessageOptions,
 } from '../src/providers';
-import { sanitizeLogOutput } from '../src/providers/cli-utils';
 
 interface SmokeArgs {
   model: string;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -87,7 +87,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): SmokeArgs {
   return { model, effort, prompt: prompt ?? DEFAULT_PROMPT };
 }
 
-function readProviderInputsFromEnv(): ProviderInputs {
+export function readProviderInputsFromEnv(): ProviderInputs {
   return {
     anthropicOauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN ?? '',
     anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? '',

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -20,6 +20,7 @@ import {
   type ProviderInputs,
   type SendMessageOptions,
 } from '../src/providers';
+import { sanitizeLogOutput } from '../src/providers/cli-utils';
 
 interface SmokeArgs {
   model: string;
@@ -155,7 +156,7 @@ async function main(): Promise<number> {
 
   console.log(`ok latency_ms=${ms} response_chars=${response.content.length}`);
   console.log('---');
-  console.log(response.content);
+  console.log(sanitizeLogOutput(response.content));
   console.log('---');
   return 0;
 }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -53,8 +53,7 @@ Exit codes:
 `);
 }
 
-function parseArgs(): SmokeArgs {
-  const argv = process.argv.slice(2);
+export function parseArgs(argv: string[] = process.argv.slice(2)): SmokeArgs {
   let model: string | undefined;
   let effort: SmokeArgs['effort'];
   let prompt: string | undefined;
@@ -161,9 +160,11 @@ async function main(): Promise<number> {
   return 0;
 }
 
-main()
-  .then((code) => process.exit(code))
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+if (require.main === module) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -62,14 +62,18 @@ function parseArgs(): SmokeArgs {
     const arg = argv[i];
     if (arg === '--model') {
       model = argv[++i];
+      if (!model) throw new Error('--model requires a value.');
     } else if (arg === '--effort') {
       const val = argv[++i];
+      if (!val) throw new Error('--effort requires a value.');
       if (val !== 'low' && val !== 'medium' && val !== 'high' && val !== 'max') {
         throw new Error(`Invalid --effort "${val}". Use: low | medium | high | max.`);
       }
       effort = val;
     } else if (arg === '--prompt') {
-      prompt = argv[++i];
+      const val = argv[++i];
+      if (val === undefined) throw new Error('--prompt requires a value.');
+      prompt = val;
     } else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -126,10 +130,18 @@ async function main(): Promise<number> {
   console.log(`provider=${spec.provider} model=${spec.model} effort=${args.effort ?? 'default'}`);
   console.log(`prompt=${JSON.stringify(args.prompt)}`);
 
+  const TIMEOUT_MS = 60_000;
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`timed out after ${TIMEOUT_MS}ms`)), TIMEOUT_MS),
+  );
+
   const t0 = Date.now();
   let response;
   try {
-    response = await client.sendMessage(SYSTEM_PROMPT, args.prompt, opts);
+    response = await Promise.race([
+      client.sendMessage(SYSTEM_PROMPT, args.prompt, opts),
+      timeoutPromise,
+    ]);
   } catch (err) {
     const ms = Date.now() - t0;
     console.error(`transport error after ${ms}ms: ${(err as Error).message}`);

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -103,7 +103,7 @@ async function main(): Promise<number> {
   try {
     args = parseArgs();
   } catch (err) {
-    console.error((err as Error).message);
+    console.error(err instanceof Error ? err.message : String(err));
     return 1;
   }
 
@@ -111,7 +111,7 @@ async function main(): Promise<number> {
   try {
     spec = parseModelSpec(args.model);
   } catch (err) {
-    console.error((err as Error).message);
+    console.error(err instanceof Error ? err.message : String(err));
     return 1;
   }
 
@@ -120,7 +120,7 @@ async function main(): Promise<number> {
   try {
     auth = buildAuthForProvider(spec.provider, inputs);
   } catch (err) {
-    console.error(`No credentials found for provider "${spec.provider}": ${(err as Error).message}`);
+    console.error(`No credentials found for provider "${spec.provider}": ${err instanceof Error ? err.message : String(err)}`);
     return 2;
   }
 
@@ -131,9 +131,13 @@ async function main(): Promise<number> {
   console.log(`prompt=${JSON.stringify(args.prompt)}`);
 
   const TIMEOUT_MS = 60_000;
-  const timeoutPromise = new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error(`timed out after ${TIMEOUT_MS}ms`)), TIMEOUT_MS),
-  );
+  let timeoutHandle: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error(`timed out after ${TIMEOUT_MS}ms`)),
+      TIMEOUT_MS,
+    );
+  });
 
   const t0 = Date.now();
   let response;
@@ -144,8 +148,10 @@ async function main(): Promise<number> {
     ]);
   } catch (err) {
     const ms = Date.now() - t0;
-    console.error(`transport error after ${ms}ms: ${(err as Error).message}`);
+    console.error(`transport error after ${ms}ms: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
+  } finally {
+    clearTimeout(timeoutHandle!);
   }
   const ms = Date.now() - t0;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,9 +53,6 @@ jest.mock('./auth', () => ({
 }));
 
 jest.mock('./providers', () => ({
-  buildAnthropicAuth: jest.requireActual('./providers').buildAnthropicAuth,
-  buildOpenAIAuth: jest.requireActual('./providers').buildOpenAIAuth,
-  buildGeminiAuth: jest.requireActual('./providers').buildGeminiAuth,
   buildAuthForProvider: jest.requireActual('./providers').buildAuthForProvider,
   hasAnyProviderCredentials: jest.requireActual('./providers').hasAnyProviderCredentials,
   createLLMClient: jest.fn().mockImplementation(() => ({ sendMessage: jest.fn() })),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -56,6 +56,8 @@ jest.mock('./providers', () => ({
   buildAnthropicAuth: jest.requireActual('./providers').buildAnthropicAuth,
   buildOpenAIAuth: jest.requireActual('./providers').buildOpenAIAuth,
   buildGeminiAuth: jest.requireActual('./providers').buildGeminiAuth,
+  buildAuthForProvider: jest.requireActual('./providers').buildAuthForProvider,
+  hasAnyProviderCredentials: jest.requireActual('./providers').hasAnyProviderCredentials,
   createLLMClient: jest.fn().mockImplementation(() => ({ sendMessage: jest.fn() })),
   parseModelSpec: jest.fn().mockImplementation((m: string) => ({ provider: 'anthropic', model: m })),
 }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
 import { loadConfig, resolveModel } from './config';
-import { buildAnthropicAuth, buildOpenAIAuth, buildGeminiAuth, createLLMClient, parseModelSpec } from './providers';
-import type { LLMClient, ProviderAuth, ProviderName } from './providers';
+import { buildAuthForProvider, createLLMClient, hasAnyProviderCredentials, parseModelSpec } from './providers';
+import type { LLMClient, ProviderAuth, ProviderInputs } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention, parseCommand, isLLMAccessAllowed } from './interaction';
@@ -40,30 +40,6 @@ import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
-interface ProviderInputs {
-  anthropicOauthToken: string;
-  anthropicApiKey: string;
-  openaiOauthToken: string;
-  openaiApiKey: string;
-  geminiOauthToken: string;
-  geminiApiKey: string;
-}
-
-function buildAuthForProvider(provider: ProviderName, inputs: ProviderInputs): ProviderAuth {
-  switch (provider) {
-    case 'anthropic':
-      return buildAnthropicAuth(inputs.anthropicOauthToken, inputs.anthropicApiKey);
-    case 'openai':
-      return buildOpenAIAuth(inputs.openaiOauthToken, inputs.openaiApiKey);
-    case 'gemini':
-      return buildGeminiAuth(inputs.geminiOauthToken, inputs.geminiApiKey);
-    default: {
-      const exhaustive: never = provider;
-      throw new Error(`Unsupported provider: ${exhaustive as string}`);
-    }
-  }
-}
-
 function readProviderInputs(): ProviderInputs {
   return {
     anthropicOauthToken: core.getInput('claude_code_oauth_token'),
@@ -74,11 +50,6 @@ function readProviderInputs(): ProviderInputs {
     geminiApiKey: core.getInput('gemini_api_key'),
   };
 }
-
-function hasAnyProviderCredentials(inputs: ProviderInputs): boolean {
-  return !!(inputs.anthropicOauthToken || inputs.anthropicApiKey || inputs.openaiOauthToken || inputs.openaiApiKey || inputs.geminiOauthToken || inputs.geminiApiKey);
-}
-
 
 function buildLLMClientFromInputs(opts: {
   inputs: ProviderInputs;
@@ -1362,4 +1333,4 @@ function _resetOctokitCache(): void {
   octokitCache.identity = null;
 }
 
-export { run, handlePullRequest, handleCommentTrigger, handleInteraction, handleIssueInteraction, handleReviewCommentInteraction, handleReviewStateCheck, runFullReview, main, _resetOctokitCache, buildAnthropicAuth };
+export { run, handlePullRequest, handleCommentTrigger, handleInteraction, handleIssueInteraction, handleReviewCommentInteraction, handleReviewStateCheck, runFullReview, main, _resetOctokitCache };

--- a/src/providers/auth.test.ts
+++ b/src/providers/auth.test.ts
@@ -54,9 +54,9 @@ describe('buildAuthForProvider', () => {
   });
 
   it('throws for each provider when no matching credential is present', () => {
-    expect(() => buildAuthForProvider('anthropic', empty)).toThrow();
-    expect(() => buildAuthForProvider('openai', empty)).toThrow();
-    expect(() => buildAuthForProvider('gemini', empty)).toThrow();
+    expect(() => buildAuthForProvider('anthropic', empty)).toThrow(/credential|api.?key|token/i);
+    expect(() => buildAuthForProvider('openai', empty)).toThrow(/credential|api.?key|token/i);
+    expect(() => buildAuthForProvider('gemini', empty)).toThrow(/credential|api.?key|token/i);
   });
 
   it('prefers OAuth token over API key when both are present for anthropic', () => {

--- a/src/providers/auth.test.ts
+++ b/src/providers/auth.test.ts
@@ -1,0 +1,61 @@
+import { buildAuthForProvider, hasAnyProviderCredentials, ProviderInputs } from './auth';
+
+const empty: ProviderInputs = {
+  anthropicOauthToken: '',
+  anthropicApiKey: '',
+  openaiOauthToken: '',
+  openaiApiKey: '',
+  geminiOauthToken: '',
+  geminiApiKey: '',
+};
+
+describe('hasAnyProviderCredentials', () => {
+  it('returns false when all six fields are empty', () => {
+    expect(hasAnyProviderCredentials(empty)).toBe(false);
+  });
+
+  it('returns true when any single field is set', () => {
+    for (const key of Object.keys(empty) as (keyof ProviderInputs)[]) {
+      const inputs = { ...empty, [key]: 'x' };
+      expect(hasAnyProviderCredentials(inputs)).toBe(true);
+    }
+  });
+});
+
+describe('buildAuthForProvider', () => {
+  it('routes anthropic to oauth when only the OAuth token is present', () => {
+    const inputs = { ...empty, anthropicOauthToken: 'oauth-tok' };
+    expect(buildAuthForProvider('anthropic', inputs)).toEqual({ kind: 'oauth', token: 'oauth-tok' });
+  });
+
+  it('routes anthropic to apiKey when only the API key is present', () => {
+    const inputs = { ...empty, anthropicApiKey: 'sk-ant' };
+    expect(buildAuthForProvider('anthropic', inputs)).toEqual({ kind: 'apiKey', key: 'sk-ant' });
+  });
+
+  it('routes openai to oauth when only the OAuth token is present', () => {
+    const inputs = { ...empty, openaiOauthToken: 'codex-tok' };
+    expect(buildAuthForProvider('openai', inputs)).toEqual({ kind: 'oauth', token: 'codex-tok' });
+  });
+
+  it('routes openai to apiKey when only the API key is present', () => {
+    const inputs = { ...empty, openaiApiKey: 'sk-openai' };
+    expect(buildAuthForProvider('openai', inputs)).toEqual({ kind: 'apiKey', key: 'sk-openai' });
+  });
+
+  it('routes gemini to oauth when only the OAuth token is present', () => {
+    const inputs = { ...empty, geminiOauthToken: 'gemini-tok' };
+    expect(buildAuthForProvider('gemini', inputs)).toEqual({ kind: 'oauth', token: 'gemini-tok' });
+  });
+
+  it('routes gemini to apiKey when only the API key is present', () => {
+    const inputs = { ...empty, geminiApiKey: 'gemini-key' };
+    expect(buildAuthForProvider('gemini', inputs)).toEqual({ kind: 'apiKey', key: 'gemini-key' });
+  });
+
+  it('throws for each provider when no matching credential is present', () => {
+    expect(() => buildAuthForProvider('anthropic', empty)).toThrow();
+    expect(() => buildAuthForProvider('openai', empty)).toThrow();
+    expect(() => buildAuthForProvider('gemini', empty)).toThrow();
+  });
+});

--- a/src/providers/auth.test.ts
+++ b/src/providers/auth.test.ts
@@ -73,4 +73,9 @@ describe('buildAuthForProvider', () => {
     const inputs = { ...empty, geminiOauthToken: 'gemini-tok', geminiApiKey: 'gemini-key' };
     expect(buildAuthForProvider('gemini', inputs)).toEqual({ kind: 'oauth', token: 'gemini-tok' });
   });
+
+  it('throws for an unsupported/unknown provider', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => buildAuthForProvider('unknown' as any, empty)).toThrow('Unsupported provider: unknown');
+  });
 });

--- a/src/providers/auth.test.ts
+++ b/src/providers/auth.test.ts
@@ -58,4 +58,19 @@ describe('buildAuthForProvider', () => {
     expect(() => buildAuthForProvider('openai', empty)).toThrow();
     expect(() => buildAuthForProvider('gemini', empty)).toThrow();
   });
+
+  it('prefers OAuth token over API key when both are present for anthropic', () => {
+    const inputs = { ...empty, anthropicOauthToken: 'oauth-tok', anthropicApiKey: 'sk-ant' };
+    expect(buildAuthForProvider('anthropic', inputs)).toEqual({ kind: 'oauth', token: 'oauth-tok' });
+  });
+
+  it('prefers OAuth token over API key when both are present for openai', () => {
+    const inputs = { ...empty, openaiOauthToken: 'codex-tok', openaiApiKey: 'sk-openai' };
+    expect(buildAuthForProvider('openai', inputs)).toEqual({ kind: 'oauth', token: 'codex-tok' });
+  });
+
+  it('prefers OAuth token over API key when both are present for gemini', () => {
+    const inputs = { ...empty, geminiOauthToken: 'gemini-tok', geminiApiKey: 'gemini-key' };
+    expect(buildAuthForProvider('gemini', inputs)).toEqual({ kind: 'oauth', token: 'gemini-tok' });
+  });
 });

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -1,0 +1,39 @@
+import { buildAnthropicAuth } from './anthropic';
+import { buildGeminiAuth } from './gemini';
+import { buildOpenAIAuth } from './openai';
+import { ProviderAuth, ProviderName } from './types';
+
+export interface ProviderInputs {
+  anthropicOauthToken: string;
+  anthropicApiKey: string;
+  openaiOauthToken: string;
+  openaiApiKey: string;
+  geminiOauthToken: string;
+  geminiApiKey: string;
+}
+
+export function buildAuthForProvider(provider: ProviderName, inputs: ProviderInputs): ProviderAuth {
+  switch (provider) {
+    case 'anthropic':
+      return buildAnthropicAuth(inputs.anthropicOauthToken, inputs.anthropicApiKey);
+    case 'openai':
+      return buildOpenAIAuth(inputs.openaiOauthToken, inputs.openaiApiKey);
+    case 'gemini':
+      return buildGeminiAuth(inputs.geminiOauthToken, inputs.geminiApiKey);
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unsupported provider: ${exhaustive as string}`);
+    }
+  }
+}
+
+export function hasAnyProviderCredentials(inputs: ProviderInputs): boolean {
+  return !!(
+    inputs.anthropicOauthToken ||
+    inputs.anthropicApiKey ||
+    inputs.openaiOauthToken ||
+    inputs.openaiApiKey ||
+    inputs.geminiOauthToken ||
+    inputs.geminiApiKey
+  );
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 export { buildAuthForProvider, hasAnyProviderCredentials } from './auth';
 export type { ProviderInputs } from './auth';
+export { sanitizeLogOutput } from './cli-utils';
 export { createLLMClient } from './factory';
 export { parseModelSpec } from './model-registry';
 export type { ModelSpec } from './model-registry';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,3 @@
-export { buildAnthropicAuth } from './anthropic';
-export { buildOpenAIAuth } from './openai';
-export { buildGeminiAuth } from './gemini';
 export { buildAuthForProvider, hasAnyProviderCredentials } from './auth';
 export type { ProviderInputs } from './auth';
 export { createLLMClient } from './factory';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,8 @@
 export { buildAnthropicAuth } from './anthropic';
 export { buildOpenAIAuth } from './openai';
 export { buildGeminiAuth } from './gemini';
+export { buildAuthForProvider, hasAnyProviderCredentials } from './auth';
+export type { ProviderInputs } from './auth';
 export { createLLMClient } from './factory';
 export { parseModelSpec } from './model-registry';
 export type { ModelSpec } from './model-registry';


### PR DESCRIPTION
## Summary
- Adds local script and CI matrix to exercise each provider's auth and effort knobs against real credentials, no full review required
- Extracts `buildAuthForProvider` and `ProviderInputs` to `providers/auth` so the harness and the action share one auth code path

Closes #693

Part of #652 (v5.0.0).