### PR TITLE
feat: split `forceReview` from `skipCap`, add `Force review` tickbox to round-cap notice

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 
-import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, buildNitIssueBody, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, createNitIssue, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, FindingFingerprintEntry, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, roundContextToFlatAliases } from './types';
 import { DEFAULT_CONFIG } from './config';
 
@@ -3106,6 +3106,16 @@ describe('isReviewInProgress', () => {
   it('returns false when comment is a skip comment containing FORCE_REVIEW_MARKER', async () => {
     const { octokit } = makeMockOctokit({
       comments: [{ body: `${BOT_MARKER}\n**Review skipped**\n\n${FORCE_REVIEW_MARKER}`, user: { type: 'Bot' } }],
+    });
+
+    const result = await isReviewInProgress(octokit, 'owner', 'repo', 1);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when comment is a cap-notice comment containing FORCE_CAP_MARKER', async () => {
+    const { octokit } = makeMockOctokit({
+      comments: [{ body: `${BOT_MARKER}\nAutomatic review is paused.\n\n- [ ] Force review\n\n${FORCE_CAP_MARKER}`, user: { type: 'Bot' } }],
     });
 
     const result = await isReviewInProgress(octokit, 'owner', 'repo', 1);

--- a/src/github.ts
+++ b/src/github.ts
@@ -15,6 +15,7 @@ const ACTIONS_BOT_LOGIN = 'github-actions[bot]';
 const BOT_MARKER = '<!-- manki-bot -->';
 const REVIEW_COMPLETE_MARKER = '<!-- manki-review-complete -->';
 const FORCE_REVIEW_MARKER = '<!-- manki-force-review -->';
+const FORCE_CAP_MARKER = '<!-- manki-force-cap -->';
 const RUN_ID_MARKER_PREFIX = '<!-- manki-run-id:';
 const CANCELLED_MARKER = '<!-- manki-review-cancelled -->';
 const VERSION_MARKER_PREFIX = '<!-- manki-version:';
@@ -1280,6 +1281,7 @@ async function findProgressComment(
     c.body?.includes(BOT_MARKER) &&
     !c.body?.includes(REVIEW_COMPLETE_MARKER) &&
     !c.body?.includes(FORCE_REVIEW_MARKER) &&
+    !c.body?.includes(FORCE_CAP_MARKER) &&
     !c.body?.includes(CANCELLED_MARKER)
   );
   if (!match || !match.body) return null;
@@ -1470,4 +1472,4 @@ async function cancelActiveReviewRun(
   }
 }
 
-export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,6 +144,7 @@ jest.mock('./github', () => ({
   postAppWarningIfNeeded: jest.fn().mockResolvedValue(undefined),
   cancelActiveReviewRun: jest.fn().mockResolvedValue(false),
   BOT_LOGIN: 'manki-review[bot]',
+  ACTIONS_BOT_LOGIN: 'github-actions[bot]',
   BOT_MARKER: '<!-- manki-bot -->',
   REVIEW_COMPLETE_MARKER: '<!-- manki-review-complete -->',
   FORCE_REVIEW_MARKER: '<!-- manki-force-review -->',
@@ -4236,6 +4237,26 @@ describe('runFullReview orchestration', () => {
 
       expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
     });
+
+    it('@manki review bypasses the round cap (skipCap=true)', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      seedPriorRounds(42, 'test-repo', priorRounds(5));
+
+      jest.mocked(interaction.isReviewRequest).mockReturnValue(true);
+      setContext({
+        eventName: 'issue_comment',
+        payload: {
+          action: 'created',
+          sender: { login: 'owner' },
+          issue: { number: 42, pull_request: { url: 'https://api.github.com/repos/test-owner/test-repo/pulls/42' } },
+          comment: { id: 1, body: '@manki review', author_association: 'OWNER' },
+        },
+      });
+
+      await run();
+
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
   });
 
   it('calls setFailed when parseModelSpec throws for an unknown model', async () => {
@@ -4922,7 +4943,7 @@ describe('force review checkbox', () => {
         action: 'edited',
         sender: { login: 'user' },
         issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 42, body: forceBody, author_association: 'COLLABORATOR' },
+        comment: { id: 42, body: forceBody, user: { login: ghUtils.BOT_LOGIN }, author_association: 'COLLABORATOR' },
       },
     });
 
@@ -4947,7 +4968,7 @@ describe('force review checkbox', () => {
         action: 'edited',
         sender: { login: 'user' },
         issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 99, body: capNoticeBody, author_association: 'COLLABORATOR' },
+        comment: { id: 99, body: capNoticeBody, user: { login: ghUtils.BOT_LOGIN }, author_association: 'COLLABORATOR' },
       },
     });
 
@@ -5008,7 +5029,7 @@ describe('force review checkbox', () => {
         action: 'edited',
         sender: { login: 'user' },
         issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 42, body: forceBody, author_association: 'COLLABORATOR' },
+        comment: { id: 42, body: forceBody, user: { login: ghUtils.BOT_LOGIN }, author_association: 'COLLABORATOR' },
       },
     });
 
@@ -5020,5 +5041,110 @@ describe('force review checkbox', () => {
     // by verifying the pulls.get call (entry into runFullReview) since runFullReview
     // is the real implementation here, not a mock.
     expect(mockPullsGet).toHaveBeenCalled();
+  });
+
+  it('in-progress tickbox still blocked by cap when rounds at limit (skipCap=false)', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'test-api-key' : '',
+    );
+    const reviewableFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(authModule.getMemoryToken).mockReturnValue('mem-token');
+    jest.mocked(memoryModule.loadMemory).mockResolvedValue({ learnings: [], suppressions: [], patterns: [] });
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({ files: [reviewableFile], totalAdditions: 5, totalDeletions: 5 });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([reviewableFile]);
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, max_diff_lines: 5000,
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [], instructions: '', review_level: 'auto',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: true, repo: 'owner/memory' },
+      convergence: { max_auto_rounds: 5, test_path_patterns: ['**/*.test.*'], suppress_resolved_threads: true },
+    });
+    const rounds = Array.from({ length: 5 }, (_, i) => ({
+      round: i + 1, commitSha: `sha${i + 1}`, timestamp: '2025-01-01T00:00:00Z', findings: [],
+    }));
+    seedPriorRounds(1, 'test-repo', rounds);
+
+    const forceBody = `<!-- manki-bot -->\n**Review skipped** — a review is currently in progress. Retry when it completes, or force now:\n\n- [x] Force review\n\n${FORCE_REVIEW_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'user' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/test-owner/test-repo/pulls/1' } },
+        comment: { id: 42, body: forceBody, user: { login: ghUtils.BOT_LOGIN }, author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await run();
+
+    // cap fires because skipCap=false — forceReview only bypasses in-progress check, not cap
+    expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining('Automatic review is paused') }),
+    );
+  });
+
+  it('cap-notice tickbox bypasses cap end-to-end when rounds at limit (skipCap=true)', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'test-api-key' : '',
+    );
+    const reviewableFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(authModule.getMemoryToken).mockReturnValue('mem-token');
+    jest.mocked(memoryModule.loadMemory).mockResolvedValue({ learnings: [], suppressions: [], patterns: [] });
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({ files: [reviewableFile], totalAdditions: 5, totalDeletions: 5 });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([reviewableFile]);
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, max_diff_lines: 5000,
+      exclude_paths: [], nit_handling: 'issues',
+      reviewers: [], instructions: '', review_level: 'auto',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: true, repo: 'owner/memory' },
+      convergence: { max_auto_rounds: 5, test_path_patterns: ['**/*.test.*'], suppress_resolved_threads: true },
+    });
+    const rounds = Array.from({ length: 5 }, (_, i) => ({
+      round: i + 1, commitSha: `sha${i + 1}`, timestamp: '2025-01-01T00:00:00Z', findings: [],
+    }));
+    seedPriorRounds(1, 'test-repo', rounds);
+
+    const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:\n\n- [x] Force review\n\n${FORCE_CAP_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'user' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/test-owner/test-repo/pulls/1' } },
+        comment: { id: 99, body: capNoticeBody, user: { login: ghUtils.BOT_LOGIN }, author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await run();
+
+    // skipCap=true bypasses the cap guard — review runs despite rounds at limit
+    expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+  });
+
+  it('ignores force review tickbox when comment is not from the bot', async () => {
+    const forceBody = `<!-- manki-bot -->\n**Review skipped** — a review is currently in progress. Retry when it completes, or force now:\n\n- [x] Force review\n\n${FORCE_REVIEW_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'attacker' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 77, body: forceBody, user: { login: 'attacker' } },
+      },
+    });
+
+    await run();
+
+    expect(mockPullsGet).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.reactToIssueComment)).not.toHaveBeenCalled();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -147,6 +147,7 @@ jest.mock('./github', () => ({
   BOT_MARKER: '<!-- manki-bot -->',
   REVIEW_COMPLETE_MARKER: '<!-- manki-review-complete -->',
   FORCE_REVIEW_MARKER: '<!-- manki-force-review -->',
+  FORCE_CAP_MARKER: '<!-- manki-force-cap -->',
   APP_WARNING_MARKER: '<!-- manki-app-warning -->',
 }));
 
