### PR TITLE
chore: prepare v5.0.1 release (action.yml description + CHANGELOG stamp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to Manki will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - unreleased
+## [5.0.1] - 2026-05-20
+
+### Fixed
+
+- `action.yml` description shortened to fit GitHub Marketplace's 125-character limit so the action can be published / re-published to the Marketplace. No runtime behavior change.
+
+### Docs
+
+- CHANGELOG entry for `v5.0.0` stamped with its actual release date (was `unreleased`).
+
+## [5.0.0] - 2026-05-20
 
 ### Added
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Manki Review'
-description: 'Multi-agent AI code review for GitHub — a planner picks the team, agents review in parallel, dedup removes repeats, and a judge filters the noise.'
+description: 'Multi-agent AI code review for GitHub. Planner picks the team, agents review in parallel, judge filters the noise.'
 author: 'xdustinface'
 
 inputs:


### PR DESCRIPTION
## Summary

Tiny patch bundle so we can publish a clean v5.0.1 to the GitHub Marketplace.

1. **`action.yml` description shortened** from 153 to 114 chars (under the Marketplace 125-char limit). Same meaning, just less prose. Required because trying to Marketplace-publish v5.0.0 fails with "Description must be less than 125 characters."
2. **CHANGELOG entry for v5.0.0 stamped with its actual release date** (was `unreleased`). v5.0.0 was tagged 2026-05-20T06:06:22Z.
3. **New v5.0.1 CHANGELOG entry** documenting these two fixes.

No runtime behavior change. Once merged, will tag `v5.0.1` and publish to Marketplace.