### PR TITLE
feat: define `RoundContext` type for unified per-round state

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -172,4 +172,25 @@ describe('roundContextToFlatAliases', () => {
     expect(aliases.findingsRaw).toBe(ctx.findings.count);
     expect(aliases.findingsDropped).toBe(0);
   });
+
+  it('handles minimal context with no optional fields', () => {
+    const ctx: RoundContext = {
+      meta: { prNumber: 1, commitSha: 'sha', round: 1, timestamp: 'ts', runId: 1, mankiVersion: '5.0.0', promptVersions: { judge: 'j', reviewer: 'r', planner: 'p' } },
+      config: { reviewLevel: 'small', nitHandling: 'comments', memoryEnabled: false },
+      diff: { lines: 10, additions: 10, deletions: 0, filesReviewed: 1, fileTypes: {} },
+      models: { reviewer: 'model-a', judge: 'model-b' },
+      planner: { used: false },
+      reviewers: { agents: [] },
+      judge: { summary: '' },
+      dedup: {},
+      memory: {},
+      findings: { count: 0, severityCounts: {}, entries: [] },
+      usage: {},
+      verdict: 'APPROVE',
+    };
+    const aliases = roundContextToFlatAliases(ctx);
+    expect(aliases.findingsRaw).toBe(0);
+    expect(aliases.findingsDropped).toBe(0);
+    expect(aliases.agents).toEqual([]);
+  });
 });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,4 +1,4 @@
