### PR TITLE
fix: source review-summary timings from agents on planner fallback

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2185,8 +2185,8 @@ describe('buildDashboard', () => {
     expect(md).toContain(`${INDENT}✅ Testing & Coverage — 4 (36s)`);
     expect(md).toContain(`${INDENT}✅ Performance & Efficiency — 2 (39s)`);
     expect(md).not.toContain('0 (0ms)');
-    const perTeamSum = 4 + 3 + 5 + 4 + 2;
-    expect(perTeamSum).toBe(data.rawFindingCount);
+    const renderedCounts = [4, 3, 5, 4, 2];
+    expect(renderedCounts.reduce((a, b) => a + b, 0)).toBe(data.rawFindingCount!);
   });
 
   it('renders heuristic-fallback marker under the planner header when set', () => {
@@ -2197,7 +2197,11 @@ describe('buildDashboard', () => {
       plannerDurationMs: 60000,
     };
     const md = buildDashboard(data);
-    expect(md).toContain(`${INDENT}_(planner heuristic fallback used)_`);
+    const plannerIdx = md.indexOf('**Planner**');
+    const reviewIdx = md.indexOf('**Review**');
+    const markerIdx = md.indexOf(`${INDENT}_(planner heuristic fallback used)_`);
+    expect(markerIdx).toBeGreaterThan(plannerIdx);
+    expect(markerIdx).toBeLessThan(reviewIdx);
   });
 
   it('omits heuristic-fallback marker when not set', () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2163,6 +2163,53 @@ describe('buildDashboard', () => {
     expect(md).not.toContain('**Planner** (');
   });
 
+  it('renders per-team counts and durations from agentProgress when planner metadata is empty (heuristic-fallback path)', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 600, agentCount: 5,
+      rawFindingCount: 18, keptCount: 12, droppedCount: 6,
+      heuristicFallback: true,
+      plannerDurationMs: 60000,
+      agentProgress: [
+        { name: 'Security & Safety', status: 'done', findingCount: 4, durationMs: 41000 },
+        { name: 'Architecture & Design', status: 'done', findingCount: 3, durationMs: 38000 },
+        { name: 'Correctness & Logic', status: 'done', findingCount: 5, durationMs: 45000 },
+        { name: 'Testing & Coverage', status: 'done', findingCount: 4, durationMs: 36000 },
+        { name: 'Performance & Efficiency', status: 'done', findingCount: 2, durationMs: 39000 },
+      ],
+    };
+    const md = buildDashboard(data);
+    expect(md).toContain('**Review** — 18 findings');
+    expect(md).toContain(`${INDENT}✅ Security & Safety — 4 (41s)`);
+    expect(md).toContain(`${INDENT}✅ Architecture & Design — 3 (38s)`);
+    expect(md).toContain(`${INDENT}✅ Correctness & Logic — 5 (45s)`);
+    expect(md).toContain(`${INDENT}✅ Testing & Coverage — 4 (36s)`);
+    expect(md).toContain(`${INDENT}✅ Performance & Efficiency — 2 (39s)`);
+    expect(md).not.toContain('0 (0ms)');
+    const perTeamSum = 4 + 3 + 5 + 4 + 2;
+    expect(perTeamSum).toBe(data.rawFindingCount);
+  });
+
+  it('renders heuristic-fallback marker under the planner header when set', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 200, agentCount: 5,
+      rawFindingCount: 0, keptCount: 0, droppedCount: 0,
+      heuristicFallback: true,
+      plannerDurationMs: 60000,
+    };
+    const md = buildDashboard(data);
+    expect(md).toContain(`${INDENT}_(planner heuristic fallback used)_`);
+  });
+
+  it('omits heuristic-fallback marker when not set', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 200, agentCount: 5,
+      rawFindingCount: 0, keptCount: 0, droppedCount: 0,
+      plannerDurationMs: 850,
+    };
+    const md = buildDashboard(data);
+    expect(md).not.toContain('planner heuristic fallback used');
+  });
+
   it('renders judge duration in complete phase', () => {
     const data: DashboardData = {
       phase: 'complete', lineCount: 500, agentCount: 7,

--- a/src/github.ts
+++ b/src/github.ts
@@ -307,6 +307,9 @@ export function buildDashboard(data: DashboardData): string {
     plannerLines.push(`**Planner**${plannerDur}`);
     plannerLines.push(`${INDENT}${data.lineCount} lines · ${data.agentCount} agents`);
   }
+  if (data.heuristicFallback) {
+    plannerLines.push(`${INDENT}_(planner heuristic fallback used)_`);
+  }
   sections.push(plannerLines.join('\n'));
 
   const reviewLines: string[] = [];

--- a/src/github.ts
+++ b/src/github.ts
@@ -306,9 +306,9 @@ export function buildDashboard(data: DashboardData): string {
     const plannerDur = data.plannerDurationMs != null ? ` (${formatDuration(data.plannerDurationMs)})` : '';
     plannerLines.push(`**Planner**${plannerDur}`);
     plannerLines.push(`${INDENT}${data.lineCount} lines · ${data.agentCount} agents`);
-  }
-  if (data.heuristicFallback) {
-    plannerLines.push(`${INDENT}_(planner heuristic fallback used)_`);
+    if (data.heuristicFallback) {
+      plannerLines.push(`${INDENT}_(planner heuristic fallback used)_`);
+    }
   }
   sections.push(plannerLines.join('\n'));
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3058,7 +3058,7 @@ describe('runFullReview orchestration', () => {
           onProgress({
             phase: 'planning',
             rawFindingCount: 0,
-            plannerResult: { teamSize: 2, reviewerEffort: 'medium', judgeEffort: 'low', prType: 'feature' },
+            plannerResult: { teamSize: 2, reviewerEffort: 'medium', judgeEffort: 'low', prType: 'feat' },
             plannerDurationMs: 400,
           });
         }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2937,53 +2937,56 @@ describe('runFullReview orchestration', () => {
 
   it('seeds dashboard from heuristic-fallback planning progress event', async () => {
     jest.useFakeTimers();
-    const testFile = {
-      path: 'src/app.ts', changeType: 'modified' as const,
-      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
-    };
-    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
-    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
-      files: [testFile], totalAdditions: 10, totalDeletions: 5,
-    });
-    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    try {
+      const testFile = {
+        path: 'src/app.ts', changeType: 'modified' as const,
+        hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+      };
+      jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [testFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
 
-    const fallbackAgents = ['Security & Safety', 'Correctness & Logic', 'general'];
+      const fallbackAgents = ['Security & Safety', 'Correctness & Logic', 'general'];
 
-    jest.mocked(reviewModule.runReview).mockImplementation(
-      async (_clients, _config, _diff, _rawDiff, _repoContext, _memory, _fileContents, _prContext, _linkedIssues, onProgress) => {
-        if (onProgress) {
-          onProgress({
-            phase: 'planning',
-            rawFindingCount: 0,
-            heuristicFallback: true,
-            teamAgentNames: fallbackAgents,
-            plannerDurationMs: 250,
-          });
-        }
-        jest.advanceTimersByTime(600);
-        await Promise.resolve();
-        return {
-          verdict: 'APPROVE', summary: 'ok', findings: [],
-          highlights: [], reviewComplete: true,
-          agentNames: fallbackAgents,
-        };
-      },
-    );
+      jest.mocked(reviewModule.runReview).mockImplementation(
+        async (_clients, _config, _diff, _rawDiff, _repoContext, _memory, _fileContents, _prContext, _linkedIssues, onProgress) => {
+          if (onProgress) {
+            onProgress({
+              phase: 'planning',
+              rawFindingCount: 0,
+              heuristicFallback: true,
+              teamAgentNames: fallbackAgents,
+              plannerDurationMs: 250,
+            });
+          }
+          jest.advanceTimersByTime(600);
+          await Promise.resolve();
+          return {
+            verdict: 'APPROVE', summary: 'ok', findings: [],
+            highlights: [], reviewComplete: true,
+            agentNames: fallbackAgents,
+          };
+        },
+      );
 
-    await callRunFullReview();
-    jest.useRealTimers();
+      await callRunFullReview();
 
-    const dashboardCalls = jest.mocked(ghUtils.updateProgressDashboard).mock.calls;
-    expect(dashboardCalls.length).toBeGreaterThanOrEqual(1);
+      const dashboardCalls = jest.mocked(ghUtils.updateProgressDashboard).mock.calls;
+      expect(dashboardCalls.length).toBeGreaterThanOrEqual(1);
 
-    const firstDashboard = dashboardCalls[0][4];
-    expect(firstDashboard.agentCount).toBe(3);
-    expect(firstDashboard.agentProgress).toEqual(
-      fallbackAgents.map(name => ({ name, status: 'reviewing' })),
-    );
-    expect(firstDashboard.plannerDurationMs).toBe(250);
-    expect(firstDashboard.heuristicFallback).toBe(true);
-    expect(firstDashboard.phase).toBe('started');
+      const firstDashboard = dashboardCalls[0][4];
+      expect(firstDashboard.agentCount).toBe(3);
+      expect(firstDashboard.agentProgress).toEqual(
+        fallbackAgents.map(name => ({ name, status: 'reviewing' })),
+      );
+      expect(firstDashboard.plannerDurationMs).toBe(250);
+      expect(firstDashboard.heuristicFallback).toBe(true);
+      expect(firstDashboard.phase).toBe('started');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('sets heuristicFallback and phase on dashboard when judging follows heuristic-fallback planning', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3050,7 +3050,7 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
 
     jest.mocked(reviewModule.selectTeam).mockReturnValue({
-      level: 'standard' as 'small',
+      level: 'small',
       agents: [{ name: 'general', focus: '' }, { name: 'Security & Safety', focus: '' }],
       lineCount: 0,
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2986,6 +2986,54 @@ describe('runFullReview orchestration', () => {
     expect(firstDashboard.phase).toBe('started');
   });
 
+  it('sets heuristicFallback and phase on dashboard when judging follows heuristic-fallback planning', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    const fallbackAgents = ['Security & Safety', 'Correctness & Logic', 'general'];
+    const snapshots: import('./types').DashboardData[] = [];
+    jest.mocked(ghUtils.updateProgressDashboard).mockImplementation(
+      async (_octokit, _owner, _repo, _id, dashboard) => {
+        snapshots.push({ ...dashboard });
+      },
+    );
+
+    jest.mocked(reviewModule.runReview).mockImplementation(
+      async (_clients, _config, _diff, _rawDiff, _repoContext, _memory, _fileContents, _prContext, _linkedIssues, onProgress) => {
+        if (onProgress) {
+          onProgress({
+            phase: 'planning',
+            rawFindingCount: 0,
+            heuristicFallback: true,
+            teamAgentNames: fallbackAgents,
+            plannerDurationMs: 150,
+          });
+          onProgress({ phase: 'judging', rawFindingCount: 0, judgeInputCount: 0 });
+        }
+        return {
+          verdict: 'APPROVE', summary: 'ok', findings: [],
+          highlights: [], reviewComplete: true,
+          agentNames: fallbackAgents,
+        };
+      },
+    );
+
+    await callRunFullReview();
+
+    const judgingSnapshot = snapshots.find(s => s.phase === 'reviewed');
+    expect(judgingSnapshot).toBeDefined();
+    expect(judgingSnapshot!.heuristicFallback).toBe(true);
+    expect(judgingSnapshot!.agentCount).toBe(3);
+    expect(judgingSnapshot!.plannerDurationMs).toBe(150);
+  });
+
   it('seeds dashboard from planner result (non-fallback planning progress event)', async () => {
     jest.useFakeTimers();
     const testFile = {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2935,6 +2935,117 @@ describe('runFullReview orchestration', () => {
     );
   });
 
+  it('seeds dashboard from heuristic-fallback planning progress event', async () => {
+    jest.useFakeTimers();
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    const fallbackAgents = ['Security & Safety', 'Correctness & Logic', 'general'];
+
+    jest.mocked(reviewModule.runReview).mockImplementation(
+      async (_clients, _config, _diff, _rawDiff, _repoContext, _memory, _fileContents, _prContext, _linkedIssues, onProgress) => {
+        if (onProgress) {
+          onProgress({
+            phase: 'planning',
+            rawFindingCount: 0,
+            heuristicFallback: true,
+            teamAgentNames: fallbackAgents,
+            plannerDurationMs: 250,
+          });
+        }
+        jest.advanceTimersByTime(600);
+        await Promise.resolve();
+        return {
+          verdict: 'APPROVE', summary: 'ok', findings: [],
+          highlights: [], reviewComplete: true,
+          agentNames: fallbackAgents,
+        };
+      },
+    );
+
+    await callRunFullReview();
+    jest.useRealTimers();
+
+    const dashboardCalls = jest.mocked(ghUtils.updateProgressDashboard).mock.calls;
+    expect(dashboardCalls.length).toBeGreaterThanOrEqual(1);
+
+    const firstDashboard = dashboardCalls[0][4];
+    expect(firstDashboard.agentCount).toBe(3);
+    expect(firstDashboard.agentProgress).toEqual(
+      fallbackAgents.map(name => ({ name, status: 'reviewing' })),
+    );
+    expect(firstDashboard.plannerDurationMs).toBe(250);
+    expect(firstDashboard.heuristicFallback).toBe(true);
+    expect(firstDashboard.phase).toBe('started');
+  });
+
+  it('seeds dashboard from planner result (non-fallback planning progress event)', async () => {
+    jest.useFakeTimers();
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    jest.mocked(reviewModule.selectTeam).mockReturnValue({
+      level: 'standard' as 'small',
+      agents: [{ name: 'general', focus: '' }, { name: 'Security & Safety', focus: '' }],
+      lineCount: 0,
+    });
+
+    jest.mocked(reviewModule.runReview).mockImplementation(
+      async (_clients, _config, _diff, _rawDiff, _repoContext, _memory, _fileContents, _prContext, _linkedIssues, onProgress) => {
+        if (onProgress) {
+          onProgress({
+            phase: 'planning',
+            rawFindingCount: 0,
+            plannerResult: { teamSize: 2, reviewerEffort: 'medium', judgeEffort: 'low', prType: 'feature' },
+            plannerDurationMs: 400,
+          });
+        }
+        jest.advanceTimersByTime(600);
+        await Promise.resolve();
+        return {
+          verdict: 'APPROVE', summary: 'ok', findings: [],
+          highlights: [], reviewComplete: true,
+          agentNames: ['general', 'Security & Safety'],
+        };
+      },
+    );
+
+    await callRunFullReview();
+    jest.useRealTimers();
+
+    const dashboardCalls = jest.mocked(ghUtils.updateProgressDashboard).mock.calls;
+    expect(dashboardCalls.length).toBeGreaterThanOrEqual(1);
+
+    const firstDashboard = dashboardCalls[0][4];
+    expect(firstDashboard.agentCount).toBe(2);
+    expect(firstDashboard.agentProgress).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'general', status: 'reviewing' }),
+        expect.objectContaining({ name: 'Security & Safety', status: 'reviewing' }),
+      ]),
+    );
+    expect(firstDashboard.plannerDurationMs).toBe(400);
+    expect(firstDashboard.heuristicFallback).toBeFalsy();
+    expect(firstDashboard.phase).toBe('started');
+    expect(firstDashboard.plannerInfo).toEqual(
+      expect.objectContaining({ teamSize: 2, reviewerEffort: 'medium' }),
+    );
+  });
+
   it('flushes dashboard immediately on judging progress', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -737,6 +737,13 @@ async function runFullReview(
             dashboard.plannerDurationMs = progress.plannerDurationMs;
             dashboard.phase = 'started';
             scheduleDashboardFlush();
+          } else if (progress.heuristicFallback && progress.teamAgentNames) {
+            dashboard.agentCount = progress.teamAgentNames.length;
+            dashboard.agentProgress = progress.teamAgentNames.map(name => ({ name, status: 'reviewing' as const }));
+            dashboard.plannerDurationMs = progress.plannerDurationMs;
+            dashboard.heuristicFallback = true;
+            dashboard.phase = 'started';
+            scheduleDashboardFlush();
           }
         } else if (progress.phase === 'agent-complete') {
           if (dashboard.agentProgress && progress.agentName) {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3533,6 +3533,33 @@ describe('runReview', () => {
     expect(fallback!.plannerDurationMs).toBeGreaterThanOrEqual(0);
   });
 
+  it('emits heuristic-fallback planning event when planner is disabled', async () => {
+    const clients: ReviewClients = {
+      reviewer: {
+        sendMessage: jest.fn().mockResolvedValue({ content: '[]' }),
+      } as unknown as import('./providers').LLMClient,
+      judge: {
+        sendMessage: jest.fn(),
+      } as unknown as import('./providers').LLMClient,
+    };
+
+    const config = makeConfig({ review_level: 'medium' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const onProgress = jest.fn();
+    mockedRunJudgeAgent.mockResolvedValue({ findings: [], summary: 'ok' });
+
+    const result = await runReview(clients, config, diff, 'raw diff', 'repo context', undefined, undefined, undefined, undefined, onProgress);
+    expect(result.reviewComplete).toBe(true);
+
+    const planningCalls = onProgress.mock.calls
+      .map((c: [import('./review').ReviewProgress]) => c[0])
+      .filter(p => p.phase === 'planning');
+    const fallback = planningCalls.find(p => p.heuristicFallback);
+    expect(fallback).toBeDefined();
+    expect(fallback!.plannerResult).toBeUndefined();
+    expect(fallback!.teamAgentNames).toEqual(result.agentNames);
+  });
+
   it('warns when agent returns 0 findings with short duration', async () => {
     const clients = makeClients('[]');
     const config = makeConfig();

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3513,11 +3513,24 @@ describe('runReview', () => {
 
     const config = makeConfig({ review_level: 'auto' });
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const onProgress = jest.fn();
 
-    const result = await runReview(clients, config, diff, 'raw diff', 'repo context');
+    const result = await runReview(clients, config, diff, 'raw diff', 'repo context', undefined, undefined, undefined, undefined, onProgress);
     expect(result.reviewComplete).toBe(true);
     // Should gracefully fall back to heuristic
     expect(result.agentNames).toHaveLength(3);
+
+    // Heuristic-fallback path emits a `planning` event carrying the resolved
+    // team names so the dashboard can seed per-agent entries and later
+    // populate them with real findingCount/durationMs from agent-complete.
+    const planningCalls = onProgress.mock.calls
+      .map((c: [import('./review').ReviewProgress]) => c[0])
+      .filter(p => p.phase === 'planning');
+    const fallback = planningCalls.find(p => p.heuristicFallback);
+    expect(fallback).toBeDefined();
+    expect(fallback!.plannerResult).toBeUndefined();
+    expect(fallback!.teamAgentNames).toEqual(result.agentNames);
+    expect(fallback!.plannerDurationMs).toBeGreaterThanOrEqual(0);
   });
 
   it('warns when agent returns 0 findings with short duration', async () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3507,7 +3507,7 @@ describe('runReview', () => {
         sendMessage: jest.fn(),
       } as unknown as import('./providers').LLMClient,
       planner: {
-        sendMessage: jest.fn().mockRejectedValue(new Error('Planner API error')),
+        sendMessage: jest.fn().mockImplementation(() => new Promise((_, reject) => setTimeout(() => reject(new Error('Planner API error')), 1))),
       } as unknown as import('./providers').LLMClient,
     };
 
@@ -3530,7 +3530,7 @@ describe('runReview', () => {
     expect(fallback).toBeDefined();
     expect(fallback!.plannerResult).toBeUndefined();
     expect(fallback!.teamAgentNames).toEqual(result.agentNames);
-    expect(fallback!.plannerDurationMs).toBeGreaterThanOrEqual(0);
+    expect(fallback!.plannerDurationMs).toBeGreaterThan(0);
   });
 
   it('emits heuristic-fallback planning event when planner is disabled', async () => {

--- a/src/review.ts
+++ b/src/review.ts
@@ -737,6 +737,14 @@ export async function runReview(
     }
   } else {
     team = heuristicFallback(diff, config, priorRoundAgents);
+    if (onProgress) {
+      onProgress({
+        phase: 'planning',
+        rawFindingCount: 0,
+        teamAgentNames: team.agents.map(a => a.name),
+        heuristicFallback: true,
+      });
+    }
   }
 
   const memoryContext = memory ? buildMemoryContext(memory) : '';

--- a/src/review.ts
+++ b/src/review.ts
@@ -679,6 +679,20 @@ function applyEffortDowngrade(picks: AgentPick[], hints: PlannerRoundHint[]): vo
   }
 }
 
+function emitHeuristicFallbackPlanning(
+  onProgress: (progress: ReviewProgress) => void,
+  team: TeamRoster,
+  plannerDurationMs?: number,
+): void {
+  onProgress({
+    phase: 'planning',
+    rawFindingCount: 0,
+    teamAgentNames: team.agents.map(a => a.name),
+    heuristicFallback: true,
+    ...(plannerDurationMs !== undefined ? { plannerDurationMs } : {}),
+  });
+}
+
 export async function runReview(
   clients: ReviewClients,
   config: ReviewConfig,
@@ -726,24 +740,13 @@ export async function runReview(
     } else {
       team = heuristicFallback(diff, config, priorRoundAgents);
       if (onProgress) {
-        onProgress({
-          phase: 'planning',
-          rawFindingCount: 0,
-          plannerDurationMs,
-          teamAgentNames: team.agents.map(a => a.name),
-          heuristicFallback: true,
-        });
+        emitHeuristicFallbackPlanning(onProgress, team, plannerDurationMs);
       }
     }
   } else {
     team = heuristicFallback(diff, config, priorRoundAgents);
     if (onProgress) {
-      onProgress({
-        phase: 'planning',
-        rawFindingCount: 0,
-        teamAgentNames: team.agents.map(a => a.name),
-        heuristicFallback: true,
-      });
+      emitHeuristicFallbackPlanning(onProgress, team);
     }
   }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -351,7 +351,7 @@ export interface ReviewProgress {
   agentFindingCount?: number;
   agentDurationMs?: number;
   agentStatus?: 'success' | 'failure' | 'retrying';
-  rawFindingCount: number;
+  rawFindingCount?: number;
   judgeInputCount?: number;
   completedAgents?: number;
   totalAgents?: number;
@@ -686,7 +686,6 @@ function emitHeuristicFallbackPlanning(
 ): void {
   onProgress({
     phase: 'planning',
-    rawFindingCount: 0,
     teamAgentNames: team.agents.map(a => a.name),
     heuristicFallback: true,
     ...(plannerDurationMs !== undefined ? { plannerDurationMs } : {}),

--- a/src/review.ts
+++ b/src/review.ts
@@ -358,6 +358,10 @@ export interface ReviewProgress {
   plannerResult?: PlannerResult;
   plannerDurationMs?: number;
   retryCount?: number;
+  /** Names of agents resolved for this review. Emitted with a `planning` event on the heuristic-fallback path so the dashboard can seed per-agent entries even though no `plannerResult` is available. */
+  teamAgentNames?: string[];
+  /** True when team selection fell back to the heuristic because the planner failed or timed out. */
+  heuristicFallback?: boolean;
 }
 
 function buildPlannerSummary(diff: ParsedDiff, prContext?: PrContext): string {
@@ -721,6 +725,15 @@ export async function runReview(
       }
     } else {
       team = heuristicFallback(diff, config, priorRoundAgents);
+      if (onProgress) {
+        onProgress({
+          phase: 'planning',
+          rawFindingCount: 0,
+          plannerDurationMs,
+          teamAgentNames: team.agents.map(a => a.name),
+          heuristicFallback: true,
+        });
+      }
     }
   } else {
     team = heuristicFallback(diff, config, priorRoundAgents);

--- a/src/types.ts
+++ b/src/types.ts
@@ -406,6 +406,8 @@ export interface DashboardData {
   droppedSeverities?: Record<string, number>;
   plannerDurationMs?: number;
   judgeDurationMs?: number;
+  /** True when team selection fell back to the heuristic because the planner failed or timed out. Surfaces a one-line marker in the rendered summary so the broader team set is self-explanatory. */
+  heuristicFallback?: boolean;
 }
 
 export interface JudgeDecision {


### PR DESCRIPTION
## Summary

On the planner-fallback path, `runReview` returned `plannerResult = null` and skipped firing the `planning` `onProgress` event. The dashboard handler in `index.ts` was the only seeder of `dashboard.agentProgress` on the planner-enabled path, so `agentProgress` stayed `undefined`. Subsequent `agent-complete` callbacks looked up entries by name in `dashboard.agentProgress`, found `undefined`, and silently no-oped. After review, `reconcileDashboardAgents` materialised entries with default zero values from `result.agentNames` alone, yielding `Security & Safety — 0 (0ms)` etc. while `Review — N findings` came from the unrelated `rawFindingCount` source.

- `runReview` now fires a `planning` progress event after `heuristicFallback` runs, carrying `teamAgentNames` and `heuristicFallback: true` so the dashboard can seed per-agent entries from the resolved team
- The dashboard handler in `runFullReview` branches on `heuristicFallback`: seeds `agentProgress` from `teamAgentNames`, records `plannerDurationMs` (the planner-failure wall time), and sets `dashboard.heuristicFallback = true`
- `buildDashboard` emits a one-line `_(planner heuristic fallback used)_` marker under the Planner header when the flag is set, so the broader team set is self-explanatory in the rendered summary
- Three new tests cover: non-zero per-team counts/durations on the fallback path, marker present when the flag is set, marker absent when not

Closes #736

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)