### PR TITLE
docs: provider auth flows for OpenAI and Gemini

### DIFF
--- a/.manki.yml.example
+++ b/.manki.yml.example
@@ -49,12 +49,22 @@
 #   agents:
 #     "Security & Safety": claude-opus-4-7
 #
-# To use Gemini, set `gemini_api_key` (or `gemini_oauth_token`) and override models:
+# To use OpenAI, set `openai_api_key` (or `openai_oauth_token` for Codex CLI) and override models:
 # models:
-#   planner: gemini-3.1-flash-lite
-#   reviewer: gemini-3.1-flash-lite
-#   judge: gemini-3.1-pro-preview
-#   dedup: gemini-3.1-flash-lite
+#   planner: gpt-4o-mini
+#   reviewer: gpt-4o-mini
+#   judge: o4-mini
+#   dedup: gpt-4o-mini
+#
+# To use Gemini, set `gemini_api_key` (or `gemini_oauth_token` for Gemini CLI) and override models:
+# models:
+#   planner: gemini-2.5-flash
+#   reviewer: gemini-2.5-flash
+#   judge: gemini-2.5-pro
+#   dedup: gemini-2.5-flash
+#
+# Models are auto-detected by prefix: `claude-*` -> Anthropic, `gpt-*` / `o*` -> OpenAI, `gemini-*` -> Gemini.
+# You can also use explicit `provider/model` syntax (e.g. `anthropic/claude-haiku-4-5`).
 
 # Planner stage (default: enabled)
 # When enabled and review_level is "auto", a fast pre-review pass chooses the

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Manki assembles a dynamic review team sized to your PR's content and complexity.
 - **Multi-stage pipeline** — a planner picks the team, agents review in parallel, dedup catches repeats from prior reviews, a judge filters noise and classifies findings by severity
 - **Adaptive team sizing** — 1, 3, 5, or 7 reviewers chosen per PR based on content and complexity
 - **Smart verdicts** — blocks PRs on real issues, approves over style nitpicks; auto-approves when all blocking threads resolve
+- **Multi-provider** — Anthropic, OpenAI, and Gemini, mix-and-match per agent via `.manki.yml`
 - **Self-learning memory** — `/manki remember` teaches conventions, `/manki dismiss` suppresses false positives, patterns stick across PRs
 - **Conversational** — reply to any review comment to discuss, or use `@manki explain`/`triage`/`forget` inline
 - **Self-hosted GitHub Action** — your API key, your compute, no SaaS intermediary
