### PR TITLE
fix: post fresh skip-ack instead of editing the prior one

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -751,6 +751,7 @@ describe('handlePullRequest', () => {
     await handlePullRequest();
 
     expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledTimes(2);
     const skipCalls = mockOctokitInstance.rest.issues.createComment.mock.calls.filter(
       (c: [{ body: string }]) => c[0].body.includes('Review skipped'),
     );
@@ -861,6 +862,7 @@ describe('handleCommentTrigger', () => {
     await handleCommentTrigger();
 
     expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledTimes(2);
     const skipCalls = mockOctokitInstance.rest.issues.createComment.mock.calls.filter(
       (c: [{ body: string }]) => c[0].body.includes('Review skipped'),
     );
@@ -890,6 +892,7 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
       expect.stringContaining('Failed to post review-skipped comment'),
     );
+    expect(mockOctokitInstance.rest.issues.createComment).toHaveBeenCalledTimes(1);
     expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
     expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -727,40 +727,38 @@ describe('handlePullRequest', () => {
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
   });
 
-  it('updates existing skip comment instead of creating a duplicate', async () => {
-    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    mockListComments.mockResolvedValueOnce({
-      data: [
-        {
-          id: 77,
-          body: '<!-- manki-bot -->\n**Review skipped** — a review is currently in progress.',
-          user: { login: 'manki-review[bot]', type: 'Bot' },
-        },
-      ],
-    });
+  it('always posts a fresh skip comment, never edits an existing one', async () => {
+    jest.mocked(ghUtils.isReviewInProgress)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
 
-    setContext({
-      eventName: 'pull_request',
-      payload: {
-        action: 'opened',
-        sender: { login: 'user' },
-        pull_request: {
-          number: 1,
-          head: { sha: 'abc' },
-          base: { ref: 'main' },
-          title: 'Test PR',
-          body: '',
-          draft: false,
-        },
+    const prPayload = {
+      action: 'opened',
+      sender: { login: 'user' },
+      pull_request: {
+        number: 1,
+        head: { sha: 'abc' },
+        base: { ref: 'main' },
+        title: 'Test PR',
+        body: '',
+        draft: false,
       },
-    });
+    };
 
+    setContext({ eventName: 'pull_request', payload: prPayload });
+    await handlePullRequest();
+    setContext({ eventName: 'pull_request', payload: prPayload });
     await handlePullRequest();
 
-    expect(mockOctokitInstance.rest.issues.updateComment).toHaveBeenCalledWith(
-      expect.objectContaining({ comment_id: 77, body: expect.stringContaining('Review skipped') }),
+    expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
+    const skipCalls = mockOctokitInstance.rest.issues.createComment.mock.calls.filter(
+      (c: [{ body: string }]) => c[0].body.includes('Review skipped'),
     );
-    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalled();
+    expect(skipCalls).toHaveLength(2);
+    for (const call of skipCalls) {
+      expect(call[0].body).toContain(FORCE_REVIEW_MARKER);
+      expect(call[0].body).toContain('- [ ] Force review');
+    }
     expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.isApprovedOnCommit)).not.toHaveBeenCalled();
   });
@@ -816,7 +814,6 @@ describe('handleCommentTrigger', () => {
 
   it('posts skip comment and returns early when review is already in progress', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    mockListComments.mockResolvedValueOnce({ data: [] });
 
     setContext({
       eventName: 'issue_comment',
@@ -847,41 +844,37 @@ describe('handleCommentTrigger', () => {
     expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();
   });
 
-  it('updates existing skip comment instead of creating a duplicate', async () => {
-    jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    mockListComments.mockResolvedValueOnce({
-      data: [
-        {
-          id: 99,
-          body: `${ghUtils.BOT_MARKER}\n**Review skipped** — a review is currently in progress.`,
-          user: { login: ghUtils.BOT_LOGIN, type: 'Bot' },
-        },
-      ],
-    });
+  it('always posts a fresh skip comment, never edits an existing one', async () => {
+    jest.mocked(ghUtils.isReviewInProgress)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
 
-    setContext({
-      eventName: 'issue_comment',
-      payload: {
-        action: 'created',
-        issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
-        comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
-      },
-    });
+    const payload = {
+      action: 'created',
+      issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' } },
+      comment: { id: 42, body: '@manki review', author_association: 'COLLABORATOR' },
+    };
 
+    setContext({ eventName: 'issue_comment', payload });
+    await handleCommentTrigger();
+    setContext({ eventName: 'issue_comment', payload });
     await handleCommentTrigger();
 
-    expect(mockOctokitInstance.rest.issues.updateComment).toHaveBeenCalledWith(
-      expect.objectContaining({ comment_id: 99, body: expect.stringContaining('Review skipped') }),
+    expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
+    const skipCalls = mockOctokitInstance.rest.issues.createComment.mock.calls.filter(
+      (c: [{ body: string }]) => c[0].body.includes('Review skipped'),
     );
-    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalledWith(
-      expect.objectContaining({ body: expect.stringContaining('Review skipped') }),
-    );
+    expect(skipCalls).toHaveLength(2);
+    for (const call of skipCalls) {
+      expect(call[0].body).toContain(FORCE_REVIEW_MARKER);
+      expect(call[0].body).toContain('- [ ] Force review');
+    }
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
   });
 
   it('swallows errors from skip-comment helpers and emits a warning', async () => {
     jest.mocked(ghUtils.isReviewInProgress).mockResolvedValueOnce(true);
-    mockListComments.mockRejectedValueOnce(new Error('boom'));
+    mockOctokitInstance.rest.issues.createComment.mockRejectedValueOnce(new Error('boom'));
 
     setContext({
       eventName: 'issue_comment',
@@ -897,7 +890,6 @@ describe('handleCommentTrigger', () => {
     expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
       expect.stringContaining('Failed to post review-skipped comment'),
     );
-    expect(mockOctokitInstance.rest.issues.createComment).not.toHaveBeenCalled();
     expect(mockOctokitInstance.rest.issues.updateComment).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
     expect(mockOctokitInstance.rest.pulls.get).not.toHaveBeenCalled();

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,20 +234,11 @@ async function postReviewSkippedComment(
       '',
       FORCE_REVIEW_MARKER,
     ].join('\n');
-    // Update an existing skip comment instead of creating a duplicate
-    const { data: comments } = await octokit.rest.issues.listComments({
-      owner, repo, issue_number: prNumber, per_page: 100, direction: 'desc',
-    });
-    const existing = comments.find(c =>
-      c.user?.login === BOT_LOGIN &&
-      c.user?.type === 'Bot' &&
-      c.body?.includes(PROGRESS_MARKER) && c.body?.includes('Review skipped'),
-    );
-    if (existing) {
-      await octokit.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-    } else {
-      await octokit.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
-    }
+    // Always create a fresh comment. Editing an older skip-ack in place is
+    // silent on GitHub (no notification, original timeline position), so the
+    // user perceives no response. Each fresh comment carries its own Force
+    // review checkbox.
+    await octokit.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
   } catch (error) {
     core.warning(`Failed to post review-skipped comment: ${error instanceof Error ? error.message : error}`);
   }


### PR DESCRIPTION
## Summary

`@manki review` on a PR with a review in progress used to scan recent issue comments for an existing skip-ack and edit it in place via `updateComment`. GitHub does not notify on edits and the comment stays at its original chronological position, so the user perceived no response and assumed Manki ignored the request. Observed on [manki-review/manki#658](https://github.com/manki-review/manki/pull/658).

- `postReviewSkippedComment` now calls `createComment` unconditionally. Every skip-ack lands as a fresh comment at the bottom of the timeline.
- Removed the `listComments` + marker-search branch.
- Each fresh comment carries its own working Force-review checkbox (the existing checkbox-detection path already keys on `payload.comment.id`, so no downstream change was needed).
- Tests replace the old "edits the prior skip comment" assertions with "always posts a fresh comment, never edits an existing one" for both the `pull_request` and `issue_comment` paths.

Closes #664

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)