@@ -156,7 +157,7 @@ jest.mock('./state', () => ({
 }));
 
 import { run, runFullReview, handlePullRequest, handleCommentTrigger, handleInteraction, handleIssueInteraction, handleReviewCommentInteraction, handleReviewStateCheck, main, _resetOctokitCache } from './index';
-import { FORCE_REVIEW_MARKER } from './github';
+import { FORCE_REVIEW_MARKER, FORCE_CAP_MARKER } from './github';
 import type { ReviewConfig } from './types';
 import { createLLMClient, parseModelSpec } from './providers';
 import * as interaction from './interaction';
@@ -4113,21 +4114,38 @@ describe('runFullReview orchestration', () => {
         .find(([args]) => typeof args.body === 'string' && args.body.includes('Automatic review is paused'));
       expect(capCall).toBeDefined();
       const capBody = capCall![0].body as string;
-      expect(capBody).toContain(FORCE_REVIEW_MARKER);
+      expect(capBody).toContain(FORCE_CAP_MARKER);
+      expect(capBody).not.toContain(FORCE_REVIEW_MARKER);
       expect(capBody).toContain('- [ ] Force review');
     });
 
-    it('bypasses the cap when forceReview is true', async () => {
+    it('bypasses the cap when skipCap is true', async () => {
       jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
       seedPriorRounds(priorRounds(5));
 
       await runFullReview(
         baseArgs.owner, baseArgs.repo, baseArgs.prNumber,
         baseArgs.commitSha, baseArgs.baseRef, baseArgs.prContext,
-        undefined, true,
+        undefined, false, true,
       );
 
       expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+
+    it('does not bypass the cap when only forceReview is true', async () => {
+      jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
+      seedPriorRounds(42, 'test-repo', priorRounds(5));
+
+      await runFullReview(
+        baseArgs.owner, baseArgs.repo, baseArgs.prNumber,
+        baseArgs.commitSha, baseArgs.baseRef, baseArgs.prContext,
+        undefined, true, false,
+      );
+
+      expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+      expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining('Automatic review is paused') }),
+      );
     });
 
     it('does nothing when max_auto_rounds is 0 (cap disabled)', async () => {
@@ -4174,7 +4192,8 @@ describe('runFullReview orchestration', () => {
         .find(([args]) => typeof args.body === 'string' && args.body.includes('Automatic review is paused'));
       expect(capCall).toBeDefined();
       const capBody = capCall![0].body as string;
-      expect(capBody).toContain(FORCE_REVIEW_MARKER);
+      expect(capBody).toContain(FORCE_CAP_MARKER);
+      expect(capBody).not.toContain(FORCE_REVIEW_MARKER);
       expect(capBody).toContain('- [ ] Force review');
     });
 
@@ -4917,10 +4936,11 @@ describe('force review checkbox', () => {
     expect(mockPullsGet).toHaveBeenCalled();
   });
 
-  it('routes round-cap notice force review checkbox edit to handleCommentTrigger with forceReview', async () => {
+  it('routes round-cap notice force review checkbox edit to handleCommentTrigger with both flags', async () => {
     // Simulate a round-cap notice that the author has just checked. handleCommentTrigger
-    // must run review with forceReview=true so the cap guard is bypassed.
-    const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Force another round:\n\n- [x] Force review\n\n${FORCE_REVIEW_MARKER}`;
+    // must run review with skipCap=true (and forceReview=true defensively) so the cap
+    // guard is bypassed.
+    const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:\n\n- [x] Force review\n\n${FORCE_CAP_MARKER}`;
     setContext({
       eventName: 'issue_comment',
       payload: {
@@ -4936,7 +4956,7 @@ describe('force review checkbox', () => {
     expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 99, 'eyes',
     );
-    // force review bypasses the isReviewInProgress check entirely
+    // both flags set, so the in-progress check is bypassed
     expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled();
     expect(mockPullsGet).toHaveBeenCalled();
   });
@@ -4958,5 +4978,47 @@ describe('force review checkbox', () => {
     // Unchecked checkbox should not trigger a review
     expect(mockPullsGet).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.reactToIssueComment)).not.toHaveBeenCalled();
+  });
+
+  it('ignores cap-notice tickbox when unchecked', async () => {
+    const uncheckedCapBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:\n\n- [ ] Force review\n\n${FORCE_CAP_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'user' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 99, body: uncheckedCapBody },
+      },
+    });
+
+    await run();
+
+    expect(mockPullsGet).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.reactToIssueComment)).not.toHaveBeenCalled();
+  });
+
+  it('in-progress tickbox passes forceReview but not skipCap to handleCommentTrigger', async () => {
+    // The in-progress tickbox carries FORCE_REVIEW_MARKER. The dispatcher must pass
+    // forceReview=true (bypass in-progress) but skipCap=false so the cap guard still fires.
+    const forceBody = `<!-- manki-bot -->\n**Review skipped** — a review is currently in progress. Retry when it completes, or force now:\n\n- [x] Force review\n\n${FORCE_REVIEW_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'user' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 42, body: forceBody, author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await run();
+
+    // forceReview=true bypasses the in-progress check
+    expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled();
+    // runFullReview was invoked with forceReview=true, skipCap=false. We assert this
+    // by verifying the pulls.get call (entry into runFullReview) since runFullReview
+    // is the real implementation here, not a mock.
+    expect(mockPullsGet).toHaveBeenCalled();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4135,7 +4135,7 @@ describe('runFullReview orchestration', () => {
 
     it('does not bypass the cap when only forceReview is true', async () => {
       jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
-      seedPriorRounds(42, 'test-repo', priorRounds(5));
+      seedPriorRounds(priorRounds(5));
 
       await runFullReview(
         baseArgs.owner, baseArgs.repo, baseArgs.prNumber,
@@ -4240,7 +4240,7 @@ describe('runFullReview orchestration', () => {
 
     it('@manki review bypasses the round cap (skipCap=true)', async () => {
       jest.mocked(configModule.loadConfig).mockReturnValue(memoryEnabledConfig(5));
-      seedPriorRounds(42, 'test-repo', priorRounds(5));
+      seedPriorRounds(priorRounds(5));
 
       jest.mocked(interaction.isReviewRequest).mockReturnValue(true);
       setContext({
@@ -5066,7 +5066,7 @@ describe('force review checkbox', () => {
     const rounds = Array.from({ length: 5 }, (_, i) => ({
       round: i + 1, commitSha: `sha${i + 1}`, timestamp: '2025-01-01T00:00:00Z', findings: [],
     }));
-    seedPriorRounds(1, 'test-repo', rounds);
+    seedPriorRounds(rounds);
 
     const forceBody = `<!-- manki-bot -->\n**Review skipped** — a review is currently in progress. Retry when it completes, or force now:\n\n- [x] Force review\n\n${FORCE_REVIEW_MARKER}`;
     setContext({
@@ -5111,7 +5111,7 @@ describe('force review checkbox', () => {
     const rounds = Array.from({ length: 5 }, (_, i) => ({
       round: i + 1, commitSha: `sha${i + 1}`, timestamp: '2025-01-01T00:00:00Z', findings: [],
     }));
-    seedPriorRounds(1, 'test-repo', rounds);
+    seedPriorRounds(rounds);
 
     const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:\n\n- [x] Force review\n\n${FORCE_CAP_MARKER}`;
     setContext({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4957,10 +4957,11 @@ describe('force review checkbox', () => {
     expect(mockPullsGet).toHaveBeenCalled();
   });
 
-  it('routes round-cap notice force review checkbox edit to handleCommentTrigger with both flags', async () => {
+  it('routes round-cap notice force review checkbox edit to handleCommentTrigger with skipCap only', async () => {
     // Simulate a round-cap notice that the author has just checked. handleCommentTrigger
-    // must run review with skipCap=true (and forceReview=true defensively) so the cap
-    // guard is bypassed.
+    // must run review with skipCap=true so the cap guard is bypassed, but forceReview=false
+    // so the in-progress guard still fires if a review is already running.
+    jest.mocked(ghUtils.isReviewInProgress).mockReset().mockResolvedValue(false);
     const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:\n\n- [x] Force review\n\n${FORCE_CAP_MARKER}`;
     setContext({
       eventName: 'issue_comment',
@@ -4977,9 +4978,29 @@ describe('force review checkbox', () => {
     expect(jest.mocked(ghUtils.reactToIssueComment)).toHaveBeenCalledWith(
       expect.anything(), 'test-owner', 'test-repo', 99, 'eyes',
     );
-    // both flags set, so the in-progress check is bypassed
-    expect(jest.mocked(ghUtils.isReviewInProgress)).not.toHaveBeenCalled();
+    // forceReview=false, so the in-progress guard runs (returns false by default — no concurrent review)
+    expect(jest.mocked(ghUtils.isReviewInProgress)).toHaveBeenCalled();
     expect(mockPullsGet).toHaveBeenCalled();
+  });
+
+  it('cap-notice tickbox does not bypass in-progress guard when a review is running', async () => {
+    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
+    const capNoticeBody = `<!-- manki-bot -->\nManki has completed 5/5 review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:\n\n- [x] Force review\n\n${FORCE_CAP_MARKER}`;
+    setContext({
+      eventName: 'issue_comment',
+      payload: {
+        action: 'edited',
+        sender: { login: 'user' },
+        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+        comment: { id: 99, body: capNoticeBody, user: { login: ghUtils.BOT_LOGIN }, author_association: 'COLLABORATOR' },
+      },
+    });
+
+    await run();
+
+    // forceReview=false so the in-progress guard fires — concurrent review is blocked
+    expect(jest.mocked(ghUtils.isReviewInProgress)).toHaveBeenCalled();
+    expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
   });
 
   it('ignores force review checkbox when unchecked', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5009,7 +5009,7 @@ describe('force review checkbox', () => {
         action: 'edited',
         sender: { login: 'user' },
         issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 99, body: uncheckedCapBody },
+        comment: { id: 99, body: uncheckedCapBody, user: { login: ghUtils.BOT_LOGIN } },
       },
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,10 +195,11 @@ async function run(): Promise<void> {
 
     case 'issue_comment': {
       const commentBody = github.context.payload.comment?.body ?? '';
-      const forceReviewTickbox = action === 'edited' && isBotComment && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
-      const forceCapTickbox = action === 'edited' && isBotComment && commentBody.includes(FORCE_CAP_MARKER) && commentBody.includes('- [x] Force review');
+      const isBotTickboxEdit = action === 'edited' && isBotComment && commentBody.includes('- [x] Force review');
+      const forceReviewTickbox = isBotTickboxEdit && commentBody.includes(FORCE_REVIEW_MARKER);
+      const forceCapTickbox = isBotTickboxEdit && commentBody.includes(FORCE_CAP_MARKER);
       if (forceCapTickbox && github.context.payload.issue?.pull_request) {
-        await handleCommentTrigger(true, true);
+        await handleCommentTrigger(false, true);
       } else if (forceReviewTickbox && github.context.payload.issue?.pull_request) {
         await handleCommentTrigger(true, false);
       } else if (isReviewRequest(commentBody) && github.context.payload.issue?.pull_request) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   reactToIssueComment,
   fetchLinkedIssues,
   BOT_LOGIN,
+  ACTIONS_BOT_LOGIN,
   BOT_MARKER as PROGRESS_MARKER,
   FORCE_REVIEW_MARKER,
   FORCE_CAP_MARKER,
@@ -132,7 +133,9 @@ async function run(): Promise<void> {
       return;
     }
     const body = github.context.payload.comment?.body ?? '';
-    const isForceReviewChecked = action === 'edited' &&
+    const commentAuthorLogin = github.context.payload.comment?.user?.login as string | undefined;
+    const isBotComment = commentAuthorLogin === BOT_LOGIN || commentAuthorLogin === ACTIONS_BOT_LOGIN;
+    const isForceReviewChecked = action === 'edited' && isBotComment &&
       (body.includes(FORCE_REVIEW_MARKER) || body.includes(FORCE_CAP_MARKER)) &&
       body.includes('- [x] Force review');
     if (!isForceReviewChecked && !hasBotMention(body) && !isReviewRequest(body)) {
@@ -191,8 +194,10 @@ async function run(): Promise<void> {
 
     case 'issue_comment': {
       const commentBody = github.context.payload.comment?.body ?? '';
-      const forceReviewTickbox = action === 'edited' && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
-      const forceCapTickbox = action === 'edited' && commentBody.includes(FORCE_CAP_MARKER) && commentBody.includes('- [x] Force review');
+      const dispatchAuthor = github.context.payload.comment?.user?.login as string | undefined;
+      const isDispatchBotComment = dispatchAuthor === BOT_LOGIN || dispatchAuthor === ACTIONS_BOT_LOGIN;
+      const forceReviewTickbox = action === 'edited' && isDispatchBotComment && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
+      const forceCapTickbox = action === 'edited' && isDispatchBotComment && commentBody.includes(FORCE_CAP_MARKER) && commentBody.includes('- [x] Force review');
       if (forceCapTickbox && github.context.payload.issue?.pull_request) {
         await handleCommentTrigger(true, true);
       } else if (forceReviewTickbox && github.context.payload.issue?.pull_request) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,9 @@ async function run(): Promise<void> {
     );
   }
 
+  const commentAuthorLogin = github.context.payload.comment?.user?.login as string | undefined;
+  const isBotComment = commentAuthorLogin === BOT_LOGIN || commentAuthorLogin === ACTIONS_BOT_LOGIN;
+
   // Event filtering — exit immediately for irrelevant events.
   // Tested via integration (live PR reviews) since it depends on GitHub Actions context.
   if (eventName === 'pull_request') {
@@ -133,8 +136,6 @@ async function run(): Promise<void> {
       return;
     }
     const body = github.context.payload.comment?.body ?? '';
-    const commentAuthorLogin = github.context.payload.comment?.user?.login as string | undefined;
-    const isBotComment = commentAuthorLogin === BOT_LOGIN || commentAuthorLogin === ACTIONS_BOT_LOGIN;
     const isForceReviewChecked = action === 'edited' && isBotComment &&
       (body.includes(FORCE_REVIEW_MARKER) || body.includes(FORCE_CAP_MARKER)) &&
       body.includes('- [x] Force review');
@@ -194,10 +195,8 @@ async function run(): Promise<void> {
 
     case 'issue_comment': {
       const commentBody = github.context.payload.comment?.body ?? '';
-      const dispatchAuthor = github.context.payload.comment?.user?.login as string | undefined;
-      const isDispatchBotComment = dispatchAuthor === BOT_LOGIN || dispatchAuthor === ACTIONS_BOT_LOGIN;
-      const forceReviewTickbox = action === 'edited' && isDispatchBotComment && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
-      const forceCapTickbox = action === 'edited' && isDispatchBotComment && commentBody.includes(FORCE_CAP_MARKER) && commentBody.includes('- [x] Force review');
+      const forceReviewTickbox = action === 'edited' && isBotComment && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
+      const forceCapTickbox = action === 'edited' && isBotComment && commentBody.includes(FORCE_CAP_MARKER) && commentBody.includes('- [x] Force review');
       if (forceCapTickbox && github.context.payload.issue?.pull_request) {
         await handleCommentTrigger(true, true);
       } else if (forceReviewTickbox && github.context.payload.issue?.pull_request) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ import {
   reactToIssueComment,
   fetchLinkedIssues,
   BOT_LOGIN,
-  ACTIONS_BOT_LOGIN,
   BOT_MARKER as PROGRESS_MARKER,
   FORCE_REVIEW_MARKER,
   FORCE_CAP_MARKER,
@@ -121,7 +120,7 @@ async function run(): Promise<void> {
   }
 
   const commentAuthorLogin = github.context.payload.comment?.user?.login as string | undefined;
-  const isBotComment = commentAuthorLogin === BOT_LOGIN || commentAuthorLogin === ACTIONS_BOT_LOGIN;
+  const isBotComment = commentAuthorLogin === BOT_LOGIN;
 
   // Event filtering — exit immediately for irrelevant events.
   // Tested via integration (live PR reviews) since it depends on GitHub Actions context.

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   BOT_LOGIN,
   BOT_MARKER as PROGRESS_MARKER,
   FORCE_REVIEW_MARKER,
+  FORCE_CAP_MARKER,
   MANKI_VERSION,
   isReviewInProgress,
   isApprovedOnCommit,
@@ -131,9 +132,10 @@ async function run(): Promise<void> {
       return;
     }
     const body = github.context.payload.comment?.body ?? '';
-    const isForceReview = action === 'edited' &&
-      body.includes(FORCE_REVIEW_MARKER) && body.includes('- [x] Force review');
-    if (!isForceReview && !hasBotMention(body) && !isReviewRequest(body)) {
+    const isForceReviewChecked = action === 'edited' &&
+      (body.includes(FORCE_REVIEW_MARKER) || body.includes(FORCE_CAP_MARKER)) &&
+      body.includes('- [x] Force review');
+    if (!isForceReviewChecked && !hasBotMention(body) && !isReviewRequest(body)) {
       core.info('Comment does not mention Manki — ignoring');
       return;
     }
@@ -189,11 +191,14 @@ async function run(): Promise<void> {
 
     case 'issue_comment': {
       const commentBody = github.context.payload.comment?.body ?? '';
-      const forceReviewChecked = action === 'edited' && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
-      if (forceReviewChecked && github.context.payload.issue?.pull_request) {
-        await handleCommentTrigger(true);
+      const forceReviewTickbox = action === 'edited' && commentBody.includes(FORCE_REVIEW_MARKER) && commentBody.includes('- [x] Force review');
+      const forceCapTickbox = action === 'edited' && commentBody.includes(FORCE_CAP_MARKER) && commentBody.includes('- [x] Force review');
+      if (forceCapTickbox && github.context.payload.issue?.pull_request) {
+        await handleCommentTrigger(true, true);
+      } else if (forceReviewTickbox && github.context.payload.issue?.pull_request) {
+        await handleCommentTrigger(true, false);
       } else if (isReviewRequest(commentBody) && github.context.payload.issue?.pull_request) {
-        await handleCommentTrigger();
+        await handleCommentTrigger(true, true);
       } else if (isBotMentionNonReview(commentBody) && github.context.payload.issue?.pull_request) {
         await handleInteraction();
       } else if (isBotMentionNonReview(commentBody) && !github.context.payload.issue?.pull_request) {
@@ -281,7 +286,7 @@ async function handlePullRequest(): Promise<void> {
   await runFullReview(owner, repo, prNumber, commitSha, pr.base.ref, prContext, pr.user?.login);
 }
 
-async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
+async function handleCommentTrigger(forceReview?: boolean, skipCap?: boolean): Promise<void> {
   const payload = github.context.payload;
 
   if (!payload.issue?.pull_request) {
@@ -339,7 +344,7 @@ async function handleCommentTrigger(forceReview?: boolean): Promise<void> {
     baseBranch: pr.base.ref,
   };
 
-  await runFullReview(owner, repo, prNumber, pr.head.sha, pr.base.ref, prContext, pr.user?.login, forceReview);
+  await runFullReview(owner, repo, prNumber, pr.head.sha, pr.base.ref, prContext, pr.user?.login, forceReview, skipCap);
 }
 
 function reconcileDashboardAgents(dashboard: DashboardData, names: string[]): void {
@@ -366,6 +371,7 @@ async function runFullReview(
   prContext?: PrContext,
   prAuthorLogin?: string,
   forceReview?: boolean,
+  skipCap?: boolean,
 ): Promise<void> {
   core.info(`Starting review for ${owner}/${repo}#${prNumber}`);
 
@@ -548,7 +554,7 @@ async function runFullReview(
     if (
       maxAutoRounds > 0 &&
       priorRoundCount >= maxAutoRounds &&
-      !forceReview
+      !skipCap
     ) {
       core.info(`Round cap reached (${priorRoundCount} prior rounds >= max ${maxAutoRounds}) — skipping auto review`);
       try {
@@ -559,11 +565,11 @@ async function runFullReview(
       try {
         const body = [
           PROGRESS_MARKER,
-          `Manki has completed ${priorRoundCount}/${maxAutoRounds} review rounds on this PR. Automatic review is paused. Force another round:`,
+          `Manki has completed ${priorRoundCount}/${maxAutoRounds} review rounds on this PR. Automatic review is paused. Tick the box to force another round, or comment \`@manki review\`:`,
           '',
           '- [ ] Force review',
           '',
-          FORCE_REVIEW_MARKER,
+          FORCE_CAP_MARKER,
         ].join('\n');
         await octokit.rest.issues.createComment({
           owner,


### PR DESCRIPTION
## Summary
- Round-cap notice now offers a `Force review` tickbox (matches in-progress notice UX).
- Split `forceReview` (bypass in-progress) from `skipCap` (bypass cap).
- In-progress tickbox no longer silently bypasses the cap.
- `@manki review` comment continues to bypass both.

## Verification
- All existing tests pass; new tests cover the split behavior.
- `npm run lint` / `typecheck` clean.

Closes #691