### PR TITLE
chore: deprecation warning for `claude_code_oauth_token`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -196,7 +196,11 @@ describe('run', () => {
     it('warns once when claude_code_oauth_token is set', async () => {
       setContext({
         eventName: 'pull_request',
-        payload: { action: 'opened', sender: { login: 'dependabot[bot]', type: 'Bot' } },
+        payload: {
+          action: 'opened',
+          sender: { login: 'alice', type: 'User' },
+          pull_request: { number: 1, head: { sha: 'abc' }, base: { ref: 'main' } },
+        },
       });
       jest.mocked(core.getInput).mockImplementation((name: string) =>
         name === 'claude_code_oauth_token' ? 'oauth-tok' : '',
@@ -204,6 +208,7 @@ describe('run', () => {
 
       await run();
 
+      expect(jest.mocked(core.warning)).toHaveBeenCalledTimes(1);
       expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
         expect.stringContaining('`claude_code_oauth_token` is deprecated'),
       );
@@ -212,7 +217,11 @@ describe('run', () => {
     it('does not warn when claude_code_oauth_token is unset', async () => {
       setContext({
         eventName: 'pull_request',
-        payload: { action: 'opened', sender: { login: 'dependabot[bot]', type: 'Bot' } },
+        payload: {
+          action: 'opened',
+          sender: { login: 'alice', type: 'User' },
+          pull_request: { number: 1, head: { sha: 'abc' }, base: { ref: 'main' } },
+        },
       });
 
       await run();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,6 +192,37 @@ describe('run', () => {
     );
   });
 
+  describe('claude_code_oauth_token deprecation warning', () => {
+    it('warns once when claude_code_oauth_token is set', async () => {
+      setContext({
+        eventName: 'pull_request',
+        payload: { action: 'opened', sender: { login: 'dependabot[bot]', type: 'Bot' } },
+      });
+      jest.mocked(core.getInput).mockImplementation((name: string) =>
+        name === 'claude_code_oauth_token' ? 'oauth-tok' : '',
+      );
+
+      await run();
+
+      expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
+        expect.stringContaining('`claude_code_oauth_token` is deprecated'),
+      );
+    });
+
+    it('does not warn when claude_code_oauth_token is unset', async () => {
+      setContext({
+        eventName: 'pull_request',
+        payload: { action: 'opened', sender: { login: 'dependabot[bot]', type: 'Bot' } },
+      });
+
+      await run();
+
+      expect(jest.mocked(core.warning)).not.toHaveBeenCalledWith(
+        expect.stringContaining('`claude_code_oauth_token` is deprecated'),
+      );
+    });
+  });
+
   describe('bot self-triggering prevention', () => {
     it('ignores events from any bot sender', async () => {
       setContext({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -208,10 +208,10 @@ describe('run', () => {
 
       await run();
 
-      expect(jest.mocked(core.warning)).toHaveBeenCalledTimes(1);
-      expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
-        expect.stringContaining('`claude_code_oauth_token` is deprecated'),
+      const deprecationCalls = jest.mocked(core.warning).mock.calls.filter(([msg]) =>
+        typeof msg === 'string' && msg.includes('`claude_code_oauth_token` is deprecated'),
       );
+      expect(deprecationCalls).toHaveLength(1);
     });
 
     it('does not warn when claude_code_oauth_token is unset', async () => {
@@ -223,6 +223,7 @@ describe('run', () => {
           pull_request: { number: 1, head: { sha: 'abc' }, base: { ref: 'main' } },
         },
       });
+      jest.mocked(core.getInput).mockImplementation(() => '');
 
       await run();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,13 @@ async function run(): Promise<void> {
 
   core.info(`Event: ${eventName}, Action: ${action}`);
 
+  if (core.getInput('claude_code_oauth_token')) {
+    core.warning(
+      '`claude_code_oauth_token` is deprecated. Anthropic restricts Claude Code OAuth tokens for third-party tools. ' +
+      'Use `anthropic_api_key` instead, or switch to `openai_oauth_token` (Codex CLI) or `gemini_oauth_token` (Gemini CLI) for subscription-based access.',
+    );
+  }
+
   // Prevent self-triggering — skip events caused by any bot
   const senderType = github.context.payload.sender?.type ?? '';
   const reviewAuthorType = github.context.payload.review?.user?.type ?? '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,13 +128,6 @@ async function run(): Promise<void> {
 
   core.info(`Event: ${eventName}, Action: ${action}`);
 
-  if (core.getInput('claude_code_oauth_token')) {
-    core.warning(
-      '`claude_code_oauth_token` is deprecated. Anthropic restricts Claude Code OAuth tokens for third-party tools. ' +
-      'Use `anthropic_api_key` instead, or switch to `openai_oauth_token` (Codex CLI) or `gemini_oauth_token` (Gemini CLI) for subscription-based access.',
-    );
-  }
-
   // Prevent self-triggering — skip events caused by any bot
   const senderType = github.context.payload.sender?.type ?? '';
   const reviewAuthorType = github.context.payload.review?.user?.type ?? '';
@@ -144,6 +137,13 @@ async function run(): Promise<void> {
       : (github.context.payload.review?.user?.login ?? 'unknown bot');
     core.info(`Ignoring event from bot: ${actor}`);
     return;
+  }
+
+  if (core.getInput('claude_code_oauth_token')) {
+    core.warning(
+      '`claude_code_oauth_token` is deprecated. Anthropic restricts Claude Code OAuth tokens for third-party tools. ' +
+      'Use `anthropic_api_key` instead, or use `openai_oauth_token` / `gemini_oauth_token` once provider OAuth paths are stable in v5.0.0.',
+    );
   }
 
   // Event filtering — exit immediately for irrelevant events.

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ async function run(): Promise<void> {
   if (core.getInput('claude_code_oauth_token')) {
     core.warning(
       '`claude_code_oauth_token` is deprecated. Anthropic restricts Claude Code OAuth tokens for third-party tools. ' +
-      'Use `anthropic_api_key` instead, or use `openai_oauth_token` / `gemini_oauth_token` once provider OAuth paths are stable in v5.0.0.',
+      'Use `anthropic_api_key` instead, or use `openai_oauth_token` / `gemini_oauth_token` once those provider OAuth paths are stable.',
     );
   }
 


### PR DESCRIPTION
## Summary
- Emits a deprecation warning when `claude_code_oauth_token` is set, pointing users at the new provider auth flows
- Token still works, just nudges migration ahead of v5.0.0

Closes #491

Part of #652 (v5.0.0).