### PR TITLE
feat: emit `Manki context` block from `RoundContext` in review summary

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -790,6 +790,7 @@ describe('truncateContextToFitBody', () => {
     const render = (c: RoundContext) => JSON.stringify(c);
     const budget = render(ctx).length - 100;
     const { context: once } = truncateContextToFitBody(ctx, render, budget);
+    expect(once.findings.entries.length).toBeLessThan(entries.length);
     const { context: twice, droppedCount } = truncateContextToFitBody(once, render, budget);
     expect(droppedCount).toBe(0);
     expect(twice.findings.entries).toEqual(once.findings.entries);
@@ -908,6 +909,9 @@ describe('postReview with context', () => {
     const ctx = makeContext({
       findings: { count: entries.length, severityCounts: { blocker: 250, warning: 250, suggestion: 250, nitpick: 250 }, entries },
     });
+
+    const preTruncationBody = JSON.stringify(ctx);
+    expect(preTruncationBody.length).toBeGreaterThan(60_000);
 
     const warningSpy = jest.spyOn(core, 'warning');
     await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 1000);

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -884,9 +884,16 @@ describe('postReview with context', () => {
     },
   } as unknown as Parameters<typeof postReview>[0];
 
+  let warningSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockCreateReview.mockClear();
-    jest.spyOn(core, 'warning').mockImplementation(() => {}).mockClear();
+    warningSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    warningSpy.mockClear();
+  });
+
+  afterEach(() => {
+    warningSpy.mockRestore();
   });
 
   it('includes stats one-liner and Manki context block in review body', async () => {
@@ -958,7 +965,6 @@ describe('postReview with context', () => {
     const preTruncationBody = JSON.stringify(ctx);
     expect(preTruncationBody.length).toBeGreaterThan(60_000);
 
-    const warningSpy = jest.spyOn(core, 'warning');
     await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 1000);
     const body = mockCreateReview.mock.calls[0][0].body as string;
     expect(body.length).toBeLessThanOrEqual(60000);
@@ -1005,7 +1011,6 @@ describe('postReview with context', () => {
         entries: [{ fingerprint: { file: 'src/a.ts', lineStart: 1, lineEnd: 1, slug: 'tiny' }, severity: 'suggestion' }],
       },
     });
-    const warningSpy = jest.spyOn(core, 'warning');
     await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 1000);
     const body = mockCreateReview.mock.calls[0][0].body as string;
     const match = body.match(/```json\n([\s\S]*?)\n```/);
@@ -1034,7 +1039,6 @@ describe('postReview with context', () => {
       judge: { summary: 'a'.repeat(65000) },
       findings: { count: 0, severityCounts: {}, entries: [] },
     });
-    const warningSpy = jest.spyOn(core, 'warning');
     await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 0);
     expect(warningSpy).toHaveBeenCalledWith(expect.stringMatching(/judge summary capped/));
     const body = mockCreateReview.mock.calls[0][0].body as string;

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -832,6 +832,46 @@ describe('truncateContextToFitBody', () => {
     expect(out.judge.summary.length).toBeLessThanOrEqual(2003);
     expect(render(out).length).toBeLessThanOrEqual(budget);
   });
+
+  it('drops ignore entries before nitpick entries', () => {
+    const entries: FindingFingerprintEntry[] = [
+      { fingerprint: { file: 'f.ts', lineStart: 1, lineEnd: 1, slug: 'a' }, severity: 'ignore' },
+      { fingerprint: { file: 'f.ts', lineStart: 2, lineEnd: 2, slug: 'b' }, severity: 'nitpick' },
+    ];
+    const ctx = makeContext({ findings: { count: 2, severityCounts: {}, entries } });
+    const render = (c: RoundContext) => JSON.stringify(c);
+    // Budget must fit one entry with `truncated: true` but not two entries.
+    const oneEntryTruncated = makeContext({ findings: { count: 1, severityCounts: {}, entries: [entries[1]], truncated: true } });
+    const budget = render(oneEntryTruncated).length;
+    const { context: out } = truncateContextToFitBody(ctx, render, budget);
+    expect(out.findings.entries.map(e => e.severity)).toEqual(['nitpick']);
+  });
+
+  it('drops unknown entries before blocker entries', () => {
+    const entries: FindingFingerprintEntry[] = [
+      { fingerprint: { file: 'f.ts', lineStart: 1, lineEnd: 1, slug: 'a' }, severity: 'unknown' },
+      { fingerprint: { file: 'f.ts', lineStart: 2, lineEnd: 2, slug: 'b' }, severity: 'blocker' },
+    ];
+    const ctx = makeContext({ findings: { count: 2, severityCounts: {}, entries } });
+    const render = (c: RoundContext) => JSON.stringify(c);
+    // Budget must fit one entry with `truncated: true` but not two entries.
+    const oneEntryTruncated = makeContext({ findings: { count: 1, severityCounts: {}, entries: [entries[1]], truncated: true } });
+    const budget = render(oneEntryTruncated).length;
+    const { context: out } = truncateContextToFitBody(ctx, render, budget);
+    expect(out.findings.entries.map(e => e.severity)).toEqual(['blocker']);
+  });
+
+  it('does not set summaryCapped when judge.summary is already within 2000 chars', () => {
+    const shortSummary = 'short summary';
+    const ctx = makeContext({
+      judge: { summary: shortSummary },
+      findings: { count: 0, severityCounts: {}, entries: [] },
+    });
+    const render = (c: RoundContext) => JSON.stringify(c) + 'x'.repeat(1000);
+    const { summaryCapped, context: out } = truncateContextToFitBody(ctx, render, 1);
+    expect(summaryCapped).toBe(false);
+    expect(out.judge.summary).toBe(shortSummary);
+  });
 });
 
 describe('postReview with context', () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -797,6 +797,18 @@ describe('truncateContextToFitBody', () => {
     expect(droppedCount).toBe(0);
     expect(twice.findings.entries).toEqual(once.findings.entries);
   });
+
+  it('returns over-budget context with truncated flag when body exceeds budget even after all entries dropped', () => {
+    const ctx = makeContext({
+      judge: { summary: 'x'.repeat(200) },
+      findings: { count: 0, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, entries: [] },
+    });
+    const render = (c: RoundContext) => JSON.stringify(c);
+    const { context: out, droppedCount } = truncateContextToFitBody(ctx, render, 1);
+    expect(droppedCount).toBe(0);
+    expect(out.findings.entries).toEqual([]);
+    expect(render(out).length).toBeGreaterThan(1);
+  });
 });
 
 describe('postReview with context', () => {
@@ -885,8 +897,6 @@ describe('postReview with context', () => {
     const body = mockCreateReview.mock.calls[0][0].body as string;
     expect(body.length).toBeLessThanOrEqual(60000);
 
-    // Re-extract the embedded context JSON to assert priority ordering and the
-    // `truncated` flag.
     const match = body.match(/```json\n([\s\S]*?)\n```/);
     expect(match).not.toBeNull();
     const parsed = JSON.parse(match![1]) as RoundContext;
@@ -895,6 +905,8 @@ describe('postReview with context', () => {
     // Nitpicks are dropped first, so any survivor must be a higher-priority severity
     // unless every nitpick was preserved (which would mean no truncation).
     const bySev = (s: string) => parsed.findings.entries.filter(e => e.severity === s).length;
+    // At least some nitpicks must have been dropped — the budget is tight enough to require it.
+    expect(bySev('nitpick')).toBeLessThan(250);
     const droppedSuggestion = 250 - bySev('suggestion');
     const droppedWarning = 250 - bySev('warning');
     const droppedBlocker = 250 - bySev('blocker');

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -644,9 +644,7 @@ function makeContext(overrides: Partial<RoundContext> = {}): RoundContext {
       commitSha: 'abc123',
       round: 1,
       timestamp: '2026-01-01T00:00:00.000Z',
-      runId: 1,
       mankiVersion: '4.7.0',
-      promptVersions: { judge: 'unversioned', reviewer: 'unversioned', planner: 'unversioned' },
     },
     config: { reviewLevel: 'medium', nitHandling: 'issues', memoryEnabled: false },
     diff: { lines: 120, additions: 80, deletions: 40, filesReviewed: 5, fileTypes: { '.ts': 5 } },
@@ -709,8 +707,7 @@ describe('formatContextBlock', () => {
     const ctx = makeContext({
       meta: {
         prNumber: 10, commitSha: 'def456', round: 2, timestamp: '2026-01-01T00:00:00.000Z',
-        runId: 99, mankiVersion: '4.7.0',
-        promptVersions: { judge: 'unversioned', reviewer: 'unversioned', planner: 'unversioned' },
+        mankiVersion: '4.7.0',
       },
       findings: { count: 2, severityCounts: { blocker: 1, warning: 0, suggestion: 1, nitpick: 0 }, entries: [] },
       verdict: 'APPROVE',
@@ -808,6 +805,25 @@ describe('truncateContextToFitBody', () => {
     expect(droppedCount).toBe(0);
     expect(out.findings.entries).toEqual([]);
     expect(render(out).length).toBeGreaterThan(1);
+  });
+
+  it('truncates judge.summary when it alone exceeds budget after entries are exhausted', () => {
+    const longSummary = 'a'.repeat(3000);
+    const ctx = makeContext({
+      judge: { summary: longSummary },
+      findings: { count: 0, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, entries: [] },
+    });
+    const render = (c: RoundContext) => JSON.stringify(c);
+    // Set budget just below the size of the bare context with the long summary so
+    // summary truncation is what pulls it under.
+    const fullSize = render(ctx).length;
+    const budget = fullSize - 500;
+    const { context: out, droppedCount } = truncateContextToFitBody(ctx, render, budget);
+    expect(droppedCount).toBe(0);
+    expect(out.judge.summary.length).toBeLessThan(longSummary.length);
+    // safeTruncate(summary, 2000) yields at most 2003 chars (2000 + ellipsis)
+    expect(out.judge.summary.length).toBeLessThanOrEqual(2003);
+    expect(render(out).length).toBeLessThanOrEqual(budget);
   });
 });
 
@@ -907,6 +923,9 @@ describe('postReview with context', () => {
     const bySev = (s: string) => parsed.findings.entries.filter(e => e.severity === s).length;
     // At least some nitpicks must have been dropped — the budget is tight enough to require it.
     expect(bySev('nitpick')).toBeLessThan(250);
+    // Nitpicks are always dropped before suggestions. With 1000 entries and 4 tiers the budget
+    // is designed so that suggestions must also be dropped, so we can assert this unconditionally.
+    expect(bySev('nitpick')).toBe(0);
     const droppedSuggestion = 250 - bySev('suggestion');
     const droppedWarning = 250 - bySev('warning');
     const droppedBlocker = 250 - bySev('blocker');

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 
-import { buildDashboard, formatFindingComment, formatStatsJson, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
-import { DashboardData, Finding, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats } from './types';
+import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { DashboardData, Finding, FindingFingerprintEntry, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, roundContextToFlatAliases } from './types';
 
 describe('formatFindingComment', () => {
   const baseFinding: Finding = {
@@ -637,46 +637,61 @@ describe('postReview generalFindings', () => {
   });
 });
 
-describe('formatStatsOneLiner', () => {
-  const baseStats: ReviewStats = {
-    model: 'claude-sonnet-4-20250514',
-    reviewTimeMs: 45000,
-    diffLines: 120,
-    diffAdditions: 80,
-    diffDeletions: 40,
-    filesReviewed: 5,
-    agents: ['Security & Safety', 'Correctness'],
-    findingsRaw: 10,
-    findingsKept: 4,
-    findingsDropped: 6,
-    severity: { blocker: 1, warning: 0, suggestion: 2, nitpick: 1 },
+function makeContext(overrides: Partial<RoundContext> = {}): RoundContext {
+  const base: RoundContext = {
+    meta: {
+      prNumber: 42,
+      commitSha: 'abc123',
+      round: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      runId: 1,
+      mankiVersion: '4.7.0',
+      promptVersions: { judge: 'unversioned', reviewer: 'unversioned', planner: 'unversioned' },
+    },
+    config: { reviewLevel: 'medium', nitHandling: 'issues', memoryEnabled: false },
+    diff: { lines: 120, additions: 80, deletions: 40, filesReviewed: 5, fileTypes: { '.ts': 5 } },
+    models: { reviewer: 'claude-sonnet-4-20250514', judge: 'claude-opus-4-20250514' },
+    planner: { used: false },
+    reviewers: { agents: ['Security & Safety', 'Correctness'] },
+    judge: { summary: 'All checks done.' },
+    dedup: {},
+    memory: {},
+    findings: { count: 4, severityCounts: { blocker: 1, warning: 0, suggestion: 2, nitpick: 1 }, entries: [] },
+    usage: {},
     verdict: 'REQUEST_CHANGES',
-    prNumber: 42,
-    commitSha: 'abc123',
   };
+  return { ...base, ...overrides };
+}
 
+describe('formatStatsOneLiner', () => {
   it('formats a one-liner with severity breakdown', () => {
-    const result = formatStatsOneLiner(baseStats);
+    const result = formatStatsOneLiner(makeContext(), 45000);
     expect(result).toBe('\u{1F4CA} 4 findings (1 blocker, 2 suggestion, 1 nitpick) \u00B7 120 lines \u00B7 45s');
   });
 
   it('omits zero-count severities', () => {
-    const stats = { ...baseStats, severity: { blocker: 0, warning: 0, suggestion: 3, nitpick: 0 }, findingsKept: 3 };
-    const result = formatStatsOneLiner(stats);
+    const ctx = makeContext({
+      findings: { count: 3, severityCounts: { blocker: 0, warning: 0, suggestion: 3, nitpick: 0 }, entries: [] },
+    });
+    const result = formatStatsOneLiner(ctx, 45000);
     expect(result).toContain('(3 suggestion)');
     expect(result).not.toContain('blocker');
     expect(result).not.toContain('nitpick');
   });
 
   it('shows none when all severities are zero', () => {
-    const stats = { ...baseStats, severity: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, findingsKept: 0 };
-    const result = formatStatsOneLiner(stats);
+    const ctx = makeContext({
+      findings: { count: 0, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, entries: [] },
+    });
+    const result = formatStatsOneLiner(ctx, 45000);
     expect(result).toContain('(none)');
   });
 
   it('includes non-zero warning count in output', () => {
-    const stats = { ...baseStats, severity: { blocker: 0, warning: 2, suggestion: 1, nitpick: 0 }, findingsKept: 3 };
-    const result = formatStatsOneLiner(stats);
+    const ctx = makeContext({
+      findings: { count: 3, severityCounts: { blocker: 0, warning: 2, suggestion: 1, nitpick: 0 }, entries: [] },
+    });
+    const result = formatStatsOneLiner(ctx, 45000);
     expect(result).toContain('2 warning');
     expect(result).toContain('1 suggestion');
     expect(result).not.toContain('blocker');
@@ -684,41 +699,62 @@ describe('formatStatsOneLiner', () => {
   });
 
   it('rounds review time to nearest second', () => {
-    const stats = { ...baseStats, reviewTimeMs: 1500 };
-    const result = formatStatsOneLiner(stats);
+    const result = formatStatsOneLiner(makeContext(), 1500);
     expect(result).toContain('2s');
   });
 });
 
-describe('formatStatsJson', () => {
-  it('wraps stats in a collapsed details block with JSON', () => {
-    const stats: ReviewStats = {
-      model: 'claude-sonnet-4-20250514',
-      reviewTimeMs: 30000,
-      diffLines: 50,
-      diffAdditions: 30,
-      diffDeletions: 20,
-      filesReviewed: 3,
-      agents: ['Security'],
-      findingsRaw: 5,
-      findingsKept: 2,
-      findingsDropped: 3,
-      severity: { blocker: 1, warning: 0, suggestion: 1, nitpick: 0 },
+describe('formatContextBlock', () => {
+  it('wraps the round context in a collapsed details block with JSON', () => {
+    const ctx = makeContext({
+      meta: {
+        prNumber: 10, commitSha: 'def456', round: 2, timestamp: '2026-01-01T00:00:00.000Z',
+        runId: 99, mankiVersion: '4.7.0',
+        promptVersions: { judge: 'unversioned', reviewer: 'unversioned', planner: 'unversioned' },
+      },
+      findings: { count: 2, severityCounts: { blocker: 1, warning: 0, suggestion: 1, nitpick: 0 }, entries: [] },
       verdict: 'APPROVE',
-      prNumber: 10,
-      commitSha: 'def456',
-    };
-    const result = formatStatsJson(stats);
+    });
+    const result = formatContextBlock(ctx);
     expect(result).toContain('<details>');
-    expect(result).toContain('<summary>Review stats</summary>');
+    expect(result).toContain('<summary>Manki context</summary>');
     expect(result).toContain('```json');
-    expect(result).toContain('"model": "claude-sonnet-4-20250514"');
-    expect(result).toContain('"findingsKept": 2');
+    expect(result).toContain('"reviewer": "claude-sonnet-4-20250514"');
+    expect(result).toContain('"count": 2');
+    expect(result).toContain('"verdict": "APPROVE"');
     expect(result).toContain('</details>');
+    expect(result).not.toContain('Review stats');
+  });
+
+  it('round-trips the flat-alias projection for a representative round', () => {
+    const ctx = makeContext({
+      dedup: { staticDropped: 1, llmDropped: 2 },
+      judge: { summary: 'sum', mergedDuplicates: 3 },
+      findings: { count: 4, severityCounts: { blocker: 1, warning: 0, suggestion: 2, nitpick: 1 }, entries: [] },
+      diff: { lines: 120, additions: 80, deletions: 40, filesReviewed: 5, fileTypes: { '.ts': 5 } },
+    });
+    const aliases = roundContextToFlatAliases(ctx);
+    expect(aliases).toEqual({
+      prNumber: 42,
+      commitSha: 'abc123',
+      verdict: 'REQUEST_CHANGES',
+      diffLines: 120,
+      diffAdditions: 80,
+      diffDeletions: 40,
+      filesReviewed: 5,
+      agents: ['Security & Safety', 'Correctness'],
+      findingsRaw: 10,
+      findingsKept: 4,
+      findingsDropped: 6,
+      severity: { blocker: 1, warning: 0, suggestion: 2, nitpick: 1 },
+      model: 'claude-sonnet-4-20250514',
+      reviewerModel: 'claude-sonnet-4-20250514',
+      judgeModel: 'claude-opus-4-20250514',
+    });
   });
 });
 
-describe('postReview with stats', () => {
+describe('postReview with context', () => {
   const mockCreateReview = jest.fn().mockResolvedValue({ data: { id: 1 } });
   const mockOctokit = {
     rest: {
@@ -730,9 +766,10 @@ describe('postReview with stats', () => {
 
   beforeEach(() => {
     mockCreateReview.mockClear();
+    jest.spyOn(core, 'warning').mockImplementation(() => {}).mockClear();
   });
 
-  it('includes stats one-liner and collapsed JSON in review body', async () => {
+  it('includes stats one-liner and Manki context block in review body', async () => {
     const result: ReviewResult = {
       verdict: 'APPROVE',
       summary: 'All good.',
@@ -741,33 +778,23 @@ describe('postReview with stats', () => {
       reviewComplete: true,
       agentNames: [],
     };
-    const stats: ReviewStats = {
-      model: 'claude-sonnet-4-20250514',
-      reviewTimeMs: 60000,
-      diffLines: 200,
-      diffAdditions: 150,
-      diffDeletions: 50,
-      filesReviewed: 8,
-      agents: ['Security', 'Correctness'],
-      findingsRaw: 6,
-      findingsKept: 3,
-      findingsDropped: 3,
-      severity: { blocker: 0, warning: 0, suggestion: 2, nitpick: 1 },
+    const ctx = makeContext({
+      diff: { lines: 200, additions: 150, deletions: 50, filesReviewed: 8, fileTypes: { '.ts': 8 } },
+      reviewers: { agents: ['Security', 'Correctness'] },
+      findings: { count: 3, severityCounts: { blocker: 0, warning: 0, suggestion: 2, nitpick: 1 }, entries: [] },
       verdict: 'APPROVE',
-      prNumber: 99,
-      commitSha: 'abc',
-    };
+    });
 
-    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, stats);
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 60000);
     const body = mockCreateReview.mock.calls[0][0].body as string;
     expect(body).toContain('\u{1F4CA} 3 findings');
     expect(body).toContain('200 lines');
     expect(body).toContain('60s');
-    expect(body).toContain('<details>');
-    expect(body).toContain('"model": "claude-sonnet-4-20250514"');
+    expect(body).toContain('<summary>Manki context</summary>');
+    expect(body).toContain('"reviewer": "claude-sonnet-4-20250514"');
   });
 
-  it('omits stats section when stats not provided', async () => {
+  it('omits stats section when context not provided', async () => {
     const result: ReviewResult = {
       verdict: 'APPROVE',
       summary: 'All good.',
@@ -780,7 +807,83 @@ describe('postReview with stats', () => {
     await postReview(mockOctokit, 'owner', 'repo', 1, 'sha', result);
     const body = mockCreateReview.mock.calls[0][0].body as string;
     expect(body).not.toContain('\u{1F4CA}');
+    expect(body).not.toContain('Manki context');
     expect(body).not.toContain('Review stats');
+  });
+
+  it('truncates findings.entries in priority order when body exceeds 60k chars', async () => {
+    const result: ReviewResult = {
+      verdict: 'COMMENT',
+      summary: 'Many findings.',
+      findings: [],
+      highlights: [],
+      reviewComplete: true,
+      agentNames: [],
+    };
+    // Each fingerprint slug is ~120 chars; 1000 entries with mixed severities push the
+    // serialized JSON over the 60k budget so truncation must drop the lowest-priority
+    // entries first.
+    const longSlug = 'long-slug-token-'.repeat(8);
+    const entries: FindingFingerprintEntry[] = [];
+    for (let i = 0; i < 250; i++) {
+      entries.push({ fingerprint: { file: `src/file-${i}.ts`, lineStart: i, lineEnd: i, slug: `nit-${longSlug}${i}` }, severity: 'nitpick' });
+      entries.push({ fingerprint: { file: `src/file-${i}.ts`, lineStart: i, lineEnd: i, slug: `sug-${longSlug}${i}` }, severity: 'suggestion' });
+      entries.push({ fingerprint: { file: `src/file-${i}.ts`, lineStart: i, lineEnd: i, slug: `warn-${longSlug}${i}` }, severity: 'warning' });
+      entries.push({ fingerprint: { file: `src/file-${i}.ts`, lineStart: i, lineEnd: i, slug: `block-${longSlug}${i}` }, severity: 'blocker' });
+    }
+    const ctx = makeContext({
+      findings: { count: entries.length, severityCounts: { blocker: 250, warning: 250, suggestion: 250, nitpick: 250 }, entries },
+    });
+
+    const warningSpy = jest.spyOn(core, 'warning');
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 1000);
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    expect(body.length).toBeLessThanOrEqual(60000);
+
+    // Re-extract the embedded context JSON to assert priority ordering and the
+    // `truncated` flag.
+    const match = body.match(/```json\n([\s\S]*?)\n```/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]) as RoundContext;
+    expect(parsed.findings.truncated).toBe(true);
+    expect(parsed.findings.entries.length).toBeLessThan(entries.length);
+    // Nitpicks are dropped first, so any survivor must be a higher-priority severity
+    // unless every nitpick was preserved (which would mean no truncation).
+    const survivingNitpicks = parsed.findings.entries.filter(e => e.severity === 'nitpick').length;
+    const survivingSuggestions = parsed.findings.entries.filter(e => e.severity === 'suggestion').length;
+    const survivingWarnings = parsed.findings.entries.filter(e => e.severity === 'warning').length;
+    const survivingBlockers = parsed.findings.entries.filter(e => e.severity === 'blocker').length;
+    if (survivingSuggestions > 0) expect(survivingNitpicks).toBe(0);
+    if (survivingWarnings > 0) expect(survivingSuggestions).toBe(0);
+    if (survivingBlockers > 0) expect(survivingWarnings).toBe(0);
+
+    expect(warningSpy).toHaveBeenCalledWith(expect.stringMatching(/Manki context truncated: dropped \d+ finding entries/));
+  });
+
+  it('does not truncate when rendered body is under the 60k budget', async () => {
+    const result: ReviewResult = {
+      verdict: 'APPROVE',
+      summary: 'Small review.',
+      findings: [],
+      highlights: [],
+      reviewComplete: true,
+      agentNames: [],
+    };
+    const ctx = makeContext({
+      findings: {
+        count: 1,
+        severityCounts: { blocker: 0, warning: 0, suggestion: 1, nitpick: 0 },
+        entries: [{ fingerprint: { file: 'src/a.ts', lineStart: 1, lineEnd: 1, slug: 'tiny' }, severity: 'suggestion' }],
+      },
+    });
+    const warningSpy = jest.spyOn(core, 'warning');
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 1000);
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    const match = body.match(/```json\n([\s\S]*?)\n```/);
+    const parsed = JSON.parse(match![1]) as RoundContext;
+    expect(parsed.findings.truncated).toBeUndefined();
+    expect(parsed.findings.entries).toHaveLength(1);
+    expect(warningSpy).not.toHaveBeenCalledWith(expect.stringMatching(/Manki context truncated/));
   });
 });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -735,6 +735,9 @@ describe('formatContextBlock', () => {
     expect(result).toContain('\\u0060\\u0060\\u0060');
   });
 
+});
+
+describe('roundContextToFlatAliases', () => {
   it('round-trips the flat-alias projection for a representative round', () => {
     const ctx = makeContext({
       dedup: { staticDropped: 1, llmDropped: 2 },
@@ -980,6 +983,25 @@ describe('postReview with context', () => {
     await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, makeContext());
     const body = mockCreateReview.mock.calls[0][0].body as string;
     expect(body).toContain('0s');
+  });
+
+  it('fires core.warning and caps summary when only judge.summary exceeds budget', async () => {
+    const result: ReviewResult = {
+      verdict: 'APPROVE', summary: '', findings: [],
+      highlights: [], reviewComplete: true, agentNames: [],
+    };
+    const ctx = makeContext({
+      judge: { summary: 'a'.repeat(65000) },
+      findings: { count: 0, severityCounts: {}, entries: [] },
+    });
+    const warningSpy = jest.spyOn(core, 'warning');
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 0);
+    expect(warningSpy).toHaveBeenCalledWith(expect.stringMatching(/judge summary capped/));
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    const match = body.match(/```json\n([\s\S]*?)\n```/);
+    const parsed = JSON.parse(match![1]) as RoundContext;
+    expect(parsed.findings.truncated).toBeUndefined();
+    expect(parsed.judge.summary.length).toBeLessThanOrEqual(2003);
   });
 });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 
-import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, FindingFingerprintEntry, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, roundContextToFlatAliases } from './types';
 
 describe('formatFindingComment', () => {
@@ -726,6 +726,18 @@ describe('formatContextBlock', () => {
     expect(result).not.toContain('Review stats');
   });
 
+  it('escapes triple-backtick runs in the serialized JSON to avoid breaking the code fence', () => {
+    const ctx = makeContext({ judge: { summary: 'Use ```json``` fences in examples.' } });
+    const result = formatContextBlock(ctx);
+    // The JSON blob between the opening ```json fence and closing ``` must not
+    // contain a raw triple-backtick sequence that would close the fence early.
+    const fenceOpen = result.indexOf('```json\n');
+    const fenceClose = result.indexOf('\n```\n', fenceOpen + 8);
+    const jsonBlob = result.slice(fenceOpen + 8, fenceClose);
+    expect(jsonBlob).not.toContain('```');
+    expect(result).toContain('\\u0060\\u0060\\u0060');
+  });
+
   it('round-trips the flat-alias projection for a representative round', () => {
     const ctx = makeContext({
       dedup: { staticDropped: 1, llmDropped: 2 },
@@ -751,6 +763,39 @@ describe('formatContextBlock', () => {
       reviewerModel: 'claude-sonnet-4-20250514',
       judgeModel: 'claude-opus-4-20250514',
     });
+  });
+
+  it('uses zero defaults when optional dedup/judge counts are absent', () => {
+    const ctx = makeContext();
+    const aliases = roundContextToFlatAliases(ctx);
+    expect(aliases.findingsRaw).toBe(4);
+    expect(aliases.findingsDropped).toBe(0);
+  });
+});
+
+describe('truncateContextToFitBody', () => {
+  it('returns original context unchanged when body is already within budget', () => {
+    const ctx = makeContext();
+    const render = (c: RoundContext) => JSON.stringify(c);
+    const { context: out, droppedCount } = truncateContextToFitBody(ctx, render, 1_000_000);
+    expect(droppedCount).toBe(0);
+    expect(out).toBe(ctx);
+  });
+
+  it('is idempotent — calling twice on an already-truncated context is a no-op', () => {
+    const entries: FindingFingerprintEntry[] = Array.from({ length: 50 }, (_, i) => ({
+      fingerprint: { file: `src/f-${i}.ts`, lineStart: i, lineEnd: i, slug: 'slug-'.repeat(20) + i },
+      severity: 'nitpick' as const,
+    }));
+    const ctx = makeContext({
+      findings: { count: entries.length, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: entries.length }, entries },
+    });
+    const render = (c: RoundContext) => JSON.stringify(c);
+    const budget = render(ctx).length - 100;
+    const { context: once } = truncateContextToFitBody(ctx, render, budget);
+    const { context: twice, droppedCount } = truncateContextToFitBody(once, render, budget);
+    expect(droppedCount).toBe(0);
+    expect(twice.findings.entries).toEqual(once.findings.entries);
   });
 });
 
@@ -849,13 +894,16 @@ describe('postReview with context', () => {
     expect(parsed.findings.entries.length).toBeLessThan(entries.length);
     // Nitpicks are dropped first, so any survivor must be a higher-priority severity
     // unless every nitpick was preserved (which would mean no truncation).
-    const survivingNitpicks = parsed.findings.entries.filter(e => e.severity === 'nitpick').length;
-    const survivingSuggestions = parsed.findings.entries.filter(e => e.severity === 'suggestion').length;
-    const survivingWarnings = parsed.findings.entries.filter(e => e.severity === 'warning').length;
-    const survivingBlockers = parsed.findings.entries.filter(e => e.severity === 'blocker').length;
-    if (survivingSuggestions > 0) expect(survivingNitpicks).toBe(0);
-    if (survivingWarnings > 0) expect(survivingSuggestions).toBe(0);
-    if (survivingBlockers > 0) expect(survivingWarnings).toBe(0);
+    const bySev = (s: string) => parsed.findings.entries.filter(e => e.severity === s).length;
+    const droppedSuggestion = 250 - bySev('suggestion');
+    const droppedWarning = 250 - bySev('warning');
+    const droppedBlocker = 250 - bySev('blocker');
+    // Nitpicks are dropped first: any dropped suggestion implies all nitpicks gone.
+    if (droppedSuggestion > 0) expect(bySev('nitpick')).toBe(0);
+    // Suggestions are dropped before warnings: any dropped warning implies all suggestions gone.
+    if (droppedWarning > 0) expect(bySev('suggestion')).toBe(0);
+    // Warnings are dropped before blockers: any dropped blocker implies all warnings gone.
+    if (droppedBlocker > 0) expect(bySev('warning')).toBe(0);
 
     expect(warningSpy).toHaveBeenCalledWith(expect.stringMatching(/Manki context truncated: dropped \d+ finding entries/));
   });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -795,7 +795,7 @@ describe('truncateContextToFitBody', () => {
     expect(twice.findings.entries).toEqual(once.findings.entries);
   });
 
-  it('returns over-budget context with truncated flag when body exceeds budget even after all entries dropped', () => {
+  it('returns over-budget context without truncated flag when no entries were dropped', () => {
     const ctx = makeContext({
       judge: { summary: 'x'.repeat(200) },
       findings: { count: 0, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, entries: [] },
@@ -804,6 +804,7 @@ describe('truncateContextToFitBody', () => {
     const { context: out, droppedCount } = truncateContextToFitBody(ctx, render, 1);
     expect(droppedCount).toBe(0);
     expect(out.findings.entries).toEqual([]);
+    expect(out.findings.truncated).toBeUndefined();
     expect(render(out).length).toBeGreaterThan(1);
   });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -774,8 +774,9 @@ describe('truncateContextToFitBody', () => {
   it('returns original context unchanged when body is already within budget', () => {
     const ctx = makeContext();
     const render = (c: RoundContext) => JSON.stringify(c);
-    const { context: out, droppedCount } = truncateContextToFitBody(ctx, render, 1_000_000);
+    const { context: out, droppedCount, summaryCapped } = truncateContextToFitBody(ctx, render, 1_000_000);
     expect(droppedCount).toBe(0);
+    expect(summaryCapped).toBe(false);
     expect(out).toBe(ctx);
   });
 
@@ -820,8 +821,9 @@ describe('truncateContextToFitBody', () => {
     // summary truncation is what pulls it under.
     const fullSize = render(ctx).length;
     const budget = fullSize - 500;
-    const { context: out, droppedCount } = truncateContextToFitBody(ctx, render, budget);
+    const { context: out, droppedCount, summaryCapped } = truncateContextToFitBody(ctx, render, budget);
     expect(droppedCount).toBe(0);
+    expect(summaryCapped).toBe(true);
     expect(out.judge.summary.length).toBeLessThan(longSummary.length);
     // safeTruncate(summary, 2000) yields at most 2003 chars (2000 + ellipsis)
     expect(out.judge.summary.length).toBeLessThanOrEqual(2003);
@@ -968,6 +970,16 @@ describe('postReview with context', () => {
     expect(parsed.findings.truncated).toBeUndefined();
     expect(parsed.findings.entries).toHaveLength(1);
     expect(warningSpy).not.toHaveBeenCalledWith(expect.stringMatching(/Manki context truncated/));
+  });
+
+  it('shows 0s for review time when reviewTimeMs is omitted', async () => {
+    const result: ReviewResult = {
+      verdict: 'APPROVE', summary: '', findings: [],
+      highlights: [], reviewComplete: true, agentNames: [],
+    };
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, makeContext());
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    expect(body).toContain('0s');
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -550,7 +550,7 @@ function truncateContextToFitBody(
   }
   let truncated: RoundContext = {
     ...context,
-    findings: { ...context.findings, entries: remaining, ...(dropped > 0 && { truncated: true }) },
+    findings: { ...context.findings, entries: remaining, count: remaining.length, ...(dropped > 0 && { truncated: true }) },
   };
   let summaryCapped = false;
   if (renderBody(truncated).length > maxBodyLength && truncated.judge.summary) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -554,11 +554,11 @@ function truncateContextToFitBody(
   };
   let summaryCapped = false;
   if (renderBody(truncated).length > maxBodyLength && truncated.judge.summary) {
-    truncated = {
-      ...truncated,
-      judge: { ...truncated.judge, summary: safeTruncate(truncated.judge.summary, 2000) },
-    };
-    summaryCapped = true;
+    const cappedSummary = safeTruncate(truncated.judge.summary, 2000);
+    if (cappedSummary !== truncated.judge.summary) {
+      truncated = { ...truncated, judge: { ...truncated.judge, summary: cappedSummary } };
+      summaryCapped = true;
+    }
   }
   return { context: truncated, droppedCount: dropped, summaryCapped };
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -504,7 +504,8 @@ function formatStatsOneLiner(context: RoundContext, reviewTimeMs: number): strin
 }
 
 function formatContextBlock(context: RoundContext): string {
-  const json = JSON.stringify(context, null, 2);
+  const json = JSON.stringify(context, null, 2)
+    .replace(/`{3,}/g, match => match.replace(/`/g, '\\u0060'));
   return `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
 }
 
@@ -1440,4 +1441,4 @@ async function cancelActiveReviewRun(
   }
 }
 
-export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };

--- a/src/github.ts
+++ b/src/github.ts
@@ -515,7 +515,7 @@ function formatContextBlock(context: RoundContext): string {
  * summary, models, and usage are preserved unconditionally.
  */
 const TRUNCATION_PRIORITY: ReadonlyArray<FindingFingerprintEntry['severity']> = [
-  'nitpick', 'suggestion', 'warning', 'blocker', 'unknown', 'ignore',
+  'ignore', 'nitpick', 'suggestion', 'warning', 'blocker', 'unknown',
 ];
 
 /**
@@ -545,10 +545,16 @@ function truncateContextToFitBody(
       break;
     }
   }
-  const truncated: RoundContext = {
+  let truncated: RoundContext = {
     ...context,
     findings: { ...context.findings, entries: remaining, truncated: true },
   };
+  if (renderBody(truncated).length > maxBodyLength && truncated.judge.summary) {
+    truncated = {
+      ...truncated,
+      judge: { ...truncated.judge, summary: safeTruncate(truncated.judge.summary, 2000) },
+    };
+  }
   return { context: truncated, droppedCount: dropped };
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -524,16 +524,16 @@ const TRUNCATION_PRIORITY: ReadonlyArray<FindingFingerprintEntry['severity']> = 
 /**
  * Drop entries from `findings.entries[]` in priority order until the
  * rendered review body is within `maxBodyLength`. Returns the (possibly
- * mutated) context and the count of entries dropped. Caller is expected to
- * `core.warning` when `droppedCount > 0`.
+ * mutated) context, the count of entries dropped, and whether the judge
+ * summary was capped. Caller is expected to `core.warning` on either signal.
  */
 function truncateContextToFitBody(
   context: RoundContext,
   renderBody: (ctx: RoundContext) => string,
   maxBodyLength: number,
-): { context: RoundContext; droppedCount: number } {
+): { context: RoundContext; droppedCount: number; summaryCapped: boolean } {
   if (renderBody(context).length <= maxBodyLength) {
-    return { context, droppedCount: 0 };
+    return { context, droppedCount: 0, summaryCapped: false };
   }
   const remaining = [...context.findings.entries];
   let dropped = 0;
@@ -552,13 +552,15 @@ function truncateContextToFitBody(
     ...context,
     findings: { ...context.findings, entries: remaining, ...(dropped > 0 && { truncated: true }) },
   };
+  let summaryCapped = false;
   if (renderBody(truncated).length > maxBodyLength && truncated.judge.summary) {
     truncated = {
       ...truncated,
       judge: { ...truncated.judge, summary: safeTruncate(truncated.judge.summary, 2000) },
     };
+    summaryCapped = true;
   }
-  return { context: truncated, droppedCount: dropped };
+  return { context: truncated, droppedCount: dropped, summaryCapped };
 }
 
 const REVIEW_BODY_BUDGET = 60000;
@@ -656,14 +658,14 @@ export async function postReview(
 
   let effectiveContext = context;
   if (context) {
-    const { context: maybeTruncated, droppedCount } = truncateContextToFitBody(
+    const { context: maybeTruncated, droppedCount, summaryCapped } = truncateContextToFitBody(
       context,
       ctx => renderBody(ctx),
       REVIEW_BODY_BUDGET,
     );
     effectiveContext = maybeTruncated;
-    if (droppedCount > 0) {
-      core.warning(`Manki context truncated: dropped ${droppedCount} finding entries to fit comment body`);
+    if (droppedCount > 0 || summaryCapped) {
+      core.warning(`Manki context truncated: dropped ${droppedCount} finding entries${summaryCapped ? ', judge summary capped at 2000 chars' : ''} to fit comment body`);
     }
   }
   const body = renderBody(effectiveContext);

--- a/src/github.ts
+++ b/src/github.ts
@@ -515,7 +515,7 @@ function formatContextBlock(context: RoundContext): string {
  * summary, models, and usage are preserved unconditionally.
  */
 const TRUNCATION_PRIORITY: ReadonlyArray<FindingFingerprintEntry['severity']> = [
-  'ignore', 'nitpick', 'suggestion', 'warning', 'blocker', 'unknown',
+  'ignore', 'nitpick', 'suggestion', 'warning', 'unknown', 'blocker',
 ];
 
 /**
@@ -547,7 +547,7 @@ function truncateContextToFitBody(
   }
   let truncated: RoundContext = {
     ...context,
-    findings: { ...context.findings, entries: remaining, truncated: true },
+    findings: { ...context.findings, entries: remaining, ...(dropped > 0 && { truncated: true }) },
   };
   if (renderBody(truncated).length > maxBodyLength && truncated.judge.summary) {
     truncated = {
@@ -562,6 +562,9 @@ const REVIEW_BODY_BUDGET = 60000;
 
 /**
  * Post the review with inline comments.
+ *
+ * When `context` is provided without `reviewTimeMs`, the stats one-liner
+ * will display `0s` for review time. Pass both together to avoid this.
  */
 export async function postReview(
   octokit: Octokit,
@@ -655,9 +658,9 @@ export async function postReview(
       ctx => renderBody(ctx),
       REVIEW_BODY_BUDGET,
     );
+    effectiveContext = maybeTruncated;
     if (droppedCount > 0) {
       core.warning(`Manki context truncated: dropped ${droppedCount} finding entries to fit comment body`);
-      effectiveContext = maybeTruncated;
     }
   }
   const body = renderBody(effectiveContext);

--- a/src/github.ts
+++ b/src/github.ts
@@ -513,6 +513,9 @@ function formatContextBlock(context: RoundContext): string {
  * Severity drop order when shrinking `findings.entries[]` to fit the review
  * body budget. Lowest-impact severities go first; metadata, agents, judge
  * summary, models, and usage are preserved unconditionally.
+ *
+ * `'unknown'` is placed before `'blocker'` because a confirmed blocker carries
+ * more informational value than an entry whose severity could not be determined.
  */
 const TRUNCATION_PRIORITY: ReadonlyArray<FindingFingerprintEntry['severity']> = [
   'ignore', 'nitpick', 'suggestion', 'warning', 'unknown', 'blocker',

--- a/src/github.ts
+++ b/src/github.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { AgentProgressEntry, DEFENSIVE_HARDENING_TAG, DashboardData, Finding, FindingSeverity, OWN_PROPOSAL_TAG, ParsedDiff, ReviewMetadata, ReviewResult, ReviewStats, ReviewVerdict } from './types';
+import { AgentProgressEntry, DEFENSIVE_HARDENING_TAG, DashboardData, Finding, FindingFingerprintEntry, FindingSeverity, OWN_PROPOSAL_TAG, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, ReviewVerdict } from './types';
 import { isLineInDiff, findClosestDiffLine } from './diff';
 import { MAX_AGENT_RETRIES } from './types';
 import { safeTruncate } from './utils';
@@ -490,22 +490,68 @@ export async function dismissPreviousReviews(
   }
 }
 
-function formatStatsOneLiner(stats: ReviewStats): string {
+function formatStatsOneLiner(context: RoundContext, reviewTimeMs: number): string {
+  const sev = context.findings.severityCounts;
   const parts: string[] = [];
-  if (stats.severity.blocker) parts.push(`${stats.severity.blocker} blocker`);
-  if (stats.severity.warning) parts.push(`${stats.severity.warning} warning`);
-  if (stats.severity.suggestion) parts.push(`${stats.severity.suggestion} suggestion`);
-  if (stats.severity.nitpick) parts.push(`${stats.severity.nitpick} nitpick`);
+  if (sev.blocker) parts.push(`${sev.blocker} blocker`);
+  if (sev.warning) parts.push(`${sev.warning} warning`);
+  if (sev.suggestion) parts.push(`${sev.suggestion} suggestion`);
+  if (sev.nitpick) parts.push(`${sev.nitpick} nitpick`);
   const breakdown = parts.length > 0 ? parts.join(', ') : 'none';
-  const total = stats.findingsKept;
-  const time = Math.round(stats.reviewTimeMs / 1000);
-  return `\u{1F4CA} ${total} findings (${breakdown}) \u00B7 ${stats.diffLines} lines \u00B7 ${time}s`;
+  const total = context.findings.count;
+  const time = Math.round(reviewTimeMs / 1000);
+  return `\u{1F4CA} ${total} findings (${breakdown}) \u00B7 ${context.diff.lines} lines \u00B7 ${time}s`;
 }
 
-function formatStatsJson(stats: ReviewStats): string {
-  const json = JSON.stringify(stats, null, 2);
-  return `<details>\n<summary>Review stats</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
+function formatContextBlock(context: RoundContext): string {
+  const json = JSON.stringify(context, null, 2);
+  return `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
 }
+
+/**
+ * Severity drop order when shrinking `findings.entries[]` to fit the review
+ * body budget. Lowest-impact severities go first; metadata, agents, judge
+ * summary, models, and usage are preserved unconditionally.
+ */
+const TRUNCATION_PRIORITY: ReadonlyArray<FindingFingerprintEntry['severity']> = [
+  'nitpick', 'suggestion', 'warning', 'blocker', 'unknown', 'ignore',
+];
+
+/**
+ * Drop entries from `findings.entries[]` in priority order until the
+ * rendered review body is within `maxBodyLength`. Returns the (possibly
+ * mutated) context and the count of entries dropped. Caller is expected to
+ * `core.warning` when `droppedCount > 0`.
+ */
+function truncateContextToFitBody(
+  context: RoundContext,
+  renderBody: (ctx: RoundContext) => string,
+  maxBodyLength: number,
+): { context: RoundContext; droppedCount: number } {
+  if (renderBody(context).length <= maxBodyLength) {
+    return { context, droppedCount: 0 };
+  }
+  const remaining = [...context.findings.entries];
+  let dropped = 0;
+  for (const target of TRUNCATION_PRIORITY) {
+    while (renderBody({ ...context, findings: { ...context.findings, entries: remaining, truncated: true } }).length > maxBodyLength) {
+      const idx = remaining.findIndex(e => e.severity === target);
+      if (idx === -1) break;
+      remaining.splice(idx, 1);
+      dropped++;
+    }
+    if (renderBody({ ...context, findings: { ...context.findings, entries: remaining, truncated: true } }).length <= maxBodyLength) {
+      break;
+    }
+  }
+  const truncated: RoundContext = {
+    ...context,
+    findings: { ...context.findings, entries: remaining, truncated: true },
+  };
+  return { context: truncated, droppedCount: dropped };
+}
+
+const REVIEW_BODY_BUDGET = 60000;
 
 /**
  * Post the review with inline comments.
@@ -518,7 +564,8 @@ export async function postReview(
   commitSha: string,
   result: ReviewResult,
   diff?: ParsedDiff,
-  stats?: ReviewStats,
+  context?: RoundContext,
+  reviewTimeMs?: number,
 ): Promise<number> {
   const event = mapVerdictToEvent(result.verdict);
 
@@ -576,20 +623,37 @@ export async function postReview(
     }
   }
 
-  let body = `${BOT_MARKERS}\n${sanitizeMarkdown(result.summary)}`;
-  if (result.partialNote) {
-    body += `\n\n> **Note:** ${sanitizeMarkdown(result.partialNote)}`;
+  const renderBody = (ctx: RoundContext | undefined): string => {
+    let b = `${BOT_MARKERS}\n${sanitizeMarkdown(result.summary)}`;
+    if (result.partialNote) {
+      b += `\n\n> **Note:** ${sanitizeMarkdown(result.partialNote)}`;
+    }
+    if (ctx) {
+      b += `\n\n${formatStatsOneLiner(ctx, reviewTimeMs ?? 0)}`;
+      b += `\n\n${formatContextBlock(ctx)}`;
+    }
+    if (generalFindings.length > 0) {
+      b += `\n\n**General findings:**\n${generalFindings.map(c => `- ${c}`).join('\n')}`;
+    }
+    if (invalidComments.length > 0) {
+      b += `\n\n**Findings (not on changed lines):**\n${invalidComments.map(c => `- ${c}`).join('\n')}`;
+    }
+    return b;
+  };
+
+  let effectiveContext = context;
+  if (context) {
+    const { context: maybeTruncated, droppedCount } = truncateContextToFitBody(
+      context,
+      ctx => renderBody(ctx),
+      REVIEW_BODY_BUDGET,
+    );
+    if (droppedCount > 0) {
+      core.warning(`Manki context truncated: dropped ${droppedCount} finding entries to fit comment body`);
+      effectiveContext = maybeTruncated;
+    }
   }
-  if (stats) {
-    body += `\n\n${formatStatsOneLiner(stats)}`;
-    body += `\n\n${formatStatsJson(stats)}`;
-  }
-  if (generalFindings.length > 0) {
-    body += `\n\n**General findings:**\n${generalFindings.map(c => `- ${c}`).join('\n')}`;
-  }
-  if (invalidComments.length > 0) {
-    body += `\n\n**Findings (not on changed lines):**\n${invalidComments.map(c => `- ${c}`).join('\n')}`;
-  }
+  const body = renderBody(effectiveContext);
 
   if (invalidComments.length > 0) {
     core.info(`Moved ${invalidComments.length} comments to review body (lines not in diff)`);
@@ -1376,4 +1440,4 @@ async function cancelActiveReviewRun(
   }
 }
 
-export { dynamicFence, formatFindingComment, formatStatsJson, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2217,6 +2217,57 @@ describe('runFullReview orchestration', () => {
     expect(roundContextArg!.meta.round).toBe(2);
   });
 
+  describe('meta.round derivation', () => {
+    const roundTestFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+
+    it('sets meta.round to 1 when no handover is present', async () => {
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [roundTestFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([roundTestFile]);
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue(null);
+
+      await callRunFullReview();
+
+      const roundContextArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+      expect(roundContextArg!.meta.round).toBe(1);
+    });
+
+    it('sets meta.round to N+1 when handover has N prior rounds', async () => {
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [roundTestFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([roundTestFile]);
+      jest.mocked(configModule.loadConfig).mockReturnValue({
+        auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
+        reviewers: [], instructions: '', review_level: 'auto',
+        review_thresholds: { small: 200, medium: 800 },
+        memory: { enabled: true, repo: 'owner/memory' },
+      });
+      jest.mocked(authModule.getMemoryToken).mockReturnValue('token123');
+      jest.mocked(memoryModule.loadMemory).mockResolvedValue({
+        learnings: [], suppressions: [], patterns: [],
+      });
+
+      const priorRounds = [
+        { round: 1, commitSha: 'sha1', timestamp: '2025-01-01T00:00:00Z', findings: [] },
+        { round: 2, commitSha: 'sha2', timestamp: '2025-01-02T00:00:00Z', findings: [] },
+        { round: 3, commitSha: 'sha3', timestamp: '2025-01-03T00:00:00Z', findings: [] },
+      ];
+      jest.mocked(memoryModule.loadHandover).mockResolvedValue({
+        prNumber: 1, repo: 'test-repo', rounds: priorRounds,
+      });
+
+      await callRunFullReview();
+
+      const roundContextArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+      expect(roundContextArg!.meta.round).toBe(4);
+    });
+  });
+
   describe('prior-round agent pinning', () => {
     const pinTestFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1803,6 +1803,8 @@ describe('runFullReview orchestration', () => {
     expect(statsArg!.models.reviewer).toBeDefined();
     expect(statsArg!.models.judge).toBeDefined();
 
+    expect(statsArg!.meta.round).toBe(1);
+
     // keptSeverities/droppedSeverities passed to dashboard use original severity for dropped findings
     const dashboardArg = jest.mocked(ghUtils.updateProgressComment).mock.calls.at(-1)?.[4];
     expect(dashboardArg?.keptSeverities).toEqual({ blocker: 1, suggestion: 1, nitpick: 1 });
@@ -2209,6 +2211,10 @@ describe('runFullReview orchestration', () => {
     const { 11: existingHandoverArg } = appendCall;
     // existingHandover param should be the already-loaded handover, not re-fetched
     expect(existingHandoverArg).toEqual({ prNumber: 1, repo: 'test-repo', rounds: priorRounds });
+
+    // With 1 prior round in handover, meta.round must be 2
+    const roundContextArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    expect(roundContextArg!.meta.round).toBe(2);
   });
 
   describe('prior-round agent pinning', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1727,6 +1727,7 @@ describe('runFullReview orchestration', () => {
       expect.objectContaining({ verdict: 'REQUEST_CHANGES' }),
       expect.anything(),
       expect.anything(),
+      expect.anything(),
     );
     // Outputs set
     expect(jest.mocked(core.setOutput)).toHaveBeenCalledWith('verdict', 'REQUEST_CHANGES');
@@ -1785,31 +1786,22 @@ describe('runFullReview orchestration', () => {
     expect(statsArg).toBeDefined();
 
     // agentMetrics: third finding has both reviewers, so security gets 3 raw / 2 kept
-    expect(statsArg!.agentMetrics).toEqual([
+    expect(statsArg!.reviewers.agentMetrics).toEqual([
       { name: 'security', findingsRaw: 3, findingsKept: 2 },
       { name: 'general', findingsRaw: 2, findingsKept: 2 },
     ]);
 
-    // judgeMetrics
-    expect(statsArg!.judgeMetrics).toEqual({
+    expect(statsArg!.judge).toEqual(expect.objectContaining({
       confidenceDistribution: { high: 2, medium: 1, low: 1 },
       severityChanges: 2,
       mergedDuplicates: 2,
       verdictReason: 'novel_suggestion',
-    });
+    }));
 
-    // fileMetrics
-    expect(statsArg!.fileMetrics).toEqual({
-      fileTypes: { '.ts': 1, '.js': 1 },
-      findingsPerFile: { 'src/app.ts': 2, 'src/utils.js': 1 },
-    });
+    expect(statsArg!.diff.fileTypes).toEqual({ '.ts': 1, '.js': 1 });
 
-    // Model split
-    expect(statsArg!.reviewerModel).toBeDefined();
-    expect(statsArg!.judgeModel).toBeDefined();
-
-    // Backwards compatibility: model field still present
-    expect(statsArg!.model).toBeDefined();
+    expect(statsArg!.models.reviewer).toBeDefined();
+    expect(statsArg!.models.judge).toBeDefined();
 
     // keptSeverities/droppedSeverities passed to dashboard use original severity for dropped findings
     const dashboardArg = jest.mocked(ghUtils.updateProgressComment).mock.calls.at(-1)?.[4];
@@ -1863,10 +1855,10 @@ describe('runFullReview orchestration', () => {
     expect(statsArg).toBeDefined();
 
     // mergedDuplicates excludes pre-judge dedup: 5 - 1 (static) - 1 (llm) - 1 (judged) = 2
-    expect(statsArg!.judgeMetrics?.mergedDuplicates).toBe(2);
+    expect(statsArg!.judge.mergedDuplicates).toBe(2);
 
     // findingsRaw comes from rawFindings (pre-dedup per-agent counts)
-    expect(statsArg!.agentMetrics).toEqual([
+    expect(statsArg!.reviewers.agentMetrics).toEqual([
       { name: 'security', findingsRaw: 2, findingsKept: 1 },
       { name: 'general', findingsRaw: 3, findingsKept: 0 },
     ]);
@@ -1915,7 +1907,7 @@ describe('runFullReview orchestration', () => {
     expect(statsArg).toBeDefined();
 
     // mergedDuplicates excludes memory suppressions: 4 - 2 (suppressed) - 0 - 0 - 1 (judged) = 1
-    expect(statsArg!.judgeMetrics?.mergedDuplicates).toBe(1);
+    expect(statsArg!.judge.mergedDuplicates).toBe(1);
   });
 
   it('counts defensive-hardening findings in judgeMetrics', async () => {
@@ -1950,7 +1942,7 @@ describe('runFullReview orchestration', () => {
     await callRunFullReview();
 
     const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
-    expect(statsArg!.judgeMetrics?.defensiveHardeningCount).toBe(1);
+    expect(statsArg!.judge.defensiveHardeningCount).toBe(1);
   });
 
   it('surfaces crossRoundSuppressed and crossRoundDemoted counts in judgeMetrics', async () => {
@@ -1985,8 +1977,8 @@ describe('runFullReview orchestration', () => {
     await callRunFullReview();
 
     const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
-    expect(statsArg!.judgeMetrics?.crossRoundSuppressed).toBe(1);
-    expect(statsArg!.judgeMetrics?.crossRoundDemoted).toBe(1);
+    expect(statsArg!.judge.crossRoundSuppressed).toBe(1);
+    expect(statsArg!.judge.crossRoundDemoted).toBe(1);
   });
 
   it('creates nit issues when nit_handling is "issues"', async () => {
@@ -2073,7 +2065,7 @@ describe('runFullReview orchestration', () => {
       expect.objectContaining({
         findings: [expect.objectContaining({ severity: 'nitpick' })],
       }),
-      expect.anything(), expect.anything(),
+      expect.anything(), expect.anything(), expect.anything(),
     );
   });
 
@@ -2558,13 +2550,13 @@ describe('runFullReview orchestration', () => {
     expect(jest.mocked(reviewModule.determineVerdict)).toHaveBeenCalled();
 
     const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
-    expect(statsArg?.judgeMetrics?.verdictReason).toBe('novel_suggestion');
+    expect(statsArg?.judge.verdictReason).toBe('novel_suggestion');
     // result.verdictReason must also be updated alongside result.verdict after escalation
     const reviewResultArg = jest.mocked(ghUtils.postReview).mock.calls[0][5];
     expect(reviewResultArg?.verdictReason).toBe('novel_suggestion');
   });
 
-  it('populates verdictReason in judgeMetrics on clean APPROVE with no findings', async () => {
+  it('populates verdictReason in judge on clean APPROVE with no findings', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,
       hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
@@ -2585,7 +2577,7 @@ describe('runFullReview orchestration', () => {
     await callRunFullReview();
 
     const statsArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
-    expect(statsArg?.judgeMetrics?.verdictReason).toBe('only_nit_or_suggestion');
+    expect(statsArg?.judge.verdictReason).toBe('only_nit_or_suggestion');
   });
 
   it('enriches findings with code context from diff hunks', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2560,6 +2560,8 @@ describe('runFullReview orchestration', () => {
     // result.verdictReason must also be updated alongside result.verdict after escalation
     const reviewResultArg = jest.mocked(ghUtils.postReview).mock.calls[0][5];
     expect(reviewResultArg?.verdictReason).toBe('novel_suggestion');
+    // one finding changed severity → escalationsApplied must reflect that
+    expect(statsArg?.memory.escalationsApplied).toBe(1);
   });
 
   it('populates verdictReason in judge on clean APPROVE with no findings', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -814,9 +814,9 @@ async function runFullReview(
     const priorFindingsFlat = handover?.rounds.flatMap(r => r.findings) ?? [];
     let escalationsApplied = 0;
     if (memory && memory.patterns.length > 0) {
-      const beforeEscalation = result.findings;
+      const beforeSeverities = result.findings.map(f => f.severity);
       result.findings = applyEscalations(result.findings, memory.patterns);
-      escalationsApplied = result.findings.filter((f, i) => f.severity !== beforeEscalation[i].severity).length;
+      escalationsApplied = result.findings.filter((f, i) => f.severity !== beforeSeverities[i]).length;
     }
     const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat, openThreads);
     result.verdict = recomputedVerdict;

--- a/src/index.ts
+++ b/src/index.ts
@@ -905,9 +905,7 @@ async function runFullReview(
         commitSha,
         round,
         timestamp: new Date().toISOString(),
-        runId: github.context.runId,
         mankiVersion: MANKI_VERSION,
-        promptVersions: { judge: 'unversioned', reviewer: 'unversioned', planner: 'unversioned' },
       },
       config: {
         reviewLevel: config.review_level,

--- a/src/index.ts
+++ b/src/index.ts
@@ -908,7 +908,7 @@ async function runFullReview(
         mankiVersion: MANKI_VERSION,
       },
       config: {
-        reviewLevel: config.review_level,
+        reviewLevel: team.level === 'trivial' ? 'small' : team.level,
         nitHandling,
         memoryEnabled: config.memory?.enabled ?? false,
         ...(config.review_passes != null && { reviewPasses: config.review_passes }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -812,8 +812,11 @@ async function runFullReview(
     }
 
     const priorFindingsFlat = handover?.rounds.flatMap(r => r.findings) ?? [];
+    let escalationsApplied = 0;
     if (memory && memory.patterns.length > 0) {
+      const beforeEscalation = result.findings;
       result.findings = applyEscalations(result.findings, memory.patterns);
+      escalationsApplied = result.findings.filter((f, i) => f.severity !== beforeEscalation[i].severity).length;
     }
     const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat, openThreads);
     result.verdict = recomputedVerdict;
@@ -957,6 +960,8 @@ async function runFullReview(
       },
       memory: {
         ...(memory && memory.patterns.length > 0 && { patternsApplied: memory.patterns.length }),
+        ...(result.suppressionCount != null && result.suppressionCount > 0 && { suppressionsApplied: result.suppressionCount }),
+        ...(escalationsApplied > 0 && { escalationsApplied }),
       },
       findings: {
         count: result.findings.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { isEmptyInterRoundDiff } from './judge';
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
 import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam, TRIVIAL_VERIFIER_AGENT } from './review';
-import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, ReviewStats } from './types';
+import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -31,6 +31,7 @@ import {
   BOT_LOGIN,
   BOT_MARKER as PROGRESS_MARKER,
   FORCE_REVIEW_MARKER,
+  MANKI_VERSION,
   isReviewInProgress,
   isApprovedOnCommit,
   markOwnProgressCommentCancelled,
@@ -882,17 +883,6 @@ async function runFullReview(
     const crossRoundSuppressed = result.crossRoundSuppressed;
     const crossRoundDemoted = result.crossRoundDemoted;
     const inPrSuppressedCount = result.inPrSuppressedCount ?? 0;
-    const judgeMetrics: ReviewStats['judgeMetrics'] = {
-      confidenceDistribution,
-      severityChanges,
-      mergedDuplicates,
-      ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
-      ...(inPrSuppressedCount > 0 && { inPrSuppressedCount }),
-      verdictReason,
-      ...(crossRoundSuppressed != null && crossRoundSuppressed > 0 && { crossRoundSuppressed }),
-      ...(crossRoundDemoted != null && crossRoundDemoted > 0 && { crossRoundDemoted }),
-    };
-
     // File analysis metrics
     const fileTypes: Record<string, number> = {};
     for (const file of filteredFiles) {
@@ -900,33 +890,83 @@ async function runFullReview(
       const ext = dotIdx !== -1 ? file.path.slice(dotIdx) : '(none)';
       fileTypes[ext] = (fileTypes[ext] ?? 0) + 1;
     }
-    const findingsPerFile: Record<string, number> = {};
-    for (const f of result.findings) {
-      if (f.file) findingsPerFile[f.file] = (findingsPerFile[f.file] ?? 0) + 1;
-    }
-    const fileMetrics = { fileTypes, findingsPerFile };
 
-    const stats: ReviewStats = {
-      model: reviewerModel,
-      reviewTimeMs,
-      diffLines: diff.totalAdditions + diff.totalDeletions,
-      diffAdditions: diff.totalAdditions,
-      diffDeletions: diff.totalDeletions,
-      filesReviewed: filteredFiles.length,
-      agents: result.agentNames,
-      findingsRaw: result.rawFindingCount ?? result.findings.length,
-      findingsKept: result.findings.length,
-      findingsDropped: (result.rawFindingCount ?? result.findings.length) - result.findings.length,
-      severity: severityMap,
+    const round = (handover?.rounds.length ?? 0) + 1;
+    const findingEntries = result.findings.map(f => ({
+      fingerprint: fingerprintFinding(f.title, f.file ?? '', f.line || 0),
+      severity: f.severity,
+    }));
+    const context: RoundContext = {
+      meta: {
+        prNumber,
+        commitSha,
+        round,
+        timestamp: new Date().toISOString(),
+        runId: github.context.runId,
+        mankiVersion: MANKI_VERSION,
+        promptVersions: { judge: 'unversioned', reviewer: 'unversioned', planner: 'unversioned' },
+      },
+      config: {
+        reviewLevel: config.review_level,
+        nitHandling,
+        memoryEnabled: config.memory?.enabled ?? false,
+        ...(config.review_passes != null && { reviewPasses: config.review_passes }),
+      },
+      diff: {
+        lines: diff.totalAdditions + diff.totalDeletions,
+        additions: diff.totalAdditions,
+        deletions: diff.totalDeletions,
+        filesReviewed: filteredFiles.length,
+        fileTypes,
+      },
+      models: {
+        ...(plannerClient && { planner: plannerModel }),
+        reviewer: reviewerModel,
+        judge: judgeModel,
+        dedup: dedupModel,
+      },
+      planner: result.plannerResult
+        ? {
+            used: true,
+            teamSize: result.plannerResult.teamSize,
+            reviewerEffort: result.plannerResult.reviewerEffort,
+            judgeEffort: result.plannerResult.judgeEffort,
+            prType: result.plannerResult.prType,
+            ...(dashboard.plannerDurationMs != null && { durationMs: dashboard.plannerDurationMs }),
+          }
+        : { used: false },
+      reviewers: {
+        agents: result.agentNames,
+        ...(agentMetrics && { agentMetrics }),
+      },
+      judge: {
+        summary: result.summary,
+        confidenceDistribution,
+        severityChanges,
+        mergedDuplicates,
+        durationMs: judgeEndTime - reviewEndTime,
+        ...(verdictReason && { verdictReason }),
+        ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
+        ...(inPrSuppressedCount > 0 && { inPrSuppressedCount }),
+        ...(crossRoundSuppressed != null && crossRoundSuppressed > 0 && { crossRoundSuppressed }),
+        ...(crossRoundDemoted != null && crossRoundDemoted > 0 && { crossRoundDemoted }),
+      },
+      dedup: {
+        ...(result.staticDedupCount != null && { staticDropped: result.staticDedupCount }),
+        ...(result.llmDedupCount != null && { llmDropped: result.llmDedupCount }),
+      },
+      memory: {
+        ...(memory && memory.patterns.length > 0 && { patternsApplied: memory.patterns.length }),
+      },
+      findings: {
+        count: result.findings.length,
+        severityCounts: severityMap,
+        entries: findingEntries,
+      },
+      usage: {},
       verdict: result.verdict,
-      prNumber,
-      commitSha,
-      agentMetrics,
-      judgeMetrics,
-      fileMetrics,
-      reviewerModel,
-      judgeModel,
     };
+    const flatAliases = roundContextToFlatAliases(context);
 
     // Resolve threads the judge marked `addressed`. Other statuses
     // (`not_addressed`, `uncertain`) are logged for audit but never trigger a
@@ -963,7 +1003,7 @@ async function runFullReview(
     }
 
     const reviewResult = { ...result, findings: inlineFindings };
-    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, stats);
+    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, context, reviewTimeMs);
 
     if (nitHandling === 'issues' && nitFindings.length > 0) {
       try {
@@ -1089,17 +1129,17 @@ async function runFullReview(
     await updateProgressComment(octokit, owner, repo, progressCommentId, completeDashboard, metadata);
 
     core.setOutput('review_id', reviewId.toString());
-    core.setOutput('verdict', result.verdict);
-    core.setOutput('findings_count', result.findings.length.toString());
+    core.setOutput('verdict', flatAliases.verdict);
+    core.setOutput('findings_count', flatAliases.findingsKept.toString());
     core.setOutput('findings_json', JSON.stringify(result.findings));
 
     // `result.findings` excludes 'ignore' severity (filtered in review.ts), so
-    // the counts here mirror `severityMap` above and the `stats.severity` output.
-    core.setOutput('severity_counts', JSON.stringify(severityMap));
+    // the counts here mirror `severityMap` above and the legacy `severity` alias.
+    core.setOutput('severity_counts', JSON.stringify(flatAliases.severity));
 
-    core.setOutput('judge_model', judgeModel);
+    core.setOutput('judge_model', flatAliases.judgeModel);
 
-    core.info(`Review complete: ${result.verdict} with ${result.findings.length} findings`);
+    core.info(`Review complete: ${result.verdict} with ${flatAliases.findingsKept} findings`);
     core.info(`Severity breakdown: ${severityMap.blocker} blocker, ${severityMap.warning} warning, ${severityMap.suggestion} suggestion, ${severityMap.nitpick} nitpick`);
   } catch (error) {
     if (dashboardFlushTimer) {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -32,7 +32,6 @@ function fullyPopulatedContext(): RoundContext {
       commitSha: 'abc123',
       round: 2,
       timestamp: '2026-01-01T00:00:00.000Z',
-      runId: 9876543210,
       mankiVersion: '4.7.0',
       promptVersions: { judge: 'j1', reviewer: 'r1', planner: 'p1' },
     },
@@ -182,7 +181,7 @@ describe('roundContextToFlatAliases', () => {
 
   it('handles minimal context with no optional fields', () => {
     const ctx: RoundContext = {
-      meta: { prNumber: 1, commitSha: 'sha', round: 1, timestamp: 'ts', runId: 1, mankiVersion: '5.0.0', promptVersions: { judge: 'j', reviewer: 'r', planner: 'p' } },
+      meta: { prNumber: 1, commitSha: 'sha', round: 1, timestamp: 'ts', mankiVersion: '5.0.0' },
       config: { reviewLevel: 'small', nitHandling: 'comments', memoryEnabled: false },
       diff: { lines: 10, additions: 10, deletions: 0, filesReviewed: 1, fileTypes: {} },
       models: { reviewer: 'model-a', judge: 'model-b' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -562,6 +562,12 @@ export interface RoundFindings {
   count: number;
   severityCounts: Record<string, number>;
   entries: FindingFingerprintEntry[];
+  /**
+   * True when the emit-side budget enforcer dropped one or more entries from
+   * `entries[]` to fit the review-comment body limit. Set by the truncation
+   * helper at emit time, never by upstream pipeline stages.
+   */
+  truncated?: boolean;
 }
 
 export interface FindingFingerprintEntry {

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,11 +461,9 @@ export interface RoundMeta {
   round: number;
   /** ISO 8601 timestamp at which the round completed. */
   timestamp: string;
-  /** GitHub Actions `run_id` that produced this round. */
-  runId: number;
   /** `version` from `package.json` of the manki release that produced this round. */
   mankiVersion: string;
-  promptVersions: PromptVersions;
+  promptVersions?: PromptVersions;
 }
 
 /** Version identifiers for the prompt templates used by each pipeline stage. */


### PR DESCRIPTION
## Summary
- Replaces the `Review stats` JSON block with a `Manki context` block carrying a full `RoundContext` (defined in #685 / merged via #702)
- New `formatContextBlock(context)` in `src/github.ts`; `RoundContext` is assembled at the call site in `src/index.ts` and threaded through `postReview`
- Action outputs (`severity_counts`, `verdict`, etc.) now derive from the same `RoundContext` via `roundContextToFlatAliases` so values do not regress
- Truncation policy: if the rendered review body exceeds 60k chars, drops `findings.entries[]` in priority order (nitpick → suggestion → warning → blocker → unknown → ignore), sets `findings.truncated = true`, and logs `core.warning` once
- Round metadata, agents, judge summary, models, usage are always preserved through truncation
- 1768 tests pass; lint and typecheck clean

Closes #686.

Emit half of the round-state cutover. Reading happens in #688. Render-mode switch (`stats.hidden`) is #687. Both unblocked once this lands.

Part of #684 / #652 (v5.0.0).