### PR TITLE
fix: trigger review on `ready_for_review` event

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -2,7 +2,7 @@ name: Manki
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:

--- a/SETUP.md
+++ b/SETUP.md
@@ -211,7 +211,7 @@ name: Manki
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:
@@ -347,6 +347,7 @@ You can also forward `severity_counts` or `findings_json` to a metrics sink (Sla
 | Event | Purpose |
 |-------|---------|
 | `pull_request: [opened, synchronize]` | Auto-review on PR open and new pushes |
+| `pull_request: [ready_for_review]` | Auto-review when a draft PR is marked ready (head SHA unchanged, so the planner sees the same diff a `synchronize` would have produced) |
 | `issue_comment: [created, edited]` | `/manki` commands on PRs and issues (review, explain, triage, etc.) |
 | `pull_request_review_comment: [created]` | Replies to review comment threads |
 | `pull_request_review: [submitted, dismissed]` | Auto-approve check when reviews change state |

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:


### PR DESCRIPTION
## Summary

When a draft PR is marked ready for review, neither `opened` nor `synchronize` fires (head SHA unchanged, PR already open), so Manki does not run until the author pushes or posts `@manki review`. Adding the event to the workflow trigger list restores the expected first-review-on-undraft behavior.

- `.github/workflows/manki.yml` adds `ready_for_review` to `pull_request.types` for the self-test workflow
- `SETUP.md` mirrors the change in the consumer example workflow and adds a row to the event-triggers table explaining what the new event does
- `docs/index.html` mirrors the change in the landing-page quickstart snippet so the copy-paste install does not drift

Closes #717

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)