### PR TITLE
feat: `stats.hidden` config switches `Manki context` block to HTML-comment-only render

### DIFF
--- a/.manki.yml.example
+++ b/.manki.yml.example
@@ -82,6 +82,10 @@
 # Must be an integer between 1 and 5. Default: 1 (no multi-pass).
 # review_passes: 1
 
+# Hide the structured `Manki context` block as an HTML comment instead of a `<details>` block (default: false)
+# stats:
+#   hidden: false
+
 # Review memory (requires memory_repo_token)
 # Stores learnings, suppressions, and patterns to improve reviews over time
 # memory:

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -93,6 +93,11 @@ describe('config', () => {
       expect(config.stats?.hidden).toBe(true);
     });
 
+    it('keeps stats.hidden false when stats key is present but hidden is omitted', () => {
+      const config = loadConfigFromContent('stats: {}');
+      expect(config.stats?.hidden).toBe(false);
+    });
+
     it('rejects non-boolean stats.hidden', () => {
       expect(() => loadConfigFromContent('stats:\n  hidden: "yes"\n'))
         .toThrow(/stats\.hidden/);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -81,6 +81,29 @@ describe('config', () => {
     });
   });
 
+  describe('stats config', () => {
+    it('defaults stats.hidden to false', () => {
+      expect(DEFAULT_CONFIG.stats?.hidden).toBe(false);
+      const config = loadConfigFromContent('');
+      expect(config.stats?.hidden).toBe(false);
+    });
+
+    it('merges user-provided stats.hidden over defaults', () => {
+      const config = loadConfigFromContent('stats:\n  hidden: true\n');
+      expect(config.stats?.hidden).toBe(true);
+    });
+
+    it('rejects non-boolean stats.hidden', () => {
+      expect(() => loadConfigFromContent('stats:\n  hidden: "yes"\n'))
+        .toThrow(/stats\.hidden/);
+    });
+
+    it('rejects non-object stats', () => {
+      expect(() => loadConfigFromContent('stats: "nope"\n'))
+        .toThrow(/`stats` must be an object/);
+    });
+  });
+
   describe('loadConfig', () => {
     it('returns defaults when no content provided', () => {
       const config = loadConfig(undefined);

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,9 @@ export const DEFAULT_CONFIG: ReviewConfig = {
     test_path_patterns: ['**/*.test.*', '**/*.spec.*', '**/tests/**', '**/__tests__/**'],
     suppress_resolved_threads: true,
   },
+  stats: {
+    hidden: false,
+  },
 };
 
 const KNOWN_KEYS = new Set([
@@ -52,6 +55,7 @@ const KNOWN_KEYS = new Set([
   'nit_handling',
   'review_passes',
   'convergence',
+  'stats',
 ]);
 
 const REPO_FORMAT = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
@@ -252,6 +256,17 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
     }
   }
 
+  if ('stats' in config) {
+    const stats = config.stats as Record<string, unknown>;
+    if (!stats || typeof stats !== 'object' || Array.isArray(stats)) {
+      errors.push('`stats` must be an object');
+    } else {
+      if ('hidden' in stats && typeof stats.hidden !== 'boolean') {
+        errors.push('`stats.hidden` must be a boolean');
+      }
+    }
+  }
+
   if ('memory' in config) {
     const memory = config.memory as Record<string, unknown>;
     if (!memory || typeof memory !== 'object' || Array.isArray(memory)) {
@@ -298,6 +313,8 @@ function deepMerge(defaults: ReviewConfig, overrides: Record<string, unknown>): 
       result.review_thresholds = { ...defaults.review_thresholds, ...(value as Record<string, unknown>) } as ReviewConfig['review_thresholds'];
     } else if (key === 'convergence' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
       result.convergence = { ...defaults.convergence, ...(value as Record<string, unknown>) } as ReviewConfig['convergence'];
+    } else if (key === 'stats' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      result.stats = { ...defaults.stats, ...(value as Record<string, unknown>) } as ReviewConfig['stats'];
     } else {
       (result as Record<string, unknown>)[key] = value;
     }

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -792,6 +792,14 @@ describe('roundContextToFlatAliases', () => {
     expect(inner).toContain('--\\u003E');
   });
 
+  it('hidden mode neutralises `--!>` inside the JSON payload', () => {
+    const ctx = makeContext({ judge: { summary: 'bang close --!> here' } });
+    const result = formatContextBlock(ctx, true);
+    const inner = result.slice('<!-- manki-context: '.length, -' -->'.length);
+    expect(inner).not.toContain('--!>');
+    expect(inner).toContain('--!\\u003E');
+  });
+
   it('hidden mode JSON round-trips back to the original context after un-escaping', () => {
     const ctx = makeContext({ judge: { summary: 'arrow --> token preserved' } });
     const result = formatContextBlock(ctx, true);

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -808,6 +808,23 @@ describe('roundContextToFlatAliases', () => {
     expect(parsed).toEqual(ctx);
     expect(parsed.judge.summary).toBe('arrow --> token preserved');
   });
+
+  describe('sanitizeHtmlCommentJson (via formatContextBlock hidden path)', () => {
+    it('replaces all --> occurrences', () => {
+      const ctx = makeContext({ judge: { summary: '--> first --> second' } });
+      const result = formatContextBlock(ctx, true);
+      const inner = result.slice('<!-- manki-context: '.length, -' -->'.length);
+      expect(inner).not.toContain('-->');
+      expect((inner.match(/--\\u003E/g) ?? []).length).toBe(2);
+    });
+
+    it('is a no-op when no --> is present', () => {
+      const ctx = makeContext({ judge: { summary: 'clean summary' } });
+      const result = formatContextBlock(ctx, true);
+      const inner = result.slice('<!-- manki-context: '.length, -' -->'.length);
+      expect(JSON.parse(inner).judge.summary).toBe('clean summary');
+    });
+  });
 });
 
 describe('truncateContextToFitBody', () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 
 import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, FindingFingerprintEntry, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, roundContextToFlatAliases } from './types';
+import { DEFAULT_CONFIG } from './config';
 
 describe('formatFindingComment', () => {
   const baseFinding: Finding = {
@@ -771,6 +772,34 @@ describe('roundContextToFlatAliases', () => {
     expect(aliases.findingsRaw).toBe(4);
     expect(aliases.findingsDropped).toBe(0);
   });
+
+  it('hidden mode emits a single HTML comment with no details/code-fence', () => {
+    const ctx = makeContext();
+    const result = formatContextBlock(ctx, true);
+    expect(result.startsWith('<!-- manki-context: ')).toBe(true);
+    expect(result.endsWith(' -->')).toBe(true);
+    expect(result).not.toContain('<details>');
+    expect(result).not.toContain('<summary>');
+    expect(result).not.toContain('```');
+    expect(result.split('\n')).toHaveLength(1);
+  });
+
+  it('hidden mode neutralises `-->` inside the JSON payload', () => {
+    const ctx = makeContext({ judge: { summary: 'closes html comment with --> here' } });
+    const result = formatContextBlock(ctx, true);
+    const inner = result.slice('<!-- manki-context: '.length, -' -->'.length);
+    expect(inner).not.toContain('-->');
+    expect(inner).toContain('--\\u003E');
+  });
+
+  it('hidden mode JSON round-trips back to the original context after un-escaping', () => {
+    const ctx = makeContext({ judge: { summary: 'arrow --> token preserved' } });
+    const result = formatContextBlock(ctx, true);
+    const inner = result.slice('<!-- manki-context: '.length, -' -->'.length);
+    const parsed = JSON.parse(inner) as RoundContext;
+    expect(parsed).toEqual(ctx);
+    expect(parsed.judge.summary).toBe('arrow --> token preserved');
+  });
 });
 
 describe('truncateContextToFitBody', () => {
@@ -993,6 +1022,39 @@ describe('postReview with context', () => {
     if (droppedBlocker > 0) expect(bySev('warning')).toBe(0);
 
     expect(warningSpy).toHaveBeenCalledWith(expect.stringMatching(/Manki context truncated: dropped \d+ finding entries/));
+  });
+
+  it('hidden mode renders HTML-comment block instead of `<details>` while preserving stats one-liner and action outputs', async () => {
+    const result: ReviewResult = {
+      verdict: 'APPROVE',
+      summary: 'All good.',
+      findings: [],
+      highlights: [],
+      reviewComplete: true,
+      agentNames: [],
+    };
+    const ctx = makeContext({
+      diff: { lines: 200, additions: 150, deletions: 50, filesReviewed: 8, fileTypes: { '.ts': 8 } },
+      reviewers: { agents: ['Security', 'Correctness'] },
+      findings: { count: 3, severityCounts: { blocker: 0, warning: 0, suggestion: 2, nitpick: 1 }, entries: [] },
+      verdict: 'APPROVE',
+    });
+    const config = { ...DEFAULT_CONFIG, stats: { hidden: true } };
+
+    await postReview(mockOctokit, 'owner', 'repo', 99, 'abc', result, undefined, ctx, 60000, config);
+    const body = mockCreateReview.mock.calls[0][0].body as string;
+    expect(body).toContain('\u{1F4CA} 3 findings');
+    expect(body).toContain('200 lines');
+    expect(body).toContain('60s');
+    expect(body).toContain('<!-- manki-context: ');
+    expect(body).not.toContain('<details>');
+    expect(body).not.toContain('<summary>Manki context</summary>');
+    expect(body).not.toContain('```json');
+    const match = body.match(/<!-- manki-context: ([\s\S]*?) -->/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]) as RoundContext;
+    expect(parsed.findings.count).toBe(3);
+    expect(parsed.verdict).toBe('APPROVE');
   });
 
   it('does not truncate when rendered body is under the 60k budget', async () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -809,6 +809,14 @@ describe('roundContextToFlatAliases', () => {
     expect(parsed.judge.summary).toBe('arrow --> token preserved');
   });
 
+  it('hidden mode --!> round-trips back to original value', () => {
+    const ctx = makeContext({ judge: { summary: 'bang close --!> here' } });
+    const result = formatContextBlock(ctx, true);
+    const inner = result.slice('<!-- manki-context: '.length, -' -->'.length);
+    const parsed = JSON.parse(inner) as RoundContext;
+    expect(parsed.judge.summary).toBe('bang close --!> here');
+  });
+
   describe('sanitizeHtmlCommentJson (via formatContextBlock hidden path)', () => {
     it('replaces all --> occurrences', () => {
       const ctx = makeContext({ judge: { summary: '--> first --> second' } });
@@ -1049,7 +1057,7 @@ describe('postReview with context', () => {
     expect(warningSpy).toHaveBeenCalledWith(expect.stringMatching(/Manki context truncated: dropped \d+ finding entries/));
   });
 
-  it('hidden mode renders HTML-comment block instead of `<details>` while preserving stats one-liner and action outputs', async () => {
+  it('hidden mode renders HTML-comment block instead of `<details>` while preserving the stats one-liner', async () => {
     const result: ReviewResult = {
       verdict: 'APPROVE',
       summary: 'All good.',

--- a/src/github.ts
+++ b/src/github.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { AgentProgressEntry, DEFENSIVE_HARDENING_TAG, DashboardData, Finding, FindingFingerprintEntry, FindingSeverity, OWN_PROPOSAL_TAG, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, ReviewVerdict } from './types';
+import { AgentProgressEntry, DEFENSIVE_HARDENING_TAG, DashboardData, Finding, FindingFingerprintEntry, FindingSeverity, OWN_PROPOSAL_TAG, ParsedDiff, ReviewConfig, ReviewMetadata, ReviewResult, RoundContext, ReviewVerdict } from './types';
 import { isLineInDiff, findClosestDiffLine } from './diff';
 import { MAX_AGENT_RETRIES } from './types';
 import { safeTruncate } from './utils';
@@ -503,7 +503,19 @@ function formatStatsOneLiner(context: RoundContext, reviewTimeMs: number): strin
   return `\u{1F4CA} ${total} findings (${breakdown}) \u00B7 ${context.diff.lines} lines \u00B7 ${time}s`;
 }
 
-function formatContextBlock(context: RoundContext): string {
+/**
+ * Neutralise any `-->` inside a JSON payload by escaping the closing `>` as
+ * the JSON `>` Unicode escape. Reversible: parsing un-escapes back to `>`.
+ */
+function sanitizeHtmlCommentJson(json: string): string {
+  return json.replace(/-->/g, '--\\u003E');
+}
+
+function formatContextBlock(context: RoundContext, hidden = false): string {
+  if (hidden) {
+    const json = sanitizeHtmlCommentJson(JSON.stringify(context));
+    return `<!-- manki-context: ${json} -->`;
+  }
   const json = JSON.stringify(context, null, 2)
     .replace(/`{3,}/g, match => match.replace(/`/g, '\\u0060'));
   return `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
@@ -581,7 +593,9 @@ export async function postReview(
   diff?: ParsedDiff,
   context?: RoundContext,
   reviewTimeMs?: number,
+  config?: ReviewConfig,
 ): Promise<number> {
+  const statsHidden = config?.stats?.hidden ?? false;
   const event = mapVerdictToEvent(result.verdict);
 
   // Validate and filter inline comments against the diff
@@ -645,7 +659,7 @@ export async function postReview(
     }
     if (ctx) {
       b += `\n\n${formatStatsOneLiner(ctx, reviewTimeMs ?? 0)}`;
-      b += `\n\n${formatContextBlock(ctx)}`;
+      b += `\n\n${formatContextBlock(ctx, statsHidden)}`;
     }
     if (generalFindings.length > 0) {
       b += `\n\n**General findings:**\n${generalFindings.map(c => `- ${c}`).join('\n')}`;

--- a/src/github.ts
+++ b/src/github.ts
@@ -504,11 +504,12 @@ function formatStatsOneLiner(context: RoundContext, reviewTimeMs: number): strin
 }
 
 /**
- * Neutralise any `-->` inside a JSON payload by escaping the closing `>` as
- * the JSON `>` Unicode escape. Reversible: parsing un-escapes back to `>`.
+ * Neutralise any `-->` or `--!>` inside a JSON payload by escaping the
+ * closing `>` as the JSON Unicode escape. Both sequences close HTML5 comments.
+ * Reversible: JSON parsing un-escapes back to `>`.
  */
 function sanitizeHtmlCommentJson(json: string): string {
-  return json.replace(/-->/g, '--\\u003E');
+  return json.replace(/--(!?)>/g, '--$1\\u003E');
 }
 
 function formatContextBlock(context: RoundContext, hidden = false): string {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1727,6 +1727,7 @@ describe('runFullReview orchestration', () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
+      expect.anything(),
     );
     // Outputs set
     expect(jest.mocked(core.setOutput)).toHaveBeenCalledWith('verdict', 'REQUEST_CHANGES');
@@ -2066,7 +2067,7 @@ describe('runFullReview orchestration', () => {
       expect.objectContaining({
         findings: [expect.objectContaining({ severity: 'nitpick' })],
       }),
-      expect.anything(), expect.anything(), expect.anything(),
+      expect.anything(), expect.anything(), expect.anything(), expect.anything(),
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -977,7 +977,7 @@ async function runFullReview(
     }
 
     const reviewResult = { ...result, findings: inlineFindings };
-    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, context, reviewTimeMs);
+    const reviewId = await postReview(octokit, owner, repo, prNumber, commitSha, reviewResult, diff, context, reviewTimeMs, config);
 
     if (nitHandling === 'issues' && nitFindings.length > 0) {
       try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,15 @@ export interface ReviewConfig {
     /** When true, a prior-round finding whose thread is currently resolved on GitHub suppresses matching current findings. */
     suppress_resolved_threads?: boolean;
   };
+  stats?: {
+    /**
+     * When true, the `Manki context` block is rendered as an HTML comment
+     * (`<!-- manki-context: ... -->`) instead of a `<details>` block. Hides
+     * the structured payload from the rendered review while keeping it
+     * machine-readable.
+     */
+    hidden?: boolean;
+  };
 }
 
 export interface DiffFile {


### PR DESCRIPTION
## Summary
- Adds `stats: { hidden: boolean }` config (default `false`) and threads it through `postReview`.
- When `stats.hidden: true`, `formatContextBlock` emits a single-line `<!-- manki-context: ... -->` comment instead of the `<details>` block. Round state still parses because the recap parser (#688) accepts both wrappers.
- JSON inside the HTML comment escapes any `-->` by replacing `>` with `>`, which JSON parsers reverse losslessly.

## Notes
- Stacked on #706 (base: `feat/686-context-block`). Will be retargeted to `main` automatically when #706 squash-merges.
- Draft until #706 lands.

Closes #687