### PR TITLE
fix: preserve full `ERROR:` line in CLI failure diagnostics

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import Anthropic from '@anthropic-ai/sdk';
 import * as core from '@actions/core';
 
-import { sanitizeLogOutput, STALE_TIMEOUT_MS, buildTimeoutDiagnostics } from './cli-utils';
+import { sanitizeLogOutput, STALE_TIMEOUT_MS, buildTimeoutDiagnostics, extractCliErrorSnippet } from './cli-utils';
 import { AnthropicAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
 // Re-export for backward compatibility with existing test imports.
@@ -261,7 +261,7 @@ export class AnthropicClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderr.slice(0, 500)}`;
+          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${extractCliErrorSnippet(stderr)}`;
           core.warning(`Claude CLI failed (${msg})`);
           reject(new Error(`Claude CLI invocation failed (${msg})`));
           return;

--- a/src/providers/cli-utils.test.ts
+++ b/src/providers/cli-utils.test.ts
@@ -137,6 +137,20 @@ describe('extractCliErrorSnippet', () => {
     const stderr = 'noise\n   ERROR: trimmed payload   \nmore noise\n';
     expect(extractCliErrorSnippet(stderr)).toBe('ERROR: trimmed payload');
   });
+
+  it('truncates an ERROR line exceeding the default 16 384-char cap with an ellipsis', () => {
+    const longPayload = 'x'.repeat(20_000);
+    const stderr = `ERROR: ${longPayload}`;
+    const snippet = extractCliErrorSnippet(stderr);
+    expect(snippet.endsWith('…')).toBe(true);
+    expect(snippet.length).toBe(16_384 + 1); // cap chars + ellipsis
+  });
+
+  it('respects a custom maxErrorLineLen cap', () => {
+    const stderr = `ERROR: ${'y'.repeat(200)}`;
+    const snippet = extractCliErrorSnippet(stderr, 500, 100);
+    expect(snippet).toBe('ERROR: ' + 'y'.repeat(93) + '…');
+  });
 });
 
 describe('seedAuthFile', () => {

--- a/src/providers/cli-utils.test.ts
+++ b/src/providers/cli-utils.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync 
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { buildTimeoutDiagnostics, sanitizeLogOutput, seedAuthFile } from './cli-utils';
+import { buildTimeoutDiagnostics, extractCliErrorSnippet, sanitizeLogOutput, seedAuthFile } from './cli-utils';
 
 function encode(json: unknown): string {
   return Buffer.from(JSON.stringify(json), 'utf8').toString('base64');
@@ -62,11 +62,20 @@ describe('buildTimeoutDiagnostics', () => {
     expect(result).not.toContain('x'.repeat(501));
   });
 
-  it('truncates stderr to first 500 chars', () => {
+  it('falls back to first 500 chars of stderr when no ERROR line is present', () => {
     const long = 'y'.repeat(600);
     const result = buildTimeoutDiagnostics('', long);
     expect(result).toContain('stderr: ' + 'y'.repeat(500));
     expect(result).not.toContain('y'.repeat(501));
+  });
+
+  it('preserves a long final ERROR line in stderr without truncation', () => {
+    const longMessage = 'The model id is not supported for this account. '.repeat(20);
+    const errorLine = `ERROR: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"${longMessage}"}}`;
+    const stderr = `noise line 1\nnoise line 2\n${errorLine}\n`;
+    const result = buildTimeoutDiagnostics('', stderr);
+    expect(result).toContain(errorLine);
+    expect(result).toContain(longMessage);
   });
 
   it('sanitizes workflow commands in both snippets', () => {
@@ -74,6 +83,59 @@ describe('buildTimeoutDiagnostics', () => {
     expect(result).not.toContain('::error');
     expect(result).not.toContain('::warning');
     expect(result).toContain('[redacted-workflow-cmd]');
+  });
+});
+
+describe('extractCliErrorSnippet', () => {
+  it('returns the empty string for empty input', () => {
+    expect(extractCliErrorSnippet('')).toBe('');
+  });
+
+  it('returns the last ERROR line whole when present', () => {
+    const stderr = 'warm-up line\nERROR: short error 1\nlater noise\nERROR: short error 2\n';
+    expect(extractCliErrorSnippet(stderr)).toBe('ERROR: short error 2');
+  });
+
+  it('preserves a >500-char ERROR JSON payload end-to-end including the message field', () => {
+    const fullMessage = "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.";
+    const payload = JSON.stringify({
+      type: 'error',
+      status: 400,
+      error: {
+        type: 'invalid_request_error',
+        message: fullMessage,
+        details: 'x'.repeat(600),
+      },
+    });
+    const stderr = `2025-05-14T00:00:00Z some preamble\nERROR: ${payload}\n`;
+    expect(stderr.length).toBeGreaterThan(500);
+    const snippet = extractCliErrorSnippet(stderr);
+    expect(snippet).toContain(`"message":"${fullMessage}"`);
+    expect(snippet.endsWith('}')).toBe(true);
+    expect(snippet.length).toBeGreaterThan(500);
+  });
+
+  it('falls back to head slice when no ERROR line is present', () => {
+    const stderr = 'z'.repeat(800);
+    const snippet = extractCliErrorSnippet(stderr);
+    expect(snippet).toBe('z'.repeat(500));
+  });
+
+  it('respects a custom fallback length', () => {
+    const stderr = 'a'.repeat(800);
+    expect(extractCliErrorSnippet(stderr, 100)).toBe('a'.repeat(100));
+  });
+
+  it('sanitizes workflow commands inside an ERROR line', () => {
+    const stderr = 'ERROR: ::warning::leaked secret here';
+    const snippet = extractCliErrorSnippet(stderr);
+    expect(snippet).not.toContain('::warning');
+    expect(snippet).toContain('[redacted-workflow-cmd]');
+  });
+
+  it('handles ERROR lines with surrounding whitespace', () => {
+    const stderr = 'noise\n   ERROR: trimmed payload   \nmore noise\n';
+    expect(extractCliErrorSnippet(stderr)).toBe('ERROR: trimmed payload');
   });
 });
 

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -17,20 +17,28 @@ export function sanitizeLogOutput(text: string): string {
  * whole is more useful than a fixed head slice, which routinely cuts the JSON
  * mid-string. When no `ERROR:` line is present, falls back to the first
  * `maxFallbackChars` characters. Always applies `sanitizeLogOutput`.
+ * `maxErrorLineLen` caps the returned ERROR line to avoid embedding
+ * pathologically large strings in annotations and error objects.
  */
-export function extractCliErrorSnippet(stderrText: string, maxFallbackChars = 500): string {
+export function extractCliErrorSnippet(
+  stderrText: string,
+  maxFallbackChars = 500,
+  maxErrorLineLen = 16_384,
+): string {
   const sanitized = sanitizeLogOutput(stderrText);
   if (!sanitized) return '';
-  const errorLine = findLastErrorLine(sanitized);
+  const errorLine = findLastErrorLine(sanitized, maxErrorLineLen);
   if (errorLine) return errorLine;
   return sanitized.slice(0, maxFallbackChars);
 }
 
-function findLastErrorLine(text: string): string | null {
+function findLastErrorLine(text: string, maxLen = 16_384): string | null {
   const lines = text.split(/\r?\n/);
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i].trim();
-    if (/^ERROR:\s/.test(line)) return line;
+    if (/^ERROR:\s/.test(line)) {
+      return line.length <= maxLen ? line : line.slice(0, maxLen) + '…';
+    }
   }
   return null;
 }

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -10,10 +10,35 @@ export function sanitizeLogOutput(text: string): string {
   return text.replace(/::[a-z].*$/gim, '[redacted-workflow-cmd]');
 }
 
+/**
+ * Extract a useful snippet from CLI stderr for error messages. CLIs (Codex,
+ * Gemini, Claude) frequently emit a final `ERROR: {...}` line with a JSON
+ * payload that contains the actionable `message` field. Returning that line
+ * whole is more useful than a fixed head slice, which routinely cuts the JSON
+ * mid-string. When no `ERROR:` line is present, falls back to the first
+ * `maxFallbackChars` characters. Always applies `sanitizeLogOutput`.
+ */
+export function extractCliErrorSnippet(stderrText: string, maxFallbackChars = 500): string {
+  const sanitized = sanitizeLogOutput(stderrText);
+  if (!sanitized) return '';
+  const errorLine = findLastErrorLine(sanitized);
+  if (errorLine) return errorLine;
+  return sanitized.slice(0, maxFallbackChars);
+}
+
+function findLastErrorLine(text: string): string | null {
+  const lines = text.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (/^ERROR:\s/.test(line)) return line;
+  }
+  return null;
+}
+
 /** Build diagnostic snippets for timeout/stale error messages. */
 export function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: string): string {
   const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
-  const stderrSnippet = sanitizeLogOutput(stderrText.slice(0, 500));
+  const stderrSnippet = extractCliErrorSnippet(stderrText);
   const parts: string[] = [];
   if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
   if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import * as core from '@actions/core';
 
-import { buildTimeoutDiagnostics, sanitizeLogOutput, seedAuthFile, STALE_TIMEOUT_MS } from './cli-utils';
+import { buildTimeoutDiagnostics, extractCliErrorSnippet, sanitizeLogOutput, seedAuthFile, STALE_TIMEOUT_MS } from './cli-utils';
 import { GeminiAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -273,7 +273,7 @@ export class GeminiClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const stderrSnippet = sanitizeLogOutput(stderr.slice(0, 500));
+          const stderrSnippet = extractCliErrorSnippet(stderr);
           const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderrSnippet}`;
           core.warning(`Gemini CLI failed (${msg})`);
           reject(new Error(`Gemini CLI invocation failed (${msg})`));

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions';
 import * as core from '@actions/core';
 
-import { seedAuthFile } from './cli-utils';
+import { extractCliErrorSnippet, seedAuthFile } from './cli-utils';
 import { LLMClient, LLMResponse, OpenAIAuth, SendMessageOptions } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -76,7 +76,7 @@ export function resolveEffortTier(effort: 'low' | 'medium' | 'high' | 'max'): 'l
 /** Build diagnostic snippets for timeout/stale error messages. */
 function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: string): string {
   const stdoutSnippet = sanitizeLogOutput(lastStdoutChunk.slice(-500));
-  const stderrSnippet = sanitizeLogOutput(stderrText.slice(0, 500));
+  const stderrSnippet = extractCliErrorSnippet(stderrText);
   const parts: string[] = [];
   if (stdoutSnippet) parts.push(`Last stdout: ${stdoutSnippet}`);
   if (stderrSnippet) parts.push(`stderr: ${stderrSnippet}`);
@@ -314,7 +314,7 @@ export class OpenAIClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const sanitizedStderr = sanitizeLogOutput(stderr.slice(0, 500));
+          const sanitizedStderr = extractCliErrorSnippet(stderr);
           const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${sanitizedStderr}`;
           core.warning(`Codex CLI failed (${msg})`);
           reject(new Error(`Codex CLI invocation failed (${msg})`));


### PR DESCRIPTION
## Summary
- New `extractCliErrorSnippet` helper in `src/providers/cli-utils.ts` returns the last `ERROR: ...` line from stderr whole (still sanitized), falling back to a 500-char head slice only when no such line exists.
- Non-zero exit paths in `anthropic.ts`, `openai.ts`, and `gemini.ts` now use the helper, so a long Codex CLI JSON payload like `ERROR: {"type":"error",...,"message":"The 'gpt-5-codex' model is not supported..."}` is no longer cut mid-string.
- `buildTimeoutDiagnostics` uses the same helper for stderr while keeping the existing tail-context slice for stdout.

## Verification
- Added `extractCliErrorSnippet` unit tests covering: empty input, last-ERROR-line preservation, >500-char ERROR JSON payload survives end-to-end with the `message` field intact, fallback head slice, custom fallback length, sanitization, and surrounding whitespace.
- Updated the `buildTimeoutDiagnostics` stderr test and added one for the long-ERROR case.
- `npm run lint`, `npm run typecheck`, and the full `npm test` suite (1835 tests) pass.

Closes #709