### PR TITLE
docs: stamp v5.0.0 release date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Manki will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - unreleased
+## [5.0.0] - 2026-05-20
 
 ### Added
 


### PR DESCRIPTION
Trivial follow-up to the v5.0.0 release ([tag](https://github.com/manki-review/manki/releases/tag/v5.0.0)). The CHANGELOG entry still said \`unreleased\`; replaces it with the actual release date.