### PR TITLE
feat: aggregate per-round context blocks into `RecapState.priorRounds`

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -735,6 +735,13 @@ describe('formatContextBlock', () => {
     expect(result).toContain('\\u0060\\u0060\\u0060');
   });
 
+  it('escapes a single backtick in a string value to \\u0060', () => {
+    const ctx = makeContext({ judge: { summary: 'call `foo()` here' } });
+    const result = formatContextBlock(ctx);
+    expect(result).toContain('\\u0060foo()\\u0060');
+    expect(result).not.toContain('`foo()`');
+  });
+
 });
 
 describe('roundContextToFlatAliases', () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -505,7 +505,7 @@ function formatStatsOneLiner(context: RoundContext, reviewTimeMs: number): strin
 
 function formatContextBlock(context: RoundContext): string {
   const json = JSON.stringify(context, null, 2)
-    .replace(/`{3,}/g, match => match.replace(/`/g, '\\u0060'));
+    .replace(/`/g, '\\u0060');
   return `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2539,7 +2539,7 @@ describe('runFullReview orchestration', () => {
     });
   });
 
-  it('includes sanitized specialist, suggestedFix, and title in RoundContext findingEntries', async () => {
+  it('includes specialist, suggestedFix, and title in RoundContext findingEntries', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,
       hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
@@ -2569,7 +2569,7 @@ describe('runFullReview orchestration', () => {
     const roundContextArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
     const entry = roundContextArg!.findings.entries[0];
     expect(entry.specialist).toBe('Correctness & Logic');
-    expect(entry.suggestedFix).toBe('Rename x to userCount.');
+    expect(entry.suggestedFix).toBe('Rename `x` to `userCount`.');
     expect(entry.title).toBe('Misleading variable');
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2566,7 +2566,10 @@ describe('runFullReview orchestration', () => {
 
     await callRunFullReview();
 
-    const roundContextArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    const calls = jest.mocked(ghUtils.postReview).mock.calls;
+    expect(calls).toHaveLength(1);
+    const [,,,,,,,roundContextArg] = calls[0];
+    expect(roundContextArg).toBeDefined();
     const entry = roundContextArg!.findings.entries[0];
     expect(entry.specialist).toBe('Correctness & Logic');
     expect(entry.suggestedFix).toBe('Rename `x` to `userCount`.');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -103,6 +103,7 @@ jest.mock('./recap', () => ({
   llmDeduplicateFindings: jest.fn().mockResolvedValue({ unique: [], duplicates: [] }),
   classifyAuthorReply: jest.fn().mockReturnValue('none'),
   fingerprintFinding: jest.fn((title: string, file: string, line: number) => ({ file, lineStart: line, lineEnd: line, slug: title })),
+  sanitize: jest.requireActual('./recap').sanitize,
 }));
 
 jest.mock('./review', () => {
@@ -2536,6 +2537,40 @@ describe('runFullReview orchestration', () => {
         .filter(c => String(c[0]).includes('Bogus Unknown Agent'));
       expect(bogusWarnings).toHaveLength(0);
     });
+  });
+
+  it('includes sanitized specialist, suggestedFix, and title in RoundContext findingEntries', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'COMMENT', summary: 'Issues',
+      findings: [{
+        severity: 'warning' as const,
+        title: 'Misleading variable',
+        file: 'src/app.ts',
+        line: 5,
+        description: 'The variable name is misleading.',
+        reviewers: ['Correctness & Logic'],
+        suggestedFix: 'Rename `x` to `userCount`.',
+      }],
+      highlights: [],
+      reviewComplete: true,
+      agentNames: ['Correctness & Logic'],
+    });
+
+    await callRunFullReview();
+
+    const roundContextArg = jest.mocked(ghUtils.postReview).mock.calls[0][7];
+    const entry = roundContextArg!.findings.entries[0];
+    expect(entry.specialist).toBe('Correctness & Logic');
+    expect(entry.suggestedFix).toBe('Rename x to userCount.');
+    expect(entry.title).toBe('Misleading variable');
   });
 
   it('does not load or write handover when memory is disabled', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -98,7 +98,7 @@ jest.mock('./memory', () => ({
 }));
 
 jest.mock('./recap', () => ({
-  fetchRecapState: jest.fn().mockResolvedValue({ previousFindings: [], recapContext: '' }),
+  fetchRecapState: jest.fn().mockResolvedValue({ previousFindings: [], recapContext: '', priorRounds: [] }),
   deduplicateFindings: jest.fn().mockReturnValue({ unique: [], duplicates: [] }),
   llmDeduplicateFindings: jest.fn().mockResolvedValue({ unique: [], duplicates: [] }),
   classifyAuthorReply: jest.fn().mockReturnValue('none'),
@@ -1555,7 +1555,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.parsePRDiff).mockReturnValue({ files: [], totalAdditions: 0, totalDeletions: 0 });
     jest.mocked(diffModule.filterFiles).mockReturnValue([]);
     jest.mocked(authModule.getMemoryToken).mockReturnValue(null);
-    jest.mocked(recapModule.fetchRecapState).mockResolvedValue({ previousFindings: [], recapContext: '' });
+    jest.mocked(recapModule.fetchRecapState).mockResolvedValue({ previousFindings: [], recapContext: '', priorRounds: [] });
     jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [], duplicates: [] });
     jest.mocked(stateModule.resolveStaleThreads).mockResolvedValue(0);
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -2135,6 +2135,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings,
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     const finding2 = { severity: 'nitpick' as const, title: 'Style', file: 'src/app.ts', line: 8, description: 'desc', reviewers: ['general'] };
@@ -2964,6 +2965,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings,
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     await callRunFullReview();
@@ -3007,6 +3009,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Old warning', file: 'src/app.ts', line: 5, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_OPEN' },
       ],
       recapContext: '',
+      priorRounds: [],
     });
 
     const finding = { severity: 'nitpick' as const, title: 'Tiny', file: 'src/app.ts', line: 9, description: 'd', reviewers: ['general'] };
@@ -3055,6 +3058,7 @@ describe('runFullReview orchestration', () => {
         suggestedFix: 'Add `MissingRotationChainLockSigs(QuorumHash)` to the enum.',
       }],
       recapContext: '',
+      priorRounds: [],
     });
 
     await callRunFullReview();