-import { migrateLegacySeverity } from './types';
+import { migrateLegacySeverity, RoundContext, roundContextToFlatAliases } from './types';
 
 describe('migrateLegacySeverity', () => {
   it('maps `required` to `blocker`', () => {
@@ -22,5 +22,154 @@ describe('migrateLegacySeverity', () => {
 
   it('passes through the empty string unchanged', () => {
     expect(migrateLegacySeverity('')).toBe('');
+  });
+});
+
+function fullyPopulatedContext(): RoundContext {
+  return {
+    meta: {
+      prNumber: 42,
+      commitSha: 'abc123',
+      round: 2,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: 9876543210,
+      mankiVersion: '4.7.0',
+      promptVersions: { judge: 'j1', reviewer: 'r1', planner: 'p1' },
+    },
+    config: {
+      reviewLevel: 'medium',
+      nitHandling: 'issues',
+      memoryEnabled: true,
+      reviewPasses: 1,
+    },
+    diff: {
+      lines: 120,
+      additions: 90,
+      deletions: 30,
+      filesReviewed: 4,
+      fileTypes: { '.ts': 3, '.md': 1 },
+    },
+    models: {
+      planner: 'claude-haiku-4-5',
+      reviewer: 'claude-sonnet-4-6',
+      judge: 'claude-opus-4-6',
+      dedup: 'claude-haiku-4-5',
+    },
+    planner: {
+      used: true,
+      teamSize: 3,
+      reviewerEffort: 'medium',
+      judgeEffort: 'high',
+      prType: 'feature',
+      durationMs: 1200,
+    },
+    reviewers: {
+      agents: ['typescript', 'security', 'tests'],
+      agentMetrics: [
+        {
+          name: 'typescript',
+          findingsRaw: 5,
+          findingsKept: 3,
+          durationMs: 8000,
+          status: 'success',
+          responseLength: 4200,
+          warnings: [],
+          inputTokens: 1500,
+          outputTokens: 900,
+        },
+      ],
+    },
+    judge: {
+      summary: 'Three issues kept, two demoted to nits.',
+      confidenceDistribution: { high: 2, medium: 1, low: 0 },
+      severityChanges: 1,
+      mergedDuplicates: 2,
+      durationMs: 4500,
+      verdictReason: 'novel_suggestion',
+      defensiveHardeningCount: 0,
+      inPrSuppressedCount: 1,
+      crossRoundSuppressed: 0,
+      crossRoundDemoted: 1,
+    },
+    dedup: { staticDropped: 1, llmDropped: 0, durationMs: 200 },
+    memory: { patternsApplied: 2, suppressionsApplied: 1, escalationsApplied: 0 },
+    findings: {
+      count: 3,
+      severityCounts: { blocker: 0, warning: 1, suggestion: 1, nitpick: 1 },
+      entries: [
+        {
+          fingerprint: { file: 'src/foo.ts', lineStart: 10, lineEnd: 10, slug: 'missing-null-check' },
+          threadId: 'PRRT_kw1',
+          severity: 'warning',
+          authorReplyClass: 'none',
+        },
+        {
+          fingerprint: { file: 'src/bar.ts', lineStart: 20, lineEnd: 25, slug: 'rename-helper' },
+          severity: 'suggestion',
+        },
+        {
+          fingerprint: { file: 'src/baz.ts', lineStart: 5, lineEnd: 5, slug: 'trailing-space' },
+          severity: 'nitpick',
+          authorReplyClass: 'agree',
+        },
+      ],
+    },
+    usage: {
+      inputTokens: 12000,
+      outputTokens: 3000,
+      totalTokens: 15000,
+      estimatedCostUsd: 0.0825,
+      perStage: {
+        planner: { inputTokens: 500, outputTokens: 100, totalTokens: 600 },
+        reviewer: { inputTokens: 9000, outputTokens: 2400, totalTokens: 11400 },
+        judge: { inputTokens: 2300, outputTokens: 480, totalTokens: 2780 },
+        dedup: { inputTokens: 200, outputTokens: 20, totalTokens: 220 },
+      },
+    },
+    verdict: 'COMMENT',
+  };
+}
+
+describe('RoundContext', () => {
+  it('instantiates with every field populated', () => {
+    const ctx = fullyPopulatedContext();
+    expect(ctx.meta.mankiVersion).toBe('4.7.0');
+    expect(ctx.findings.entries).toHaveLength(3);
+    expect(ctx.judge.summary).toMatch(/Three issues/);
+    expect(ctx.reviewers.agents).toEqual(['typescript', 'security', 'tests']);
+  });
+});
+
+describe('roundContextToFlatAliases', () => {
+  it('derives every legacy alias from a `RoundContext`', () => {
+    const ctx = fullyPopulatedContext();
+    const aliases = roundContextToFlatAliases(ctx);
+    expect(aliases).toEqual({
+      prNumber: 42,
+      commitSha: 'abc123',
+      verdict: 'COMMENT',
+      diffLines: 120,
+      diffAdditions: 90,
+      diffDeletions: 30,
+      filesReviewed: 4,
+      agents: ['typescript', 'security', 'tests'],
+      // 3 kept + 1 staticDropped + 0 llmDropped + 2 mergedDuplicates
+      findingsRaw: 6,
+      findingsKept: 3,
+      findingsDropped: 3,
+      severity: { blocker: 0, warning: 1, suggestion: 1, nitpick: 1 },
+      model: 'claude-sonnet-4-6',
+      reviewerModel: 'claude-sonnet-4-6',
+      judgeModel: 'claude-opus-4-6',
+    });
+  });
+
+  it('treats missing dedup and judge merge counts as zero', () => {
+    const ctx = fullyPopulatedContext();
+    ctx.dedup = {};
+    ctx.judge.mergedDuplicates = undefined;
+    const aliases = roundContextToFlatAliases(ctx);
+    expect(aliases.findingsRaw).toBe(ctx.findings.count);
+    expect(aliases.findingsDropped).toBe(0);
   });
 });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -189,8 +189,22 @@ describe('roundContextToFlatAliases', () => {
       verdict: 'APPROVE',
     };
     const aliases = roundContextToFlatAliases(ctx);
-    expect(aliases.findingsRaw).toBe(0);
-    expect(aliases.findingsDropped).toBe(0);
-    expect(aliases.agents).toEqual([]);
+    expect(aliases).toEqual({
+      prNumber: 1,
+      commitSha: 'sha',
+      verdict: 'APPROVE',
+      diffLines: 10,
+      diffAdditions: 10,
+      diffDeletions: 0,
+      filesReviewed: 1,
+      agents: [],
+      findingsRaw: 0,
+      findingsKept: 0,
+      findingsDropped: 0,
+      severity: {},
+      model: 'model-a',
+      reviewerModel: 'model-a',
+      judgeModel: 'model-b',
+    });
   });
 });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -173,6 +173,13 @@ describe('roundContextToFlatAliases', () => {
     expect(aliases.findingsDropped).toBe(0);
   });
 
+  it('uses findings.count, not entries.length, for findingsKept', () => {
+    const ctx = fullyPopulatedContext();
+    ctx.findings.count = 5;
+    const aliases = roundContextToFlatAliases(ctx);
+    expect(aliases.findingsKept).toBe(5);
+  });
+
   it('handles minimal context with no optional fields', () => {
     const ctx: RoundContext = {
       meta: { prNumber: 1, commitSha: 'sha', round: 1, timestamp: 'ts', runId: 1, mankiVersion: '5.0.0', promptVersions: { judge: 'j', reviewer: 'r', planner: 'p' } },

--- a/src/types.ts
+++ b/src/types.ts
@@ -475,7 +475,7 @@ export interface PromptVersions {
   planner: string;
 }
 
-/** Effective config snapshot for the round, narrowed to fields that affect outcomes. */
+/** Effective config snapshot for the round: AI pipeline behavior fields (model behavior, pass configuration, memory). Convergence/post-processing rules are not included. */
 export interface RoundConfig {
   reviewLevel: ReviewLevel;
   nitHandling: 'issues' | 'comments';
@@ -517,8 +517,8 @@ export interface RoundReviewers {
 
 export interface RoundAgentMetric {
   name: string;
-  findingsRaw: number;
-  findingsKept: number;
+  findingsRaw?: number;
+  findingsKept?: number;
   durationMs?: number;
   status?: 'success' | 'failed';
   responseLength?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -477,8 +477,8 @@ export interface PromptVersions {
 
 /** Effective config snapshot for the round, narrowed to fields that affect outcomes. */
 export interface RoundConfig {
-  reviewLevel: string;
-  nitHandling: string;
+  reviewLevel: ReviewLevel;
+  nitHandling: 'issues' | 'comments';
   memoryEnabled: boolean;
   reviewPasses?: number;
 }
@@ -576,7 +576,7 @@ export interface RoundUsage {
   outputTokens?: number;
   totalTokens?: number;
   estimatedCostUsd?: number;
-  perStage?: Record<'planner' | 'reviewer' | 'judge' | 'dedup', RoundUsageStage | undefined>;
+  perStage?: Partial<Record<'planner' | 'reviewer' | 'judge' | 'dedup', RoundUsageStage>>;
 }
 
 export interface RoundUsageStage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -416,3 +416,230 @@ export interface ReviewMetadata {
     totalMs: number;
   };
 }
+
+/**
+ * Per-round semantic state of a manki review, grouped by pipeline stage.
+ *
+ * Single source of truth for per-round context, consumed by two surfaces:
+ *
+ * 1. The PR-embedded `Manki context` block — the structured payload manki
+ *    attaches to its review comment. Replaces the ad-hoc `Review stats` JSON
+ *    grown organically over time and consolidates everything `HandoverRound`
+ *    used to carry in the per-PR handover file.
+ * 2. Local replay bundles — the `context` sub-field of the bundles produced for
+ *    offline replay, so a replay carries the full prior-round state without
+ *    having to re-derive it from the review comment.
+ *
+ * Both consumers see the same shape, version-stamped via `meta.mankiVersion`
+ * (per the schema-versioning decision in #461). Flat-compat aliases used by
+ * legacy downstream workflows (`verdict`, `findingsRaw`, `findingsKept`,
+ * `severity`, `reviewTimeMs`, `diffLines`, etc.) are derived at emit time via
+ * `roundContextToFlatAliases` rather than duplicated in the type.
+ *
+ * Sub-issues #686, #687, #688, #689, #690 wire the emitter, HTML render,
+ * recap aggregator, consumer migration, and handover deletion.
+ */
+export interface RoundContext {
+  meta: RoundMeta;
+  config: RoundConfig;
+  diff: RoundDiff;
+  models: RoundModels;
+  planner: RoundPlanner;
+  reviewers: RoundReviewers;
+  judge: RoundJudge;
+  dedup: RoundDedup;
+  memory: RoundMemory;
+  findings: RoundFindings;
+  usage: RoundUsage;
+  verdict: ReviewVerdict;
+}
+
+/** Identity, provenance, and versioning for a single completed review round. */
+export interface RoundMeta {
+  prNumber: number;
+  commitSha: string;
+  round: number;
+  /** ISO 8601 timestamp at which the round completed. */
+  timestamp: string;
+  /** GitHub Actions `run_id` that produced this round. */
+  runId: number;
+  /** `version` from `package.json` of the manki release that produced this round. */
+  mankiVersion: string;
+  promptVersions: PromptVersions;
+}
+
+/** Version identifiers for the prompt templates used by each pipeline stage. */
+export interface PromptVersions {
+  judge: string;
+  reviewer: string;
+  planner: string;
+}
+
+/** Effective config snapshot for the round, narrowed to fields that affect outcomes. */
+export interface RoundConfig {
+  reviewLevel: string;
+  nitHandling: string;
+  memoryEnabled: boolean;
+  reviewPasses?: number;
+}
+
+export interface RoundDiff {
+  lines: number;
+  additions: number;
+  deletions: number;
+  filesReviewed: number;
+  fileTypes: Record<string, number>;
+}
+
+/** Resolved model IDs per pipeline stage. */
+export interface RoundModels {
+  planner?: string;
+  reviewer: string;
+  judge: string;
+  dedup?: string;
+}
+
+export interface RoundPlanner {
+  /** False when the planner was disabled or fell back to the heuristic team selector. */
+  used: boolean;
+  teamSize?: PlannerResult['teamSize'];
+  reviewerEffort?: EffortLevel;
+  judgeEffort?: EffortLevel;
+  prType?: string;
+  durationMs?: number;
+}
+
+export interface RoundReviewers {
+  /** Reviewer agent names that participated in this round (subsumes `HandoverRound.agents`). */
+  agents: string[];
+  agentMetrics?: RoundAgentMetric[];
+}
+
+export interface RoundAgentMetric {
+  name: string;
+  findingsRaw: number;
+  findingsKept: number;
+  durationMs?: number;
+  status?: 'success' | 'failed';
+  responseLength?: number;
+  warnings?: string[];
+  inputTokens?: number;
+  outputTokens?: number;
+  failureReason?: string;
+}
+
+export interface RoundJudge {
+  /** Narrative summary used today by `buildPlannerHints` and surfaced in handover. */
+  summary: string;
+  confidenceDistribution?: { high: number; medium: number; low: number };
+  severityChanges?: number;
+  mergedDuplicates?: number;
+  durationMs?: number;
+  verdictReason?: VerdictReason;
+  defensiveHardeningCount?: number;
+  inPrSuppressedCount?: number;
+  crossRoundSuppressed?: number;
+  crossRoundDemoted?: number;
+}
+
+export interface RoundDedup {
+  staticDropped?: number;
+  llmDropped?: number;
+  durationMs?: number;
+}
+
+export interface RoundMemory {
+  patternsApplied?: number;
+  suppressionsApplied?: number;
+  escalationsApplied?: number;
+}
+
+/**
+ * Per-round fingerprint table. Carries identity and outcome of each finding,
+ * never the body. Replaces `HandoverRound.findings` in the new shape.
+ */
+export interface RoundFindings {
+  count: number;
+  severityCounts: Record<string, number>;
+  entries: FindingFingerprintEntry[];
+}
+
+export interface FindingFingerprintEntry {
+  fingerprint: FindingFingerprint;
+  threadId?: string;
+  severity: FindingSeverity | 'unknown';
+  authorReplyClass?: AuthorReplyClass;
+}
+
+export interface RoundUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+  perStage?: Record<'planner' | 'reviewer' | 'judge' | 'dedup', RoundUsageStage | undefined>;
+}
+
+export interface RoundUsageStage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+}
+
+/**
+ * Flat-compat aliases preserved for downstream workflows that read the legacy
+ * `Review stats` keys (`fromJSON(steps.manki.outputs.severity_counts)` etc.).
+ * Derived from a `RoundContext` at emit time so the type itself stays free of
+ * duplicated fields. Slated for removal in v5.0.0 per the #461 decision log.
+ */
+export interface RoundContextFlatAliases {
+  prNumber: number;
+  commitSha: string;
+  verdict: ReviewVerdict;
+  diffLines: number;
+  diffAdditions: number;
+  diffDeletions: number;
+  filesReviewed: number;
+  agents: string[];
+  findingsRaw: number;
+  findingsKept: number;
+  findingsDropped: number;
+  severity: Record<string, number>;
+  model: string;
+  reviewerModel: string;
+  judgeModel: string;
+}
+
+/**
+ * Project a `RoundContext` to the legacy flat-key shape consumed by older
+ * downstream workflows. Keep this the single derivation point so removing the
+ * aliases in v5.0.0 is a one-file change.
+ *
+ * `findingsRaw` is reconstructed as `findings.count + dedup.staticDropped +
+ * dedup.llmDropped + judge.mergedDuplicates`, matching the pre-grouping
+ * `ReviewStats.findingsRaw` definition.
+ */
+export function roundContextToFlatAliases(ctx: RoundContext): RoundContextFlatAliases {
+  const kept = ctx.findings.count;
+  const staticDropped = ctx.dedup.staticDropped ?? 0;
+  const llmDropped = ctx.dedup.llmDropped ?? 0;
+  const mergedDuplicates = ctx.judge.mergedDuplicates ?? 0;
+  const raw = kept + staticDropped + llmDropped + mergedDuplicates;
+  return {
+    prNumber: ctx.meta.prNumber,
+    commitSha: ctx.meta.commitSha,
+    verdict: ctx.verdict,
+    diffLines: ctx.diff.lines,
+    diffAdditions: ctx.diff.additions,
+    diffDeletions: ctx.diff.deletions,
+    filesReviewed: ctx.diff.filesReviewed,
+    agents: ctx.reviewers.agents,
+    findingsRaw: raw,
+    findingsKept: kept,
+    findingsDropped: raw - kept,
+    severity: ctx.findings.severityCounts,
+    model: ctx.models.reviewer,
+    reviewerModel: ctx.models.reviewer,
+    judgeModel: ctx.models.judge,
+  };
+}


### PR DESCRIPTION
## Summary
- New `RoundContext` interface in `src/types.ts` with grouped sections (`meta`, `config`, `diff`, `models`, `planner`, `reviewers`, `judge`, `dedup`, `memory`, `findings`, `usage`, `verdict`), version-stamped via `meta.mankiVersion`
- Per-round finding fingerprint table (no per-finding bodies — those live in threads)
- `roundContextToFlatAliases` helper derives the legacy `Review stats` flat keys at emit time so the type stays free of duplicated fields
- Pure types-and-schema only; no emitter, parser, or consumer migration (those are sub-issues #686, #687, #688, #689, #690)

Closes #685.

First step of the #684 round-state cutover, part of #652 (v5.0.0).