### PR TITLE
docs: promote repo-settings prerequisite to its own section in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -48,7 +48,7 @@ Create `.github/workflows/manki.yml`. See [full workflow below](#step-3-add-the-
 3. Check **"Allow GitHub Actions to create and approve pull requests"**
 4. Click Save
 
-### Branch Protection (Optional)
+## Branch Protection (Optional)
 
 If you use branch protection rules and want Manki to be a required check:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,7 +27,7 @@ OAuth alternatives that ride your existing CLI subscription are also supported. 
 
 ### 3. Add the Workflow
 
-Create `.github/workflows/manki.yml` -- see [full workflow below](#step-3-add-the-workflow).
+Create `.github/workflows/manki.yml`. See [full workflow below](#step-3-add-the-workflow).
 
 ---
 
@@ -37,9 +37,11 @@ Create `.github/workflows/manki.yml` -- see [full workflow below](#step-3-add-th
 - Credentials for at least one provider (Anthropic, OpenAI, or Gemini)
 - Repository admin access (for settings changes)
 
-### Enable GitHub Actions PR Approval
+## Required Repository Settings
 
-**Required** -- without this, the action cannot approve PRs.
+### Enable PR Approvals and Change Requests
+
+**Required.** Without this setting, the action cannot post APPROVE or REQUEST_CHANGES reviews. The "Failed to post APPROVE review" error in CI means this is not enabled.
 
 1. Go to **Settings > Actions > General**
 2. Scroll to **Workflow permissions**
@@ -63,7 +65,7 @@ If you use branch protection rules and want Manki to be a required check:
 
 ## Step 1: Install the GitHub App
 
-Install the [Manki GitHub App](https://github.com/apps/manki-review) on the repositories you want reviewed. This gives Manki its own identity -- reviews appear as `manki-review[bot]` with a distinct avatar instead of the generic `github-actions[bot]`.
+Install the [Manki GitHub App](https://github.com/apps/manki-review) on the repositories you want reviewed. This gives Manki its own identity: reviews appear as `manki-review[bot]` with a distinct avatar instead of the generic `github-actions[bot]`.
 
 1. Go to [github.com/apps/manki-review](https://github.com/apps/manki-review)
 2. Click **Install**


### PR DESCRIPTION
## Summary
- Promotes the "Enable PR Approvals and Change Requests" requirement out of the buried `## Prerequisites` bullet into its own top-level `## Required Repository Settings` section between Prerequisites and Step 1, so it cannot be missed during setup.
- Sharpens the description to cross-reference the `Failed to post APPROVE review` troubleshooting entry, so users who land in the error first can trace back to the fix.

## Notes
- Small targeted polish, not the full #483 docs restructure (Docusaurus + content split). Full restructure is deferred to v5.1.
- Single file changed (`SETUP.md`, +6 / -4).

Refs #483