@@ -3085,6 +3089,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: threadFile, line: 10, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_code' },
       ],
       recapContext: '',
+      priorRounds: [],
     });
 
     await callRunFullReview();
@@ -3117,6 +3122,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings,
       recapContext: '',
+      priorRounds: [],
     });
 
     await callRunFullReview();
@@ -3147,6 +3153,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
       previousFindings,
       recapContext: '',
+      priorRounds: [],
     });
 
     await callRunFullReview();
@@ -3217,6 +3224,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_a' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     // Enable memory so loadHandover runs and fetchInterRoundDiff is invoked
@@ -3286,6 +3294,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_a' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     jest.mocked(configModule.loadConfig).mockReturnValue({
@@ -3341,7 +3350,7 @@ describe('runFullReview orchestration', () => {
     });
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
     jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
-      previousFindings: [], recapContext: '',
+      previousFindings: [], recapContext: '', priorRounds: [],
     });
     jest.mocked(configModule.loadConfig).mockReturnValue({
       auto_review: true, auto_approve: false, exclude_paths: [], max_diff_lines: 10000,
@@ -3504,6 +3513,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_override' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     jest.mocked(configModule.loadConfig).mockReturnValue({
@@ -3565,6 +3575,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_abc' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     jest.mocked(configModule.loadConfig).mockReturnValue({
@@ -3630,6 +3641,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug C', file: 'src/app.ts', line: 3, severity: 'suggestion' as const, status: 'open' as const, threadId: 'PRRT_ghi' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -3684,6 +3696,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_known' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     jest.mocked(reviewModule.runReview).mockResolvedValue({
@@ -3729,6 +3742,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug C', file: 'src/app.ts', line: 3, severity: 'nitpick' as const, status: 'resolved' as const, threadId: 'PRRT_resolved' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     await callRunFullReview();
@@ -3758,6 +3772,7 @@ describe('runFullReview orchestration', () => {
         { title: 'Bug A', file: 'src/app.ts', line: 1, severity: 'blocker' as const, status: 'open' as const, threadId: 'PRRT_fail' },
       ],
       recapContext: 'previous context',
+      priorRounds: [],
     });
 
     mockGraphql.mockRejectedValueOnce(new Error('GraphQL error'));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2576,6 +2576,63 @@ describe('runFullReview orchestration', () => {
     expect(entry.title).toBe('Misleading variable');
   });
 
+  it('truncates suggestedFix longer than 300 chars in findingEntries', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'COMMENT', summary: 'Issues',
+      findings: [{
+        severity: 'warning' as const,
+        title: 'T',
+        file: 'src/app.ts',
+        line: 5,
+        description: 'desc',
+        reviewers: ['Agent'],
+        suggestedFix: 'x'.repeat(301),
+      }],
+      highlights: [], reviewComplete: true, agentNames: ['Agent'],
+    });
+
+    await callRunFullReview();
+
+    const [,,,,,,,rc] = jest.mocked(ghUtils.postReview).mock.calls[0];
+    expect(rc!.findings.entries[0].suggestedFix).toHaveLength(300);
+  });
+
+  it('truncates title longer than 200 chars in findingEntries', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'COMMENT', summary: '',
+      findings: [{
+        severity: 'warning' as const,
+        title: 'A'.repeat(201),
+        file: 'src/app.ts',
+        line: 5,
+        description: 'd',
+        reviewers: ['Agent'],
+      }],
+      highlights: [], reviewComplete: true, agentNames: ['Agent'],
+    });
+
+    await callRunFullReview();
+
+    const [,,,,,,,rc] = jest.mocked(ghUtils.postReview).mock.calls[0];
+    expect(rc!.findings.entries[0].title).toHaveLength(200);
+  });
+
   it('does not load or write handover when memory is disabled', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -869,6 +869,9 @@ async function runFullReview(
     const findingEntries = result.findings.map(f => ({
       fingerprint: fingerprintFinding(f.title, f.file ?? '', f.line || 0),
       severity: f.severity,
+      ...(f.reviewers[0] && { specialist: f.reviewers[0] }),
+      ...(f.suggestedFix && { suggestedFix: f.suggestedFix }),
+      ...(f.title && { title: f.title }),
     }));
     const context: RoundContext = {
       meta: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention, parseCommand, isLLMAccessAllowed } from './interaction';
 import { isEmptyInterRoundDiff } from './judge';
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
-import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
+import { classifyAuthorReply, fetchRecapState, fingerprintFinding, sanitize } from './recap';
 import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam, TRIVIAL_VERIFIER_AGENT } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
@@ -870,8 +870,8 @@ async function runFullReview(
       fingerprint: fingerprintFinding(f.title, f.file ?? '', f.line || 0),
       severity: f.severity,
       ...(f.reviewers[0] && { specialist: f.reviewers[0] }),
-      ...(f.suggestedFix && { suggestedFix: f.suggestedFix }),
-      ...(f.title && { title: f.title }),
+      ...(f.suggestedFix && { suggestedFix: sanitize(f.suggestedFix, 300) }),
+      ...(f.title && { title: sanitize(f.title, 200) }),
     }));
     const context: RoundContext = {
       meta: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention, parseCommand, isLLMAccessAllowed } from './interaction';
 import { isEmptyInterRoundDiff } from './judge';
 import { appendHandoverRound, loadHandover, loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
-import { classifyAuthorReply, fetchRecapState, fingerprintFinding, sanitize } from './recap';
+import { classifyAuthorReply, fetchRecapState, fingerprintFinding } from './recap';
 import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam, TRIVIAL_VERIFIER_AGENT } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, PrHandover, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
