### PR TITLE
fix: improve effort-ignored warning for non-reasoning models

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -108,7 +108,7 @@ The `low | medium | high | max` knobs map per provider as follows. Manki passes 
 | high   | `budget_tokens: 10000` | `reasoning_effort: high` | (ignored, warning) | `thinkingBudget: 10000` |
 | max    | `budget_tokens: 16000` | `reasoning_effort: high` (collapsed) | (ignored, warning) | `thinkingBudget: 10000` (collapsed) |
 
-The `max` tier collapses silently to `high` for OpenAI o-series and Gemini — no warning is emitted, unlike the GPT non-reasoning path which logs a warning when effort is ignored. The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
+The `max` tier collapses silently to `high` for OpenAI o-series and Gemini — no warning is emitted, unlike the GPT non-reasoning path which logs a warning when effort is ignored. For GPT models via the Codex CLI (OAuth path), the warning names the Codex CLI's default effort as the value that will actually be applied. For GPT models via the API, the warning notes that effort has no effect. The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
 
 ### Anthropic
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -108,7 +108,7 @@ The `low | medium | high | max` knobs map per provider as follows. Manki passes 
 | high   | `budget_tokens: 10000` | `reasoning_effort: high` | (ignored, warning) | `thinkingBudget: 10000` |
 | max    | `budget_tokens: 16000` | `reasoning_effort: high` (collapsed) | (ignored, warning) | `thinkingBudget: 10000` (collapsed) |
 
-The `max` tier collapses silently to `high` for OpenAI o-series and Gemini — no warning is emitted, unlike the GPT non-reasoning path which logs a warning when effort is ignored. For GPT models via the Codex CLI (OAuth path), the warning names the Codex CLI's default effort as the value that will actually be applied. For GPT models via the API, the warning notes that effort has no effect. The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
+The `max` tier collapses silently to `high` for OpenAI o-series and Gemini — no warning is emitted, unlike the GPT non-reasoning path which logs a warning when effort is ignored. For GPT models via the Codex CLI (OAuth path), the warning notes that the CLI will apply its own default effort (which may differ from the requested tier). For GPT models via the API, the warning notes that effort has no effect. The Gemini OAuth (CLI) path passes prompts through the Gemini CLI binary and does not support effort tiers. Use API key auth if you need thinking budgets on Gemini.
 
 ### Anthropic
 

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -39,6 +39,10 @@ Arguments:
              Examples: claude-haiku-4-5, gpt-4o-mini, o4-mini, gemini-2.5-flash.
              Or use provider/model syntax: anthropic/claude-..., openai/gpt-..., gemini/gemini-...
   --effort   Optional. low | medium | high | max. Provider behaviour varies.
+             For non-reasoning OpenAI models (GPT family), --effort is ignored.
+             The Codex CLI (OAuth path) applies its own default effort; the API
+             path silently omits reasoning_effort. A warning is emitted in both
+             cases so the effective effort is visible in CI logs.
   --prompt   Optional. Override the default test prompt.
   --help     Print this message.
 

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -135,6 +135,7 @@ describe('sendMessage (API path)', () => {
     const params = mockCreate.mock.calls[0][0];
     expect(params.reasoning_effort).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Effort has no effect via the OpenAI API'));
     warnSpy.mockRestore();
   });
 
@@ -297,6 +298,7 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
     expect(spawnArgs.find(a => a.startsWith('model_reasoning_effort'))).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Codex CLI will apply its own default effort'));
     warnSpy.mockRestore();
   });
 

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -134,7 +134,22 @@ describe('sendMessage (API path)', () => {
 
     const params = mockCreate.mock.calls[0][0];
     expect(params.reasoning_effort).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Effort has no effect via the OpenAI API'));
+    warnSpy.mockRestore();
+  });
+
+  it('warns and ignores non-high effort on non-reasoning models', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
+
+    await client.sendMessage('sys', 'user', { effort: 'low' });
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.reasoning_effort).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=low'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Effort has no effect via the OpenAI API'));
     warnSpy.mockRestore();
   });
