### PR TITLE
fix: eagerly warm up Claude CLI to remove planner timeout race

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1617,6 +1617,53 @@ describe('runFullReview orchestration', () => {
     );
   }
 
+  describe('provider CLI warmup', () => {
+    const testFile = { path: 'src/app.ts', changeType: 'modified' as const, hunks: [] };
+    beforeEach(() => {
+      jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+        files: [testFile], totalAdditions: 10, totalDeletions: 5,
+      });
+      jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    });
+
+    it('warms up the provider CLI before runReview to avoid the planner-install race', async () => {
+      const warmupCLI = jest.fn().mockResolvedValue(undefined);
+      jest.mocked(createLLMClient).mockImplementation(() => ({
+        sendMessage: jest.fn(),
+        warmupCLI,
+      }));
+
+      await callRunFullReview();
+
+      expect(warmupCLI).toHaveBeenCalled();
+      const firstWarmupOrder = warmupCLI.mock.invocationCallOrder[0];
+      const runReviewOrder = jest.mocked(reviewModule.runReview).mock.invocationCallOrder[0];
+      expect(firstWarmupOrder).toBeLessThan(runReviewOrder);
+    });
+
+    it('tolerates providers that do not implement warmupCLI', async () => {
+      jest.mocked(createLLMClient).mockImplementation(() => ({
+        sendMessage: jest.fn(),
+      }));
+
+      await expect(callRunFullReview()).resolves.toBeUndefined();
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+
+    it('logs a warning but proceeds when warmupCLI rejects', async () => {
+      const warmupCLI = jest.fn().mockRejectedValue(new Error('npm offline'));
+      jest.mocked(createLLMClient).mockImplementation(() => ({
+        sendMessage: jest.fn(),
+        warmupCLI,
+      }));
+
+      await callRunFullReview();
+
+      expect(jest.mocked(core.warning)).toHaveBeenCalledWith(expect.stringContaining('Provider CLI warmup failed'));
+      expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+    });
+  });
+
   it('handles diff too large by posting warning review without running Claude', async () => {
     jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(true);
     jest.mocked(diffModule.parsePRDiff).mockReturnValue({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1690,6 +1690,10 @@ describe('runFullReview orchestration', () => {
     jest.mocked(diffModule.parsePRDiff).mockReturnValue({
       files: [], totalAdditions: 3000, totalDeletions: 3000,
     });
+    const warmupCLI = jest.fn().mockResolvedValue(undefined);
+    jest.mocked(createLLMClient).mockImplementation(() => ({
+      sendMessage: jest.fn(), warmupCLI,
+    }));
 
     await callRunFullReview();
 
@@ -1704,6 +1708,8 @@ describe('runFullReview orchestration', () => {
     );
     // Should NOT have called runReview (Claude)
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    // Warmup must be skipped on paths that never invoke an LLM.
+    expect(warmupCLI).not.toHaveBeenCalled();
   });
 
   it('dismisses previous reviews before posting diff-too-large warning', async () => {
@@ -1740,6 +1746,10 @@ describe('runFullReview orchestration', () => {
       totalAdditions: 10, totalDeletions: 5,
     });
     jest.mocked(diffModule.filterFiles).mockReturnValue([]);
+    const warmupCLI = jest.fn().mockResolvedValue(undefined);
+    jest.mocked(createLLMClient).mockImplementation(() => ({
+      sendMessage: jest.fn(), warmupCLI,
+    }));
 
     await callRunFullReview();
 
@@ -1752,6 +1762,8 @@ describe('runFullReview orchestration', () => {
       expect.anything(),
     );
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    // Warmup must be skipped on paths that never invoke an LLM.
+    expect(warmupCLI).not.toHaveBeenCalled();
   });
 
   it('skips auto_review disabled PR events and deletes progress comment', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1670,14 +1670,17 @@ describe('runFullReview orchestration', () => {
 
     it('logs a warning but proceeds when warmupCLI rejects', async () => {
       const warmupCLI = jest.fn().mockRejectedValue(new Error('npm offline'));
-      jest.mocked(createLLMClient).mockImplementation(() => ({
-        sendMessage: jest.fn(),
-        warmupCLI,
-      }));
+      class FakeProviderClient {
+        sendMessage = jest.fn();
+        warmupCLI = warmupCLI;
+      }
+      jest.mocked(createLLMClient).mockImplementation(() => new FakeProviderClient());
 
       await callRunFullReview();
 
-      expect(jest.mocked(core.warning)).toHaveBeenCalledWith(expect.stringContaining('Provider CLI warmup failed'));
+      expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
+        expect.stringContaining('Provider CLI warmup failed (FakeProviderClient): npm offline'),
+      );
       expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
     });
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,6 +55,7 @@ jest.mock('./auth', () => ({
 jest.mock('./providers', () => ({
   buildAuthForProvider: jest.requireActual('./providers').buildAuthForProvider,
   hasAnyProviderCredentials: jest.requireActual('./providers').hasAnyProviderCredentials,
+  sanitizeLogOutput: jest.requireActual('./providers').sanitizeLogOutput,
   createLLMClient: jest.fn().mockImplementation(() => ({ sendMessage: jest.fn() })),
   parseModelSpec: jest.fn().mockImplementation((m: string) => ({ provider: 'anthropic', model: m })),
 }));
@@ -1627,18 +1628,35 @@ describe('runFullReview orchestration', () => {
     });
 
     it('warms up the provider CLI before runReview to avoid the planner-install race', async () => {
-      const warmupCLI = jest.fn().mockResolvedValue(undefined);
-      jest.mocked(createLLMClient).mockImplementation(() => ({
-        sendMessage: jest.fn(),
-        warmupCLI,
-      }));
+      // Return a distinct client per call so the Set-based dedup in
+      // `runFullReview` keeps every role's warmup target, letting us assert
+      // that planner, reviewer, judge, and dedup were each warmed up.
+      const warmups: jest.Mock[] = [];
+      jest.mocked(createLLMClient).mockImplementation(() => {
+        const warmupCLI = jest.fn().mockResolvedValue(undefined);
+        warmups.push(warmupCLI);
+        return { sendMessage: jest.fn(), warmupCLI };
+      });
 
       await callRunFullReview();
 
-      expect(warmupCLI).toHaveBeenCalled();
-      const firstWarmupOrder = warmupCLI.mock.invocationCallOrder[0];
+      // Default config builds 4 distinct clients: reviewer, judge, planner, dedup.
+      expect(warmups).toHaveLength(4);
+      for (const w of warmups) expect(w).toHaveBeenCalledTimes(1);
+      const firstWarmupOrder = warmups[0].mock.invocationCallOrder[0];
       const runReviewOrder = jest.mocked(reviewModule.runReview).mock.invocationCallOrder[0];
       expect(firstWarmupOrder).toBeLessThan(runReviewOrder);
+    });
+
+    it('deduplicates warmup calls when role clients share an instance', async () => {
+      const warmupCLI = jest.fn().mockResolvedValue(undefined);
+      const sharedClient = { sendMessage: jest.fn(), warmupCLI };
+      jest.mocked(createLLMClient).mockImplementation(() => sharedClient);
+
+      await callRunFullReview();
+
+      // All four roles return the same instance, so warmup runs once total.
+      expect(warmupCLI).toHaveBeenCalledTimes(1);
     });
 
     it('tolerates providers that do not implement warmupCLI', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,17 +470,17 @@ async function runFullReview(
         (c): c is LLMClient => !!c,
       ),
     );
-    for (const c of warmupTargets) {
-      if (c.warmupCLI) {
-        try {
-          await c.warmupCLI();
-        } catch (error) {
-          core.warning(
-            sanitizeLogOutput(`Provider CLI warmup failed: ${error instanceof Error ? error.message : error}`),
-          );
-        }
-      }
-    }
+    await Promise.allSettled(
+      [...warmupTargets].map((c) =>
+        c.warmupCLI
+          ? c.warmupCLI().catch((error) =>
+              core.warning(
+                sanitizeLogOutput(`Provider CLI warmup failed: ${error instanceof Error ? error.message : error}`),
+              ),
+            )
+          : Promise.resolve(),
+      ),
+    );
 
     const rawDiff = await fetchPRDiff(octokit, owner, repo, prNumber);
     const diff = parsePRDiff(rawDiff);

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,7 +475,9 @@ async function runFullReview(
         c.warmupCLI
           ? c.warmupCLI().catch((error) =>
               core.warning(
-                sanitizeLogOutput(`Provider CLI warmup failed: ${error instanceof Error ? error.message : error}`),
+                sanitizeLogOutput(
+                  `Provider CLI warmup failed (${c.constructor.name}): ${error instanceof Error ? error.message : error}`,
+                ),
               ),
             )
           : Promise.resolve(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
 import { loadConfig, resolveModel } from './config';
-import { buildAuthForProvider, createLLMClient, hasAnyProviderCredentials, parseModelSpec } from './providers';
+import { buildAuthForProvider, createLLMClient, hasAnyProviderCredentials, parseModelSpec, sanitizeLogOutput } from './providers';
 import type { LLMClient, ProviderAuth, ProviderInputs } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
 import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
@@ -463,13 +463,21 @@ async function runFullReview(
     // fallback `npm install -g` inside `ensureCLI` takes around 30s on a
     // cold runner and would otherwise race the planner's own 30s timeout.
     // Warming up once here pays the cost before any per-call deadline runs.
-    const warmupTargets = [plannerClient, reviewerClient, judgeClient, dedupClient, ...perAgentClients.values()];
+    // Deduplicate by client instance so roles that share a client don't
+    // serialize redundant install retries on failure.
+    const warmupTargets = new Set<LLMClient>(
+      [plannerClient, reviewerClient, judgeClient, dedupClient, ...perAgentClients.values()].filter(
+        (c): c is LLMClient => !!c,
+      ),
+    );
     for (const c of warmupTargets) {
-      if (c?.warmupCLI) {
+      if (c.warmupCLI) {
         try {
           await c.warmupCLI();
         } catch (error) {
-          core.warning(`Provider CLI warmup failed: ${error instanceof Error ? error.message : error}`);
+          core.warning(
+            sanitizeLogOutput(`Provider CLI warmup failed: ${error instanceof Error ? error.message : error}`),
+          );
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -459,31 +459,6 @@ async function runFullReview(
       return;
     }
 
-    // Eagerly install any provider CLI before the planner timer starts. The
-    // fallback `npm install -g` inside `ensureCLI` takes around 30s on a
-    // cold runner and would otherwise race the planner's own 30s timeout.
-    // Warming up once here pays the cost before any per-call deadline runs.
-    // Deduplicate by client instance so roles that share a client don't
-    // serialize redundant install retries on failure.
-    const warmupTargets = new Set<LLMClient>(
-      [plannerClient, reviewerClient, judgeClient, dedupClient, ...perAgentClients.values()].filter(
-        (c): c is LLMClient => !!c,
-      ),
-    );
-    await Promise.allSettled(
-      [...warmupTargets].map((c) =>
-        c.warmupCLI
-          ? c.warmupCLI().catch((error) =>
-              core.warning(
-                sanitizeLogOutput(
-                  `Provider CLI warmup failed (${c.constructor.name}): ${error instanceof Error ? error.message : error}`,
-                ),
-              ),
-            )
-          : Promise.resolve(),
-      ),
-    );
-
     const rawDiff = await fetchPRDiff(octokit, owner, repo, prNumber);
     const diff = parsePRDiff(rawDiff);
     const parseEndTime = Date.now();
@@ -547,6 +522,33 @@ async function runFullReview(
       await updateProgressComment(octokit, owner, repo, progressCommentId, dashboard);
       return;
     }
+
+    // Eagerly install any provider CLI before the planner timer starts. The
+    // fallback `npm install -g` inside `ensureCLI` takes around 30s on a
+    // cold runner and would otherwise race the planner's own 30s timeout.
+    // Warming up once here pays the cost before any per-call deadline runs.
+    // Deduplicate by client instance so roles that share a client don't
+    // serialize redundant install retries on failure. Placed after the
+    // diff-size and empty-files guards so cold installs are skipped on paths
+    // that never invoke an LLM.
+    const warmupTargets = new Set<LLMClient>(
+      [plannerClient, reviewerClient, judgeClient, dedupClient, ...perAgentClients.values()].filter(
+        (c): c is LLMClient => !!c,
+      ),
+    );
+    await Promise.allSettled(
+      [...warmupTargets].map((c) =>
+        c.warmupCLI
+          ? c.warmupCLI().catch((error) =>
+              core.warning(
+                sanitizeLogOutput(
+                  `Provider CLI warmup failed (${c.constructor.name}): ${error instanceof Error ? error.message : error}`,
+                ),
+              ),
+            )
+          : Promise.resolve(),
+      ),
+    );
 
     let repoContext = await fetchRepoContext(octokit, owner, repo, baseRef);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -459,6 +459,21 @@ async function runFullReview(
       return;
     }
 
+    // Eagerly install any provider CLI before the planner timer starts. The
+    // fallback `npm install -g` inside `ensureCLI` takes around 30s on a
+    // cold runner and would otherwise race the planner's own 30s timeout.
+    // Warming up once here pays the cost before any per-call deadline runs.
+    const warmupTargets = [plannerClient, reviewerClient, judgeClient, dedupClient, ...perAgentClients.values()];
+    for (const c of warmupTargets) {
+      if (c?.warmupCLI) {
+        try {
+          await c.warmupCLI();
+        } catch (error) {
+          core.warning(`Provider CLI warmup failed: ${error instanceof Error ? error.message : error}`);
+        }
+      }
+    }
+
     const rawDiff = await fetchPRDiff(octokit, owner, repo, prNumber);
     const diff = parsePRDiff(rawDiff);
     const parseEndTime = Date.now();

--- a/src/providers/anthropic.test.ts
+++ b/src/providers/anthropic.test.ts
@@ -776,6 +776,46 @@ describe('ensureCLI — install path', () => {
   });
 });
 
+describe('warmupCLI', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockExecFileAsync.mockReset();
+    resetCLIInstallPromise();
+  });
+
+  it('invokes ensureCLI once for OAuth auth', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '/usr/bin/claude\n' });
+    const client = new AnthropicClient({ auth: { kind: 'oauth', token: 'token' }, model: 'claude-opus-4-6' });
+
+    await client.warmupCLI();
+    await client.warmupCLI();
+
+    // First call hits `which`; second call hits the cached path.
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileAsync).toHaveBeenCalledWith('which', ['claude']);
+  });
+
+  it('triggers npm install when CLI is missing', async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/claude\n' });
+    const client = new AnthropicClient({ auth: { kind: 'oauth', token: 'token' }, model: 'claude-opus-4-6' });
+
+    await client.warmupCLI();
+
+    expect(mockExecFileAsync).toHaveBeenNthCalledWith(2, 'npm', ['install', '-g', '@anthropic-ai/claude-code'], expect.any(Object));
+  });
+
+  it('is a no-op for API-key auth', async () => {
+    const client = new AnthropicClient({ auth: { kind: 'apiKey', key: 'sk-test' }, model: 'claude-opus-4-6' });
+
+    await client.warmupCLI();
+
+    expect(mockExecFileAsync).not.toHaveBeenCalled();
+  });
+});
+
 describe('sendViaOAuth — stale process detection', () => {
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/providers/anthropic.test.ts
+++ b/src/providers/anthropic.test.ts
@@ -814,6 +814,16 @@ describe('warmupCLI', () => {
 
     expect(mockExecFileAsync).not.toHaveBeenCalled();
   });
+
+  it('propagates ensureCLI errors when install fails', async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockRejectedValueOnce(new Error('still not found'));
+    const client = new AnthropicClient({ auth: { kind: 'oauth', token: 'token' }, model: 'claude-opus-4-6' });
+
+    await expect(client.warmupCLI()).rejects.toThrow('Failed to install Claude CLI');
+  });
 });
 
 describe('sendViaOAuth — stale process detection', () => {

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -69,6 +69,11 @@ export class AnthropicClient implements LLMClient {
     return this.sendViaAPI(systemPrompt, userMessage, options);
   }
 
+  async warmupCLI(): Promise<void> {
+    if (this.auth.kind !== 'oauth') return;
+    await this.ensureCLI();
+  }
+
   private async ensureCLI(): Promise<string> {
     if (this.cachedCLIPath) {
       return this.cachedCLIPath;

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -44,6 +44,11 @@ describe('GeminiClient', () => {
     const client = new GeminiClient({ auth: { kind: 'apiKey', key: 'key' }, model: 'gemini-3.1-flash-lite' });
     expect(client).toBeDefined();
   });
+
+  it('does not expose warmupCLI (planner does not run on this provider)', () => {
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+    expect((client as { warmupCLI?: unknown }).warmupCLI).toBeUndefined();
+  });
 });
 
 describe('geminiThinkingBudget', () => {

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -90,6 +90,11 @@ describe('OpenAIClient', () => {
     const client = new OpenAIClient({ auth: { kind: 'apiKey', key: 'sk-key' }, model: 'gpt-4o' });
     expect(client).toBeDefined();
   });
+
+  it('does not expose warmupCLI (planner does not run on this provider)', () => {
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
+    expect((client as { warmupCLI?: unknown }).warmupCLI).toBeUndefined();
+  });
 });
 
 describe('sendMessage (API path)', () => {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -10,6 +10,13 @@ export interface SendMessageOptions {
 
 export interface LLMClient {
   sendMessage(systemPrompt: string, userMessage: string, options?: SendMessageOptions): Promise<LLMResponse>;
+  /**
+   * Eagerly prepare any out-of-process resources (e.g. installing the Claude
+   * CLI on PATH) so the first `sendMessage` call doesn't race a 30s install
+   * against an upstream timeout. Optional; providers that don't shell out
+   * leave it undefined.
+   */
+  warmupCLI?(): Promise<void>;
 }
 
 export type AnthropicAuth =

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -4247,6 +4247,47 @@ describe('runPlanner', () => {
       jest.useRealTimers();
     }
   });
+
+  it('warns about SETUP.md ENOENT row on timeout', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    jest.useFakeTimers();
+    try {
+      const client = {
+        sendMessage: jest.fn().mockImplementation(() => new Promise(() => {})),
+      } as unknown as import('./providers').LLMClient;
+
+      const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+      const resultPromise = runPlanner(client, diff);
+
+      jest.advanceTimersByTime(PLANNER_TIMEOUT_MS);
+      await resultPromise;
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Planner timed out'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('spawn claude ENOENT'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SETUP.md'));
+    } finally {
+      jest.useRealTimers();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('preserves existing warning text for non-timeout planner failures', async () => {
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    try {
+      const client = {
+        sendMessage: jest.fn().mockResolvedValue({ content: 'not valid json at all' }),
+      } as unknown as import('./providers').LLMClient;
+
+      const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+      const result = await runPlanner(client, diff);
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/^Planner failed: /));
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('spawn claude ENOENT'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe('selectTeam with teamSizeOverride', () => {

--- a/src/review.ts
+++ b/src/review.ts
@@ -13,6 +13,13 @@ const DISMISSED_LINE_TOLERANCE = 5;
 
 export const PLANNER_TIMEOUT_MS = 30_000;
 
+class PlannerTimeoutError extends Error {
+  constructor() {
+    super('Planner timed out');
+    this.name = 'PlannerTimeoutError';
+  }
+}
+
 const SUSPICIOUS_FAST_THRESHOLD_MS = 15_000;
 
 // Standard reviewer pool used for teamSize >= 3. TRIVIAL_VERIFIER_AGENT is
@@ -533,7 +540,7 @@ export async function runPlanner(
 ): Promise<PlannerResult | null> {
   let timeoutId: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error('Planner timed out')), PLANNER_TIMEOUT_MS);
+    timeoutId = setTimeout(() => reject(new PlannerTimeoutError()), PLANNER_TIMEOUT_MS);
   });
 
   try {
@@ -590,8 +597,7 @@ export async function runPlanner(
     return { teamSize, reviewerEffort, judgeEffort, prType, agents: agents ?? undefined, language, context };
   } catch (error) {
     clearTimeout(timeoutId!);
-    const message = error instanceof Error ? error.message : String(error);
-    if (/Planner timed out/.test(message)) {
+    if (error instanceof PlannerTimeoutError) {
       core.warning(
         'Planner timed out, falling back to heuristic team selection. If your workflow does not pre-install the Claude Code CLI, see the "spawn claude ENOENT" row in SETUP.md.',
       );

--- a/src/review.ts
+++ b/src/review.ts
@@ -590,7 +590,14 @@ export async function runPlanner(
     return { teamSize, reviewerEffort, judgeEffort, prType, agents: agents ?? undefined, language, context };
   } catch (error) {
     clearTimeout(timeoutId!);
-    core.warning(`Planner failed: ${error} — falling back to heuristic team selection`);
+    const message = error instanceof Error ? error.message : String(error);
+    if (/Planner timed out/.test(message)) {
+      core.warning(
+        'Planner timed out, falling back to heuristic team selection. If your workflow does not pre-install the Claude Code CLI, see the "spawn claude ENOENT" row in SETUP.md.',
+      );
+    } else {
+      core.warning(`Planner failed: ${error} — falling back to heuristic team selection`);
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

When a consumer workflow does not pre-install `@anthropic-ai/claude-code`, the runtime fallback in `ensureCLI()` would install the CLI on first use, around 30s on `ubuntu-latest`. If the planner was the first call site, its 30s timeout would race the install and fall back to heuristic team selection with a degraded summary render (per-team timings as `0 (0ms)`, all 5 default teams). Warming up the CLI in the action's init phase removes the race entirely.

- New optional `LLMClient.warmupCLI?()` on the provider interface. `AnthropicClient` implements it (no-op for `apiKey` auth, calls existing `ensureCLI` for `oauth`). OpenAI and Gemini leave it undefined so the iteration short-circuits cheaply.
- `runFullReview` iterates all per-role clients (planner, reviewer, judge, dedup, per-agent) and awaits each `warmupCLI?.()` before the planner timer starts. Failures are warned but non-fatal.
- Planner-timeout warning now names the cause and points at the `SETUP.md` "spawn claude ENOENT" troubleshooting row. Other planner errors keep the existing message.
- 10 new tests across provider, review, and index layers.

Closes #735

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)