@@ -870,8 +870,8 @@ async function runFullReview(
       fingerprint: fingerprintFinding(f.title, f.file ?? '', f.line || 0),
       severity: f.severity,
       ...(f.reviewers[0] && { specialist: f.reviewers[0] }),
-      ...(f.suggestedFix && { suggestedFix: sanitize(f.suggestedFix, 300) }),
-      ...(f.title && { title: sanitize(f.title, 200) }),
+      ...(f.suggestedFix && { suggestedFix: f.suggestedFix.slice(0, 300) }),
+      ...(f.title && { title: f.title.slice(0, 200) }),
     }));
     const context: RoundContext = {
       meta: {

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1,7 +1,7 @@
 import { Finding, RoundContext } from './types';
 import { Suppression } from './memory';
 import { classifyAuthorReply, collectInPrSuppressions, deduplicateFindings, fingerprintFinding, PreviousFinding, fetchRecapState, titlesOverlap, llmDeduplicateFindings, parseFindingFromComment } from './recap';
-import { titleToSlug } from './github';
+import { BOT_LOGIN, titleToSlug } from './github';
 
 jest.mock('@actions/core', () => ({
   info: jest.fn(),
@@ -1120,8 +1120,6 @@ describe('fetchRecapState', () => {
   });
 
   describe('priorRounds parsing', () => {
-    const BOT_LOGIN = 'manki-review[bot]';
-
     function makeRoundContext(round: number, overrides: Partial<RoundContext> = {}): RoundContext {
       const base: RoundContext = {
         meta: {
@@ -1339,7 +1337,7 @@ describe('fetchRecapState', () => {
       );
     });
 
-    it('returns empty priorRounds when a non-SyntaxError is thrown from JSON.parse (caught by outer handler)', async () => {
+    it('skips a block when a non-SyntaxError is thrown from JSON.parse and emits core.warning', async () => {
       const sentinel = '"__sentinel_throw__"';
       const body = `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${sentinel}\n\`\`\`\n</details>`;
       const octokit = mockOctokit([], [
@@ -1354,8 +1352,52 @@ describe('fetchRecapState', () => {
       spy.mockRestore();
       expect(state.priorRounds).toEqual([]);
       expect(core.warning).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to fetch prior round contexts'),
+        expect.stringContaining('https://github.com/owner/repo/pull/1#pullrequestreview-999'),
       );
+    });
+
+    it('excludes reviews from non-bot users', async () => {
+      const ctx = makeRoundContext(1);
+      const octokit = mockOctokit([], [
+        { id: 100, body: detailsBlock(ctx), user: { login: 'some-user' } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+    });
+
+    it('skips malformed JSON block but still loads subsequent valid blocks', async () => {
+      const ctx3 = makeRoundContext(3);
+      const malformed = '<details>\n<summary>Manki context</summary>\n\n```json\n{bad}\n```\n</details>';
+      const octokit = mockOctokit([], [
+        { id: 500, body: malformed, user: { login: BOT_LOGIN } },
+        { id: 501, body: detailsBlock(ctx3), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].meta.round).toBe(3);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('https://github.com/owner/repo/pull/1#pullrequestreview-500'),
+      );
+    });
+
+    it('round-trips a field containing backticks through the details wrapper', async () => {
+      const ctx = makeRoundContext(9, { judge: { summary: 'use `foo()` here' } });
+      const octokit = mockOctokit([], [
+        { id: 400, body: detailsBlock(ctx), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].judge.summary).toBe('use `foo()` here');
+    });
+
+    it('round-trips a field containing --> through the HTML-comment wrapper', async () => {
+      const ctx = makeRoundContext(1, { judge: { summary: 'Verdict --> pass' } });
+      const octokit = mockOctokit([], [
+        { id: 300, body: htmlCommentBlock(ctx), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].judge.summary).toBe('Verdict --> pass');
     });
   });
 });

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1145,7 +1145,7 @@ describe('fetchRecapState', () => {
     }
 
     function detailsBlock(ctx: RoundContext): string {
-      const json = JSON.stringify(ctx, null, 2).replace(/`{3,}/g, m => m.replace(/`/g, '\\u0060'));
+      const json = JSON.stringify(ctx, null, 2).replace(/`/g, '\\u0060');
       return `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
     }
 
@@ -1202,6 +1202,28 @@ describe('fetchRecapState', () => {
       const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
       expect(state.priorRounds).toHaveLength(1);
       expect(state.priorRounds[0].findings.entries).toEqual([entry]);
+    });
+
+    it('round-trips suggestedFix containing a literal \\u0060 escape sequence without parse error', async () => {
+      // Regression: suggestedFix containing a regex like /`/g (literal backslash + u0060)
+      // was stored as \\u0060 in the JSON, which the old parser's naive .replace(/\\u0060/g, '`')
+      // turned into \\` — an invalid JSON escape sequence.
+      const entry = {
+        fingerprint: { file: 'src/recap.ts', lineStart: 201, lineEnd: 201, slug: 'backtick-unescape' },
+        severity: 'warning' as const,
+        specialist: 'Correctness',
+        suggestedFix: "candidates.push(m[1].replace(/\\u0060/g, '`'));",
+        title: 'Parser unescapes \\u0060 incorrectly',
+      };
+      const ctx = makeRoundContext(1, {
+        findings: { count: 1, severityCounts: { blocker: 0, warning: 1, suggestion: 0, nitpick: 0 }, entries: [entry] },
+      });
+      const octokit = mockOctokit([], [
+        { id: 100, body: detailsBlock(ctx), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].findings.entries[0].suggestedFix).toBe(entry.suggestedFix);
     });
 
     it('round-trips findings.entries through the HTML-comment wrapper', async () => {

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1187,6 +1187,45 @@ describe('fetchRecapState', () => {
       expect(state.priorRounds[0].meta.round).toBe(2);
     });
 
+    it('round-trips findings.entries with specialist, suggestedFix, and title fields', async () => {
+      const entry = {
+        fingerprint: { file: 'src/foo.ts', lineStart: 10, lineEnd: 12, slug: 'misleading-variable-name' },
+        severity: 'warning' as const,
+        specialist: 'Correctness',
+        suggestedFix: 'Rename `x` to `userCount`.',
+        title: 'Misleading variable name',
+      };
+      const ctx = makeRoundContext(1, {
+        findings: { count: 1, severityCounts: { blocker: 0, warning: 1, suggestion: 0, nitpick: 0 }, entries: [entry] },
+      });
+      const octokit = mockOctokit([], [
+        { id: 100, body: detailsBlock(ctx), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].findings.entries).toEqual([entry]);
+    });
+
+    it('round-trips findings.entries through the HTML-comment wrapper', async () => {
+      const entry = {
+        fingerprint: { file: 'src/bar.ts', lineStart: 5, lineEnd: 5, slug: 'unused-import' },
+        severity: 'nitpick' as const,
+        specialist: 'Style',
+        suggestedFix: 'Remove the unused `path` import.',
+        title: 'Unused import',
+      };
+      const ctx = makeRoundContext(2, {
+        findings: { count: 1, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: 1 }, entries: [entry] },
+      });
+      const octokit = mockOctokit([], [
+        { id: 200, body: htmlCommentBlock(ctx), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds[0].findings.entries[0].specialist).toBe('Style');
+      expect(state.priorRounds[0].findings.entries[0].suggestedFix).toBe('Remove the unused `path` import.');
+      expect(state.priorRounds[0].findings.entries[0].title).toBe('Unused import');
+    });
+
     it('sorts multiple rounds chronologically by meta.round', async () => {
       const c3 = makeRoundContext(3);
       const c1 = makeRoundContext(1);

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1185,6 +1185,19 @@ describe('fetchRecapState', () => {
       expect(state.priorRounds[0].meta.round).toBe(2);
     });
 
+    it('ignores HTML-comment block when a details block is present in the same review', async () => {
+      const ctxDetails = makeRoundContext(1, { judge: { summary: 'from details' } });
+      const ctxHtml = makeRoundContext(2, { judge: { summary: 'from html comment' } });
+      const body = `${detailsBlock(ctxDetails)}\n${htmlCommentBlock(ctxHtml)}`;
+      const octokit = mockOctokit([], [
+        { id: 100, body, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].meta.round).toBe(1);
+      expect(state.priorRounds[0].judge.summary).toBe('from details');
+    });
+
     it('round-trips findings.entries with specialist, suggestedFix, and title fields', async () => {
       const entry = {
         fingerprint: { file: 'src/foo.ts', lineStart: 10, lineEnd: 12, slug: 'misleading-variable-name' },

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1,7 +1,16 @@
-import { Finding } from './types';
+import { Finding, RoundContext } from './types';
 import { Suppression } from './memory';
 import { classifyAuthorReply, collectInPrSuppressions, deduplicateFindings, fingerprintFinding, PreviousFinding, fetchRecapState, titlesOverlap, llmDeduplicateFindings, parseFindingFromComment } from './recap';
 import { titleToSlug } from './github';
+
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+import * as core from '@actions/core';
 
 const makeFinding = (overrides: Partial<Finding> = {}): Finding => ({
   severity: 'suggestion',
@@ -505,7 +514,10 @@ describe('fetchRecapState', () => {
     };
   }
 
-  function mockOctokit(threads: ReturnType<typeof makeThread>[]) {
+  function mockOctokit(
+    threads: ReturnType<typeof makeThread>[],
+    reviews: Array<{ id: number; body: string; user: { login: string } | null }> = [],
+  ) {
     return {
       graphql: jest.fn().mockResolvedValue({
         repository: {
@@ -516,6 +528,11 @@ describe('fetchRecapState', () => {
           },
         },
       }),
+      rest: {
+        pulls: {
+          listReviews: jest.fn().mockResolvedValue({ data: reviews }),
+        },
+      },
     } as unknown as ReturnType<typeof import('@actions/github').getOctokit>;
   }
 
@@ -591,6 +608,11 @@ describe('fetchRecapState', () => {
   it('handles graphql errors gracefully', async () => {
     const octokit = {
       graphql: jest.fn().mockRejectedValue(new Error('GraphQL error')),
+      rest: {
+        pulls: {
+          listReviews: jest.fn().mockResolvedValue({ data: [] }),
+        },
+      },
     } as unknown as ReturnType<typeof import('@actions/github').getOctokit>;
 
     const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
@@ -1095,6 +1117,128 @@ describe('fetchRecapState', () => {
     const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
     expect(state.previousFindings[0].description).toBe('The variable name is misleading.');
     expect(state.previousFindings[0].suggestedFix).toBeUndefined();
+  });
+
+  describe('priorRounds parsing', () => {
+    const BOT_LOGIN = 'manki-review[bot]';
+
+    function makeRoundContext(round: number, overrides: Partial<RoundContext> = {}): RoundContext {
+      const base: RoundContext = {
+        meta: {
+          prNumber: 42,
+          commitSha: 'abc123',
+          round,
+          timestamp: '2026-01-01T00:00:00.000Z',
+          mankiVersion: '4.7.0',
+        },
+        config: { reviewLevel: 'medium', nitHandling: 'issues', memoryEnabled: false },
+        diff: { lines: 100, additions: 60, deletions: 40, filesReviewed: 3, fileTypes: { '.ts': 3 } },
+        models: { reviewer: 'r', judge: 'j' },
+        planner: { used: false },
+        reviewers: { agents: ['Correctness'] },
+        judge: { summary: 'ok' },
+        dedup: {},
+        memory: {},
+        findings: { count: 0, severityCounts: { blocker: 0, warning: 0, suggestion: 0, nitpick: 0 }, entries: [] },
+        usage: {},
+        verdict: 'COMMENT',
+      };
+      return { ...base, ...overrides, meta: { ...base.meta, ...(overrides.meta ?? {}), round } };
+    }
+
+    function detailsBlock(ctx: RoundContext): string {
+      const json = JSON.stringify(ctx, null, 2).replace(/`{3,}/g, m => m.replace(/`/g, '\\u0060'));
+      return `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${json}\n\`\`\`\n</details>`;
+    }
+
+    function htmlCommentBlock(ctx: RoundContext): string {
+      const json = JSON.stringify(ctx).replace(/-->/g, '--\\u003E');
+      return `<!-- manki-context: ${json} -->`;
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns empty priorRounds when no review summary comments exist', async () => {
+      const octokit = mockOctokit([], []);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+    });
+
+    it('parses a single details-wrapper context block', async () => {
+      const ctx = makeRoundContext(1);
+      const octokit = mockOctokit([], [
+        { id: 100, body: `Header\n\n${detailsBlock(ctx)}\n`, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].meta.round).toBe(1);
+      expect(state.priorRounds[0].meta.mankiVersion).toBe('4.7.0');
+    });
+
+    it('parses a single HTML-comment context block', async () => {
+      const ctx = makeRoundContext(2);
+      const octokit = mockOctokit([], [
+        { id: 200, body: `Public summary\n${htmlCommentBlock(ctx)}\n`, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].meta.round).toBe(2);
+    });
+
+    it('sorts multiple rounds chronologically by meta.round', async () => {
+      const c3 = makeRoundContext(3);
+      const c1 = makeRoundContext(1);
+      const c2 = makeRoundContext(2);
+      const octokit = mockOctokit([], [
+        { id: 11, body: detailsBlock(c3), user: { login: BOT_LOGIN } },
+        { id: 12, body: detailsBlock(c1), user: { login: BOT_LOGIN } },
+        { id: 13, body: htmlCommentBlock(c2), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds.map(r => r.meta.round)).toEqual([1, 2, 3]);
+    });
+
+    it('skips a review with malformed JSON and emits core.warning', async () => {
+      const malformed = '<details>\n<summary>Manki context</summary>\n\n```json\n{not valid json}\n```\n</details>';
+      const octokit = mockOctokit([], [
+        { id: 500, body: malformed, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('https://github.com/owner/repo/pull/1#pullrequestreview-500'),
+      );
+    });
+
+    it('skips a review missing required meta.round and emits core.warning', async () => {
+      const badJson = JSON.stringify({ meta: { mankiVersion: '4.7.0' }, verdict: 'COMMENT' });
+      const body = `<!-- manki-context: ${badJson} -->`;
+      const octokit = mockOctokit([], [
+        { id: 600, body, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('meta.round'),
+      );
+    });
+
+    it('dedupes duplicate meta.round, picking the higher review id, and warns', async () => {
+      const earlier = makeRoundContext(1, { judge: { summary: 'first attempt' } });
+      const later = makeRoundContext(1, { judge: { summary: 'final version' } });
+      const octokit = mockOctokit([], [
+        { id: 10, body: detailsBlock(earlier), user: { login: BOT_LOGIN } },
+        { id: 20, body: detailsBlock(later), user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toHaveLength(1);
+      expect(state.priorRounds[0].judge.summary).toBe('final version');
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Duplicate Manki context blocks for round 1'),
+      );
+    });
   });
 });
 

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1434,6 +1434,30 @@ describe('fetchRecapState', () => {
       expect(state.priorRounds).toHaveLength(1);
       expect(state.priorRounds[0].judge.summary).toBe('Verdict --> pass');
     });
+
+    it('warns when listReviews returns exactly 100 reviews', async () => {
+      const reviews = Array.from({ length: 100 }, (_, i) => ({
+        id: i + 1,
+        body: detailsBlock(makeRoundContext(i + 1)),
+        user: { login: BOT_LOGIN },
+      }));
+      const octokit = mockOctokit([], reviews);
+      await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('pagination not implemented'),
+      );
+    });
+
+    it('parses two context blocks from a single review body', async () => {
+      const c1 = makeRoundContext(1);
+      const c2 = makeRoundContext(2);
+      const body = `${detailsBlock(c1)}\n${detailsBlock(c2)}`;
+      const octokit = mockOctokit([], [
+        { id: 100, body, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds.map(r => r.meta.round)).toEqual([1, 2]);
+    });
   });
 });
 

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1239,6 +1239,85 @@ describe('fetchRecapState', () => {
         expect.stringContaining('Duplicate Manki context blocks for round 1'),
       );
     });
+
+    it('skips a context block whose parsed value is null (not an object)', async () => {
+      const body = '<details>\n<summary>Manki context</summary>\n\n```json\nnull\n```\n</details>';
+      const octokit = mockOctokit([], [
+        { id: 700, body, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('not an object'),
+      );
+    });
+
+    it('skips a context block whose meta is not an object', async () => {
+      const badJson = JSON.stringify({ meta: 'not-an-object', verdict: 'COMMENT' });
+      const body = `<!-- manki-context: ${badJson} -->`;
+      const octokit = mockOctokit([], [
+        { id: 800, body, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('missing meta'),
+      );
+    });
+
+    it('skips a context block missing meta.mankiVersion', async () => {
+      const badJson = JSON.stringify({ meta: { round: 1 }, verdict: 'COMMENT' });
+      const body = `<!-- manki-context: ${badJson} -->`;
+      const octokit = mockOctokit([], [
+        { id: 900, body, user: { login: BOT_LOGIN } },
+      ]);
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('meta.mankiVersion'),
+      );
+    });
+
+    it('returns empty priorRounds and warns when listReviews throws', async () => {
+      const octokit = {
+        graphql: jest.fn().mockResolvedValue({
+          repository: {
+            pullRequest: {
+              reviewThreads: { nodes: [] },
+            },
+          },
+        }),
+        rest: {
+          pulls: {
+            listReviews: jest.fn().mockRejectedValue(new Error('API unavailable')),
+          },
+        },
+      } as unknown as ReturnType<typeof import('@actions/github').getOctokit>;
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch prior round contexts'),
+      );
+    });
+
+    it('returns empty priorRounds when a non-SyntaxError is thrown from JSON.parse (caught by outer handler)', async () => {
+      const sentinel = '"__sentinel_throw__"';
+      const body = `<details>\n<summary>Manki context</summary>\n\n\`\`\`json\n${sentinel}\n\`\`\`\n</details>`;
+      const octokit = mockOctokit([], [
+        { id: 999, body, user: { login: BOT_LOGIN } },
+      ]);
+      const original = JSON.parse.bind(JSON);
+      const spy = jest.spyOn(JSON, 'parse').mockImplementation((text: string) => {
+        if (text.trim() === sentinel) throw new TypeError('unexpected mock error');
+        return original(text);
+      });
+      const state = await fetchRecapState(octokit, 'owner', 'repo', 1);
+      spy.mockRestore();
+      expect(state.priorRounds).toEqual([]);
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch prior round contexts'),
+      );
+    });
   });
 });
 

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 import { LLMClient } from './providers';
 import { ACTIONS_BOT_LOGIN, BOT_LOGIN, titleToSlug } from './github';
 import { matchesSuppression, Suppression } from './memory';
-import { AuthorReplyClass, Finding, FindingFingerprint, FindingMetadata, FindingSeverity, InPrSuppression, InPrSuppressionReason, migrateLegacySeverity, SEVERITY_TOKEN_PATTERN } from './types';
+import { AuthorReplyClass, Finding, FindingFingerprint, FindingMetadata, FindingSeverity, InPrSuppression, InPrSuppressionReason, migrateLegacySeverity, RoundContext, SEVERITY_TOKEN_PATTERN } from './types';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -170,6 +170,93 @@ function inPrSuppressionReasonFor(
 interface RecapState {
   previousFindings: PreviousFinding[];
   recapContext: string;
+  priorRounds: RoundContext[];
+}
+
+const CONTEXT_BLOCK_DETAILS_RE = /<details>\s*<summary>Manki context<\/summary>\s*```json\s*([\s\S]*?)```\s*<\/details>/g;
+const CONTEXT_BLOCK_HTML_COMMENT_RE = /<!-- manki-context: (.+?) -->/g;
+
+/**
+ * Parse Manki context blocks from PR-level review bodies. Supports both the
+ * `<details>` wrapper (visible aggregate review) and the `<!-- manki-context: ... -->`
+ * wrapper (hidden per-round review). Unknown future fields on `RoundContext`
+ * are preserved opaquely. Duplicates on `meta.round` are deduped by keeping
+ * the entry with the highest review id (latest-posted). Result is sorted
+ * ascending by `meta.round`.
+ */
+function parseContextBlocks(
+  reviews: Array<{ body: string; id: number }>,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): RoundContext[] {
+  const byRound = new Map<number, { ctx: RoundContext; reviewId: number }>();
+  const duplicateRounds = new Set<number>();
+
+  for (const review of reviews) {
+    const reviewUrl = `https://github.com/${owner}/${repo}/pull/${prNumber}#pullrequestreview-${review.id}`;
+    const candidates: string[] = [];
+
+    for (const m of review.body.matchAll(CONTEXT_BLOCK_DETAILS_RE)) {
+      candidates.push(m[1].replace(/\\u0060/g, '`'));
+    }
+    for (const m of review.body.matchAll(CONTEXT_BLOCK_HTML_COMMENT_RE)) {
+      candidates.push(m[1].replace(/\\u003E/g, '>'));
+    }
+
+    for (const raw of candidates) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          core.warning(`Skipping malformed Manki context block at ${reviewUrl}: ${e.message}`);
+          continue;
+        }
+        throw e;
+      }
+
+      if (!parsed || typeof parsed !== 'object') {
+        core.warning(`Skipping Manki context block at ${reviewUrl}: not an object`);
+        continue;
+      }
+      const meta = (parsed as { meta?: unknown }).meta;
+      if (!meta || typeof meta !== 'object') {
+        core.warning(`Skipping Manki context block at ${reviewUrl}: missing meta`);
+        continue;
+      }
+      const round = (meta as { round?: unknown }).round;
+      const mankiVersion = (meta as { mankiVersion?: unknown }).mankiVersion;
+      if (typeof round !== 'number') {
+        core.warning(`Skipping Manki context block at ${reviewUrl}: missing or non-numeric meta.round`);
+        continue;
+      }
+      if (typeof mankiVersion !== 'string') {
+        core.warning(`Skipping Manki context block at ${reviewUrl}: missing meta.mankiVersion`);
+        continue;
+      }
+
+      const ctx = parsed as RoundContext;
+      const existing = byRound.get(round);
+      if (existing) {
+        duplicateRounds.add(round);
+        if (review.id > existing.reviewId) {
+          byRound.set(round, { ctx, reviewId: review.id });
+        }
+      } else {
+        byRound.set(round, { ctx, reviewId: review.id });
+      }
+    }
+  }
+
+  for (const round of duplicateRounds) {
+    const winner = byRound.get(round);
+    core.warning(`Duplicate Manki context blocks for round ${round}, keeping review id ${winner?.reviewId}`);
+  }
+
+  return Array.from(byRound.values())
+    .map(v => v.ctx)
+    .sort((a, b) => a.meta.round - b.meta.round);
 }
 
 /**
@@ -183,6 +270,7 @@ async function fetchRecapState(
   prAuthorLogin?: string,
 ): Promise<RecapState> {
   const threads = await fetchReviewThreads(octokit, owner, repo, prNumber);
+  const priorRounds = await fetchPriorRoundContexts(octokit, owner, repo, prNumber);
 
   const previousFindings = threads
     .filter(t => t.isBotThread)
@@ -244,7 +332,35 @@ async function fetchRecapState(
 
   core.info(`Recap: ${resolved.length} resolved, ${open.length} open, ${previousFindings.length} total previous findings`);
 
-  return { previousFindings, recapContext };
+  return { previousFindings, recapContext, priorRounds };
+}
+
+async function fetchPriorRoundContexts(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<RoundContext[]> {
+  try {
+    const { data: reviews } = await octokit.rest.pulls.listReviews({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+    });
+    const candidates = reviews
+      .filter((r): r is typeof r & { body: string; id: number } => {
+        const body = r.body;
+        if (!body) return false;
+        if (r.user?.login !== BOT_LOGIN) return false;
+        return body.includes('<summary>Manki context</summary>') || body.includes('<!-- manki-context:');
+      })
+      .map(r => ({ body: r.body, id: r.id }));
+    return parseContextBlocks(candidates, owner, repo, prNumber);
+  } catch (error) {
+    core.warning(`Failed to fetch prior round contexts: ${error}`);
+    return [];
+  }
 }
 
 interface ReviewThread extends FindingMetadata {

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -200,8 +200,10 @@ function parseContextBlocks(
     for (const m of review.body.matchAll(CONTEXT_BLOCK_DETAILS_RE)) {
       candidates.push(m[1].replace(/\\u0060/g, '`'));
     }
-    for (const m of review.body.matchAll(CONTEXT_BLOCK_HTML_COMMENT_RE)) {
-      candidates.push(m[1].replace(/\\u003E/g, '>'));
+    if (candidates.length === 0) {
+      for (const m of review.body.matchAll(CONTEXT_BLOCK_HTML_COMMENT_RE)) {
+        candidates.push(m[1].replace(/\\u003E/g, '>'));
+      }
     }
 
     for (const raw of candidates) {
@@ -209,11 +211,9 @@ function parseContextBlocks(
       try {
         parsed = JSON.parse(raw);
       } catch (e) {
-        if (e instanceof SyntaxError) {
-          core.warning(`Skipping malformed Manki context block at ${reviewUrl}: ${e.message}`);
-          continue;
-        }
-        throw e;
+        const msg = e instanceof Error ? e.message : String(e);
+        core.warning(`Skipping malformed Manki context block at ${reviewUrl}: ${msg}`);
+        continue;
       }
 
       if (!parsed || typeof parsed !== 'object') {
@@ -269,8 +269,10 @@ async function fetchRecapState(
   prNumber: number,
   prAuthorLogin?: string,
 ): Promise<RecapState> {
-  const threads = await fetchReviewThreads(octokit, owner, repo, prNumber);
-  const priorRounds = await fetchPriorRoundContexts(octokit, owner, repo, prNumber);
+  const [threads, priorRounds] = await Promise.all([
+    fetchReviewThreads(octokit, owner, repo, prNumber),
+    fetchPriorRoundContexts(octokit, owner, repo, prNumber),
+  ]);
 
   const previousFindings = threads
     .filter(t => t.isBotThread)
@@ -348,6 +350,9 @@ async function fetchPriorRoundContexts(
       pull_number: prNumber,
       per_page: 100,
     });
+    if (reviews.length === 100) {
+      core.warning(`fetchPriorRoundContexts: received exactly 100 reviews for PR #${prNumber}; earlier rounds may be missing (pagination not implemented).`);
+    }
     const candidates = reviews
       .filter((r): r is typeof r & { body: string; id: number } => {
         const body = r.body;

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -203,7 +203,7 @@ function parseContextBlocks(
     }
     if (candidates.length === 0) {
       for (const m of review.body.matchAll(CONTEXT_BLOCK_HTML_COMMENT_RE)) {
-        candidates.push(m[1].replace(/\\u003E/g, '>'));
+        candidates.push(m[1]);
       }
     }
 

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -198,7 +198,7 @@ function parseContextBlocks(
     const candidates: string[] = [];
 
     for (const m of review.body.matchAll(CONTEXT_BLOCK_DETAILS_RE)) {
-      candidates.push(m[1].replace(/\\u0060/g, '`'));
+      candidates.push(m[1]);
     }
     if (candidates.length === 0) {
       for (const m of review.body.matchAll(CONTEXT_BLOCK_HTML_COMMENT_RE)) {

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -175,6 +175,7 @@ interface RecapState {
 
 const CONTEXT_BLOCK_DETAILS_RE = /<details>\s*<summary>Manki context<\/summary>\s*```json\s*([\s\S]*?)```\s*<\/details>/g;
 const CONTEXT_BLOCK_HTML_COMMENT_RE = /<!-- manki-context: (.+?) -->/g;
+const REQUIRED_ROUND_CONTEXT_KEYS = ['meta', 'config', 'diff', 'models', 'planner', 'reviewers', 'judge', 'dedup', 'memory', 'findings', 'usage', 'verdict'] as const;
 
 /**
  * Parse Manki context blocks from PR-level review bodies. Supports both the
@@ -233,6 +234,11 @@ function parseContextBlocks(
       }
       if (typeof mankiVersion !== 'string') {
         core.warning(`Skipping Manki context block at ${reviewUrl}: missing meta.mankiVersion`);
+        continue;
+      }
+      const missingKey = REQUIRED_ROUND_CONTEXT_KEYS.find(k => !(k in (parsed as object)));
+      if (missingKey) {
+        core.warning(`Skipping Manki context block at ${reviewUrl}: missing required field '${missingKey}'`);
         continue;
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -573,6 +573,12 @@ export interface FindingFingerprintEntry {
   threadId?: string;
   severity: FindingSeverity | 'unknown';
   authorReplyClass?: AuthorReplyClass;
+  /** Originating specialist name (from `Finding.reviewers[0]`). */
+  specialist?: string;
+  /** Reviewer's proposed fix at the time the finding was raised. Stored so later rounds can detect code that implements a prior-round proposal (own-proposal caveat rule). */
+  suggestedFix?: string;
+  /** Human-readable finding title. */
+  title?: string;
 }
 
 export interface RoundUsage {


### PR DESCRIPTION
## Summary
- Extends `RecapState` with `priorRounds: RoundContext[]` (chronological).
- New `parseContextBlocks` parser accepts both wrapper formats (`<details>` and `<!-- manki-context: ... -->`), reverses the ``` and `>` escapes used by `formatContextBlock`, dedupes duplicate `meta.round` by latest review id, and warns on malformed JSON or missing required fields.
- `fetchRecapState` now calls `pulls.listReviews` to gather summary bodies and feeds them through the parser.

## Notes
- Stacked on #706 (base: `feat/686-context-block`). Will retarget to `main` when #706 squash-merges.
- Parser already handles the HTML-comment wrapper that #687 introduces, so the two PRs are independent.
- Draft until #706 lands.

Closes #688