@@ -297,7 +312,23 @@ describe('sendViaOAuth (Codex CLI path)', () => {
 
     const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
     expect(spawnArgs.find(a => a.startsWith('model_reasoning_effort'))).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Codex CLI will apply its own default effort'));
+    warnSpy.mockRestore();
+  });
+
+  it('warns and skips reasoning override for non-high effort on non-reasoning models', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    setupSpawnMock('ok\n');
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+
+    await client.sendMessage('sys', 'user', { effort: 'low' });
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs.find(a => a.startsWith('model_reasoning_effort'))).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=low'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Codex CLI will apply its own default effort'));
     warnSpy.mockRestore();
   });

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -104,6 +104,10 @@ describe('sendMessage (API path)', () => {
     }));
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('sends model, system message, and user message in chat completions request', async () => {
     const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk' }, model: 'gpt-4o' });
     await client.sendMessage('sys-prompt', 'user-msg');
@@ -137,7 +141,6 @@ describe('sendMessage (API path)', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Effort has no effect via the OpenAI API'));
-    warnSpy.mockRestore();
   });
 
   it('warns and ignores non-high effort on non-reasoning models', async () => {
@@ -151,7 +154,6 @@ describe('sendMessage (API path)', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=low'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Effort has no effect via the OpenAI API'));
-    warnSpy.mockRestore();
   });
 
   it('maps low effort to reasoning_effort=low for o3', async () => {
@@ -248,6 +250,7 @@ describe('sendViaOAuth (Codex CLI path)', () => {
   afterEach(() => {
     if (savedCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = savedCodexHome;
+    jest.restoreAllMocks();
   });
 
   function setupSpawnMock(stdout: string, opts: { exitCode?: number; stderr?: string } = {}): void {
@@ -315,7 +318,6 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=high'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Codex CLI will apply its own default effort'));
-    warnSpy.mockRestore();
   });
 
   it('warns and skips reasoning override for non-high effort on non-reasoning models', async () => {
@@ -330,7 +332,6 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring effort=low'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Codex CLI will apply its own default effort'));
-    warnSpy.mockRestore();
   });
 
   it('does not pass the OAuth secret as a CLI env var (auth flows via $CODEX_HOME/auth.json)', async () => {
@@ -593,6 +594,7 @@ describe('sendViaOAuth — extended coverage', () => {
   afterEach(() => {
     if (savedCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = savedCodexHome;
+    jest.restoreAllMocks();
   });
 
   interface MockProc {
@@ -731,7 +733,6 @@ describe('sendViaOAuth — extended coverage', () => {
 
     await promise;
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('stdin write error'));
-    warnSpy.mockRestore();
   });
 
   it('rejects when stdin.write throws synchronously', async () => {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -187,7 +187,7 @@ export class OpenAIClient implements LLMClient {
         // here would be passed as literal characters because `spawn` bypasses the shell.
         args.push('-c', `model_reasoning_effort=${resolveEffortTier(options.effort)}`);
       } else if (options?.effort) {
-        core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
+        core.warning(`Ignoring effort=${options.effort} for model "${this.model}" — not a reasoning model. The Codex CLI will apply its own default effort instead.`);
       }
 
       // Read prompt from stdin
@@ -366,7 +366,7 @@ export class OpenAIClient implements LLMClient {
 
     const reasoning = isReasoningModel(this.model);
     if (options?.effort && !reasoning) {
-      core.warning(`Ignoring effort=${options.effort} — model "${this.model}" is not a reasoning model`);
+      core.warning(`Ignoring effort=${options.effort} for model "${this.model}" — not a reasoning model. Effort has no effect via the OpenAI API for GPT-family models.`);
     }
 
     // `reasoning_effort` is only valid on o-series chat completions and the SDK's


### PR DESCRIPTION
## Summary

- Warning emitted when `--effort` is ignored now states which effort the underlying path will actually apply: for the Codex CLI (OAuth) path it names the CLI's own default as the effective effort, for the API path it states effort has no effect on GPT-family models.
- Documented in harness `--help` and SETUP.md provider-effort section.
- Unit tests for both the API path and the CLI (OAuth) path are updated to assert the new warning content.

Closes #710