@@ -29,7 +30,7 @@ Manki assembles a dynamic review team sized to your PR's content and complexity.
 ## Quick start
 
 1. **Install the app** — [github.com/apps/manki-review](https://github.com/apps/manki-review)
-2. **Add a Claude secret** — `gh secret set CLAUDE_CODE_OAUTH_TOKEN`
+2. **Add a provider secret** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` (OAuth subscription paths are also supported, see [SETUP.md](SETUP.md#choosing-a-provider))
 3. **Add the workflow** — copy the YAML from the [Setup Guide](SETUP.md#step-3-add-the-workflow)
 
 Full setup guide with memory, triage, and troubleshooting: **[SETUP.md](SETUP.md)**

--- a/SETUP.md
+++ b/SETUP.md
@@ -83,7 +83,7 @@ The app requires these permissions:
 
 ### Choosing a provider
 
-Manki supports Anthropic, OpenAI, and Gemini. You only need credentials for the provider(s) you actually use. The model ID in `.manki.yml` selects the provider automatically (`claude-*` routes to Anthropic, `gpt-*` and `o*` to OpenAI, `gemini-*` to Gemini), or use `provider/model` syntax to be explicit.
+Manki supports Anthropic, OpenAI, and Gemini. You only need credentials for the provider(s) you actually use. The model ID in `.manki.yml` selects the provider automatically (`claude-*` routes to Anthropic, `gpt-*` and `o1`/`o3`/`o4`/... to OpenAI, `gemini-*` to Gemini), or use `provider/model` syntax to be explicit.
 
 | Provider | API key input | OAuth input |
 |----------|--------------|-------------|
@@ -104,7 +104,7 @@ The `low | medium | high | max` knobs map per provider as follows. Manki passes 
 | high   | `budget_tokens: 10000` | `reasoning_effort: high` | (ignored, warning) | `thinkingBudget: 10000` |
 | max    | `budget_tokens: 16000` | `reasoning_effort: high` (collapsed) | (ignored, warning) | `thinkingBudget: 10000` (collapsed) |
 
-The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
+The `max` tier collapses silently to `high` for OpenAI o-series and Gemini — no warning is emitted, unlike the GPT non-reasoning path which logs a warning when effort is ignored. The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
 
 ### Anthropic
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -139,18 +139,19 @@ gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>
 
 Reasoning models (`o1`, `o3`, `o4`, ...) accept the effort tiers above. Non-reasoning chat models (`gpt-4o`, `gpt-4.1`, ...) ignore effort and log a warning.
 
-#### Codex CLI OAuth Token (subscription)
+#### Codex CLI OAuth Token (subscription, experimental)
 
-If you have a ChatGPT Plus or Pro subscription, the Codex CLI generates an OAuth token that the action can ride to avoid per-token API charges.
+> **Status: experimental for CI.** The Codex CLI stores subscription auth in `~/.codex/auth.json` as short-lived tokens (`access_token` ~1h) refreshed automatically when the CLI runs. For CI workflows, use the API-key path above unless you can keep the secret refreshed externally.
 
-1. Install the Codex CLI: `npm install -g @openai/codex`
-2. Run `codex login` and complete the browser flow
-3. Bootstrap the secret from `~/.codex/auth.json`:
+If you have a ChatGPT Plus or Pro subscription and the Codex CLI installed:
+
+1. Run `codex login` and complete the browser flow. This populates `~/.codex/auth.json`.
+2. Bootstrap the secret from that file:
    ```bash
    cat ~/.codex/auth.json | base64 | gh secret set OPENAI_OAUTH_TOKEN --repo <owner>/<repo>
    ```
    The secret must be the base64-encoded contents of `~/.codex/auth.json`, which contains `tokens.access_token` and `tokens.refresh_token`. Re-run when the refresh token expires.
-4. The workflow needs to install the Codex CLI on the runner (see [Step 3](#step-3-add-the-workflow))
+3. The workflow needs to install the Codex CLI on the runner (see [Step 3](#step-3-add-the-workflow))
 
 ### Gemini
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -568,12 +568,12 @@ Each review run posts fresh inline comments. The recap phase deduplicates agains
 
 | Secret | Required | Purpose |
 |--------|----------|---------|
-| `ANTHROPIC_API_KEY` | Yes* | Anthropic API auth |
-| `CLAUDE_CODE_OAUTH_TOKEN` | Yes* | Claude Max subscription auth (deprecated) |
-| `OPENAI_OAUTH_TOKEN` | No | Base64-encoded `~/.codex/auth.json` for Codex CLI OAuth |
-| `OPENAI_API_KEY` | No | OpenAI API key (alternative to Codex OAuth) |
-| `GEMINI_OAUTH_TOKEN` | No | Base64-encoded `~/.gemini/oauth_creds.json` for Gemini CLI OAuth |
-| `GEMINI_API_KEY` | No | Google Generative AI API key (alternative to Gemini OAuth) |
+| `ANTHROPIC_API_KEY` | Yes† | Anthropic API auth |
+| `CLAUDE_CODE_OAUTH_TOKEN` | No (deprecated) | Claude Max subscription auth (deprecated, prefer `ANTHROPIC_API_KEY`) |
+| `OPENAI_API_KEY` | Yes† | OpenAI API key |
+| `OPENAI_OAUTH_TOKEN` | Yes† | Base64-encoded `~/.codex/auth.json` for Codex CLI OAuth |
+| `GEMINI_API_KEY` | Yes† | Google Generative AI API key |
+| `GEMINI_OAUTH_TOKEN` | Yes† | Base64-encoded `~/.gemini/oauth_creds.json` for Gemini CLI OAuth |
 | `REVIEW_MEMORY_TOKEN` | No | Fine-grained PAT for memory repo writes |
 
-\* At least one provider credential is required. The active provider for each agent is selected by the model ID in `.manki.yml`.
+† At least one provider credential is required — pick one auth method from one provider. The active provider per agent is selected by the model ID in `.manki.yml`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -258,7 +258,7 @@ OpenAI Codex CLI OAuth (requires the CLI on the runner):
 
 ```yaml
       - name: Install Codex CLI
-        # --ignore-scripts is safe: @openai/codex@0.129.0 ships a plain JS bin with no postinstall steps.
+        # --ignore-scripts is safe: @openai/codex@0.129.0 ships a plain JS bin with no postinstall steps. Re-verify if you bump the version pin.
         run: npm install -g --ignore-scripts '@openai/codex@0.129.0'
       - name: Manki Review
         uses: manki-review/manki@v5

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,16 +10,20 @@ Install [Manki](https://github.com/apps/manki-review) on the repositories you wa
 
 ### 2. Add Secrets
 
-Add your Claude authentication to the repository:
+Manki supports three providers. Add credentials for the one you want to use:
 
 ```bash
-# Option A: Claude Max subscription (no extra API costs)
-claude setup-token
-gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>
-
-# Option B: Anthropic API key (pay-per-use)
+# Anthropic (default)
 gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
+
+# OpenAI
+gh secret set OPENAI_API_KEY --repo <owner>/<repo>
+
+# Gemini
+gh secret set GEMINI_API_KEY --repo <owner>/<repo>
 ```
+
+OAuth alternatives that ride your existing CLI subscription are also supported. See [Step 2](#step-2-authentication-secrets) for the full matrix.
 
 ### 3. Add the Workflow
 
@@ -30,7 +34,7 @@ Create `.github/workflows/manki.yml` -- see [full workflow below](#step-3-add-th
 ## Prerequisites
 
 - A GitHub repository
-- A Claude Max subscription (or Anthropic API key)
+- Credentials for at least one provider (Anthropic, OpenAI, or Gemini)
 - Repository admin access (for settings changes)
 
 ### Enable GitHub Actions PR Approval
@@ -77,23 +81,34 @@ The app requires these permissions:
 
 > **When do you need a GitHub token?** If you installed the GitHub App (Step 1), you do **not** need to pass `github_token` -- the App handles PR access. The `memory_repo_token` input is only required when your memory repo is a **separate** repository (the App can't reach it). Users who skip the GitHub App can fall back to `github_token: ${{ secrets.GITHUB_TOKEN }}`.
 
-### Claude Code OAuth Token (Max Subscription)
+### Choosing a provider
 
-This allows the action to use your Claude Max subscription -- no extra API costs.
+Manki supports Anthropic, OpenAI, and Gemini. You only need credentials for the provider(s) you actually use. The model ID in `.manki.yml` selects the provider automatically (`claude-*` routes to Anthropic, `gpt-*` and `o*` to OpenAI, `gemini-*` to Gemini), or use `provider/model` syntax to be explicit.
 
-1. Run locally:
-   ```bash
-   claude setup-token
-   ```
-2. Copy the generated token
-3. Add as a repository secret:
-   ```bash
-   gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>
-   ```
+| Provider | API key input | OAuth input |
+|----------|--------------|-------------|
+| Anthropic | `anthropic_api_key` | `claude_code_oauth_token` (deprecated, see note) |
+| OpenAI | `openai_api_key` | `openai_oauth_token` (Codex CLI) |
+| Gemini | `gemini_api_key` | `gemini_oauth_token` (Gemini CLI) |
 
-**OR**
+> **`claude_code_oauth_token` is deprecated.** Anthropic restricted Claude Code OAuth tokens for third-party tools on April 4, 2026. The input still works and the action emits a one-line `core.warning` per run. New setups should use `anthropic_api_key`. If you want a subscription-based path with no extra API charges, switch to `openai_oauth_token` (Codex CLI) or `gemini_oauth_token` (Gemini CLI).
 
-### Anthropic API Key (Pay-per-use)
+#### Effort mapping
+
+The `low | medium | high | max` knobs map per provider as follows. Manki passes effort tiers per stage and per agent based on planner decisions and config.
+
+| Effort | Anthropic | OpenAI o-series | OpenAI GPT | Gemini |
+|--------|-----------|-----------------|------------|--------|
+| low    | no thinking | `reasoning_effort: low` | (ignored, warning) | no thinking |
+| medium | `budget_tokens: 5000` | `reasoning_effort: medium` | (ignored, warning) | `thinkingBudget: 5000` |
+| high   | `budget_tokens: 10000` | `reasoning_effort: high` | (ignored, warning) | `thinkingBudget: 10000` |
+| max    | `budget_tokens: 16000` | `reasoning_effort: high` (collapsed) | (ignored, warning) | `thinkingBudget: 10000` (collapsed) |
+
+The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
+
+### Anthropic
+
+#### Anthropic API Key (recommended)
 
 1. Get your API key from [console.anthropic.com](https://console.anthropic.com)
 2. Add as a repository secret:
@@ -101,47 +116,64 @@ This allows the action to use your Claude Max subscription -- no extra API costs
    gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
    ```
 
-### OpenAI (Optional)
+#### Claude Code OAuth Token (deprecated)
 
-Use OpenAI models (via API key or Codex CLI OAuth) instead of Claude.
+Older setups used `claude_code_oauth_token` to ride a Claude Max subscription. Anthropic restricted this token type for third-party tools on April 4, 2026. Existing tokens still work, the action prints a deprecation warning. New installations should use `ANTHROPIC_API_KEY` or one of the other providers below.
 
-**Option A: OpenAI API key**
-
-```bash
-gh secret set OPENAI_API_KEY --repo <owner>/<repo>
-```
-
-**Option B: Codex CLI OAuth** (uses your OpenAI subscription, no per-token billing)
-
-Bootstrap once on a machine where you are already logged into the Codex CLI:
+For reference, the original setup was:
 
 ```bash
-codex login
-cat ~/.codex/auth.json | base64 | gh secret set OPENAI_OAUTH_TOKEN --repo <owner>/<repo>
+claude setup-token
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>
 ```
 
-The secret must be the base64-encoded contents of `~/.codex/auth.json`, which contains `tokens.access_token` and `tokens.refresh_token`. Re-run the bootstrap command when the refresh token expires.
+### OpenAI
 
-### Gemini (Optional)
+#### OpenAI API Key
 
-Use Gemini models (via API key or Gemini CLI OAuth) instead of Claude.
+1. Get your API key from [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+2. Add as a repository secret:
+   ```bash
+   gh secret set OPENAI_API_KEY --repo <owner>/<repo>
+   ```
 
-**Option A: Gemini API key**
+Reasoning models (`o1`, `o3`, `o4`, ...) accept the effort tiers above. Non-reasoning chat models (`gpt-4o`, `gpt-4.1`, ...) ignore effort and log a warning.
 
-```bash
-gh secret set GEMINI_API_KEY --repo <owner>/<repo>
-```
+#### Codex CLI OAuth Token (subscription)
 
-**Option B: Gemini CLI OAuth** (uses your Google account, no per-token billing)
+If you have a ChatGPT Plus or Pro subscription, the Codex CLI generates an OAuth token that the action can ride to avoid per-token API charges.
 
-Bootstrap once on a machine where you are already logged into the Gemini CLI:
+1. Install the Codex CLI: `npm install -g @openai/codex`
+2. Run `codex login` and complete the browser flow
+3. Bootstrap the secret from `~/.codex/auth.json`:
+   ```bash
+   cat ~/.codex/auth.json | base64 | gh secret set OPENAI_OAUTH_TOKEN --repo <owner>/<repo>
+   ```
+   The secret must be the base64-encoded contents of `~/.codex/auth.json`, which contains `tokens.access_token` and `tokens.refresh_token`. Re-run when the refresh token expires.
+4. The workflow needs to install the Codex CLI on the runner (see [Step 3](#step-3-add-the-workflow))
 
-```bash
-gemini  # sign in with Google when prompted
-cat ~/.gemini/oauth_creds.json | base64 | gh secret set GEMINI_OAUTH_TOKEN --repo <owner>/<repo>
-```
+### Gemini
 
-The secret must be the base64-encoded contents of `~/.gemini/oauth_creds.json`, which contains `access_token` and `refresh_token`. Re-run the bootstrap command when the refresh token expires.
+#### Gemini API Key
+
+1. Get your API key from [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
+2. Add as a repository secret:
+   ```bash
+   gh secret set GEMINI_API_KEY --repo <owner>/<repo>
+   ```
+
+#### Gemini CLI OAuth Token (subscription)
+
+Rides a Google AI subscription via the Gemini CLI binary. Effort tiers are not honored on this path.
+
+1. Install the Gemini CLI: see [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli)
+2. Sign in with Google when prompted (`gemini` opens a browser flow)
+3. Bootstrap the secret from `~/.gemini/oauth_creds.json`:
+   ```bash
+   cat ~/.gemini/oauth_creds.json | base64 | gh secret set GEMINI_OAUTH_TOKEN --repo <owner>/<repo>
+   ```
+   The secret must be the base64-encoded contents of `~/.gemini/oauth_creds.json`, which contains `access_token` and `refresh_token`. Re-run when the refresh token expires.
+4. The workflow needs to install the Gemini CLI on the runner (see [Step 3](#step-3-add-the-workflow))
 
 ### Review Memory Token (Optional)
 
@@ -196,22 +228,79 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - name: Manki Review
-        uses: manki-review/manki@v4
+        uses: manki-review/manki@v5
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}  # Alternative to OAuth
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # github_token: ${{ secrets.GITHUB_TOKEN }}  # Only if not using the GitHub App
           # memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}  # Only if memory repo is separate
 ```
 
+#### Workflow examples per provider
+
+OpenAI API key:
+
+```yaml
+      - name: Manki Review
+        uses: manki-review/manki@v5
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+OpenAI Codex CLI OAuth (requires the CLI on the runner):
+
+```yaml
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+      - name: Manki Review
+        uses: manki-review/manki@v5
+        with:
+          openai_oauth_token: ${{ secrets.OPENAI_OAUTH_TOKEN }}
+```
+
+Gemini API key:
+
+```yaml
+      - name: Manki Review
+        uses: manki-review/manki@v5
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+```
+
+Gemini CLI OAuth (requires the CLI on the runner):
+
+```yaml
+      - name: Install Gemini CLI
+        run: npm install -g @google/gemini-cli
+      - name: Manki Review
+        uses: manki-review/manki@v5
+        with:
+          gemini_oauth_token: ${{ secrets.GEMINI_OAUTH_TOKEN }}
+```
+
+You can pass multiple credentials at once. The active provider for each agent is chosen by the model ID in `.manki.yml`.
+
+Pair each workflow with a matching `models:` block in `.manki.yml`, for example:
+
+```yaml
+# OpenAI
+models:
+  planner: gpt-4o-mini
+  reviewer: gpt-4o-mini
+  judge: o4-mini
+  dedup: gpt-4o-mini
+
+# Gemini
+models:
+  planner: gemini-2.5-flash
+  reviewer: gemini-2.5-flash
+  judge: gemini-2.5-pro
+  dedup: gemini-2.5-flash
+```
+
 ### Action inputs
 
-The workflow above uses the only inputs most setups need: `claude_code_oauth_token` (or `anthropic_api_key`), `github_token`, and optionally `memory_repo_token`. To point at a config file outside the repo root, set `config_path` (default: `.manki.yml`). For GitHub App identity, set `github_app_id`, `github_app_private_key`, and `manki_token_url`. See [`action.yml`](action.yml) for the full input reference.
+The workflow above uses the only inputs most setups need: a provider credential (e.g. `anthropic_api_key`, `openai_api_key`, `gemini_api_key`, or one of the OAuth equivalents), `github_token` (only if you skipped the GitHub App), and optionally `memory_repo_token`. To point at a config file outside the repo root, set `config_path` (default: `.manki.yml`). For GitHub App identity, set `github_app_id`, `github_app_private_key`, and `manki_token_url`. See [`action.yml`](action.yml) for the full input reference.
 
 ### Action outputs
 
@@ -474,12 +563,12 @@ Each review run posts fresh inline comments. The recap phase deduplicates agains
 
 | Secret | Required | Purpose |
 |--------|----------|---------|
-| `CLAUDE_CODE_OAUTH_TOKEN` | Yes* | Claude Max subscription auth (Codex OAuth) |
-| `ANTHROPIC_API_KEY` | Yes* | Anthropic API auth (alternative to OAuth) |
+| `ANTHROPIC_API_KEY` | Yes* | Anthropic API auth |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Yes* | Claude Max subscription auth (deprecated) |
 | `OPENAI_OAUTH_TOKEN` | No | Base64-encoded `~/.codex/auth.json` for Codex CLI OAuth |
 | `OPENAI_API_KEY` | No | OpenAI API key (alternative to Codex OAuth) |
 | `GEMINI_OAUTH_TOKEN` | No | Base64-encoded `~/.gemini/oauth_creds.json` for Gemini CLI OAuth |
 | `GEMINI_API_KEY` | No | Google Generative AI API key (alternative to Gemini OAuth) |
 | `REVIEW_MEMORY_TOKEN` | No | Fine-grained PAT for memory repo writes |
 
-\* One of `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is required when using Claude (the default provider).
+\* At least one provider credential is required. The active provider for each agent is selected by the model ID in `.manki.yml`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -91,6 +91,8 @@ Manki supports Anthropic, OpenAI, and Gemini. You only need credentials for the 
 | OpenAI | `openai_api_key` | `openai_oauth_token` (Codex CLI) |
 | Gemini | `gemini_api_key` | `gemini_oauth_token` (Gemini CLI) |
 
+The table lists action input names (lowercase, passed in `with:`). The corresponding GitHub secret is the uppercase version: `anthropic_api_key` reads from `secrets.ANTHROPIC_API_KEY`, and so on, as shown in the workflow examples below.
+
 > **`claude_code_oauth_token` is deprecated.** Anthropic restricted Claude Code OAuth tokens for third-party tools on April 4, 2026. The input still works and the action emits a one-line `core.warning` per run. New setups should use `anthropic_api_key`. If you want a subscription-based path with no extra API charges, switch to `openai_oauth_token` (Codex CLI) or `gemini_oauth_token` (Gemini CLI).
 
 #### Effort mapping
@@ -256,7 +258,7 @@ OpenAI Codex CLI OAuth (requires the CLI on the runner):
 
 ```yaml
       - name: Install Codex CLI
-        run: npm install -g @openai/codex
+        run: npm install -g --ignore-scripts '@openai/codex@0.129.0'
       - name: Manki Review
         uses: manki-review/manki@v5
         with:
@@ -315,7 +317,7 @@ The action exposes outputs you can chain into later workflow steps: `review_id`,
 
 ```yaml
 # Fail CI when the judge requests changes
-- uses: manki-review/manki@v4
+- uses: manki-review/manki@v5
   id: manki
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/SETUP.md
+++ b/SETUP.md
@@ -258,6 +258,7 @@ OpenAI Codex CLI OAuth (requires the CLI on the runner):
 
 ```yaml
       - name: Install Codex CLI
+        # --ignore-scripts is safe: @openai/codex@0.129.0 ships a plain JS bin with no postinstall steps.
         run: npm install -g --ignore-scripts '@openai/codex@0.129.0'
       - name: Manki Review
         uses: manki-review/manki@v5
@@ -578,7 +579,7 @@ Provide credentials for the providers you actually use. The model ID in `.manki.
 | OpenAI | `OPENAI_API_KEY` | `OPENAI_OAUTH_TOKEN` (base64 of `~/.codex/auth.json`) |
 | Gemini | `GEMINI_API_KEY` | `GEMINI_OAUTH_TOKEN` (base64 of `~/.gemini/oauth_creds.json`) |
 
-When both are set for a provider, OAuth takes precedence.
+When both are set for a provider, OAuth takes precedence (the action checks the OAuth input before the API key for each provider).
 
 ### Other
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -566,14 +566,20 @@ Each review run posts fresh inline comments. The recap phase deduplicates agains
 
 ## Quick Reference: All Secrets
 
-| Secret | Required | Purpose |
-|--------|----------|---------|
-| `ANTHROPIC_API_KEY` | Yes† | Anthropic API auth |
-| `CLAUDE_CODE_OAUTH_TOKEN` | No (deprecated) | Claude Max subscription auth (deprecated, prefer `ANTHROPIC_API_KEY`) |
-| `OPENAI_API_KEY` | Yes† | OpenAI API key |
-| `OPENAI_OAUTH_TOKEN` | Yes† | Base64-encoded `~/.codex/auth.json` for Codex CLI OAuth |
-| `GEMINI_API_KEY` | Yes† | Google Generative AI API key |
-| `GEMINI_OAUTH_TOKEN` | Yes† | Base64-encoded `~/.gemini/oauth_creds.json` for Gemini CLI OAuth |
-| `REVIEW_MEMORY_TOKEN` | No | Fine-grained PAT for memory repo writes |
+Provide credentials for the providers you actually use. The model ID in `.manki.yml` picks the provider per agent (`claude-*` → Anthropic, `gpt-*` and `o1`/`o3`/`o4`/... → OpenAI, `gemini-*` → Gemini), or use `provider/model` syntax to be explicit. The action fails fast with a clear error if a configured provider's credentials are missing.
 
-† At least one provider credential is required — pick one auth method from one provider. The active provider per agent is selected by the model ID in `.manki.yml`.
+### Provider credentials
+
+| Provider | API key | OAuth alternative |
+|----------|---------|-------------------|
+| Anthropic | `ANTHROPIC_API_KEY` | `CLAUDE_CODE_OAUTH_TOKEN` (deprecated) |
+| OpenAI | `OPENAI_API_KEY` | `OPENAI_OAUTH_TOKEN` (base64 of `~/.codex/auth.json`) |
+| Gemini | `GEMINI_API_KEY` | `GEMINI_OAUTH_TOKEN` (base64 of `~/.gemini/oauth_creds.json`) |
+
+When both are set for a provider, OAuth takes precedence.
+
+### Other
+
+| Secret | Purpose |
+|--------|---------|
+| `REVIEW_MEMORY_TOKEN` | Fine-grained PAT for memory repo writes (only when the memory repo is a separate repository — see [Review memory](#review-memory)) |

--- a/SETUP.md
+++ b/SETUP.md
@@ -153,6 +153,8 @@ If you have a ChatGPT Plus or Pro subscription and the Codex CLI installed:
    The secret must be the base64-encoded contents of `~/.codex/auth.json`, which contains `tokens.access_token` and `tokens.refresh_token`. Re-run when the refresh token expires.
 3. The workflow needs to install the Codex CLI on the runner (see [Step 3](#step-3-add-the-workflow))
 
+> **Security note:** The base64 encoding is for transport format only — it is not encrypted. Anyone with access to repository secrets can decode the full credential, including the refresh token, which grants ongoing access to your ChatGPT Plus/Pro subscription. If this secret is ever compromised, revoke the OAuth session immediately at [platform.openai.com/account/sessions](https://platform.openai.com/account/sessions). For production use, prefer the API key path (`OPENAI_API_KEY`), which can be rotated without affecting your account session.
+
 ### Gemini
 
 #### Gemini API Key
@@ -175,6 +177,8 @@ Rides a Google AI subscription via the Gemini CLI binary. Effort tiers are not h
    ```
    The secret must be the base64-encoded contents of `~/.gemini/oauth_creds.json`, which contains `access_token` and `refresh_token`. Re-run when the refresh token expires.
 4. The workflow needs to install the Gemini CLI on the runner (see [Step 3](#step-3-add-the-workflow))
+
+> **Security note:** The base64 encoding is for transport format only — it is not encrypted. Anyone with access to repository secrets can decode the full credential, including the refresh token, which grants ongoing access to your Google AI subscription. If this secret is ever compromised, revoke the OAuth session immediately at [myaccount.google.com/permissions](https://myaccount.google.com/permissions). For production use, prefer the API key path (`GEMINI_API_KEY`), which can be rotated without affecting your account session.
 
 ### Review Memory Token (Optional)
 


### PR DESCRIPTION
## Summary
- Documents provider auth flows for OpenAI and Gemini in SETUP.md and README
- Adds deprecation note for Claude Code OAuth
- Clarifies Codex CLI OAuth status as experimental and corrects auth.json field reference

Closes #694

Part of #652 (v5.0.0).