### PR TITLE
feat: add `noise_level` config plumbing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,5 +6,13 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     ignores: ['dist/', 'node_modules/', 'jest.config.js', '*.mjs'],
-  }
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+    },
+  },
 );

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -29,6 +29,7 @@ describe('config', () => {
       expect(typeof DEFAULT_CONFIG.memory.enabled).toBe('boolean');
       expect(typeof DEFAULT_CONFIG.memory.repo).toBe('string');
       expect(DEFAULT_CONFIG.nit_handling).toBe('issues');
+      expect(DEFAULT_CONFIG.noise_level).toBe('low');
       expect(DEFAULT_CONFIG.review_level).toBe('auto');
       expect(DEFAULT_CONFIG.review_thresholds).toEqual({ small: 200, medium: 1000 });
       expect(DEFAULT_CONFIG.review_passes).toBe(1);
@@ -378,6 +379,23 @@ models:
       const yaml = 'nit_handling: email';
       expect(() => loadConfigFromContent(yaml)).toThrow('Invalid config');
       expect(core.error).toHaveBeenCalledWith('`nit_handling` must be "issues" or "comments"');
+    });
+
+    it('accepts valid noise_level values', () => {
+      expect(loadConfigFromContent('noise_level: low').noise_level).toBe('low');
+      expect(loadConfigFromContent('noise_level: medium').noise_level).toBe('medium');
+      expect(loadConfigFromContent('noise_level: high').noise_level).toBe('high');
+    });
+
+    it('throws on invalid noise_level value', () => {
+      const yaml = 'noise_level: extreme';
+      expect(() => loadConfigFromContent(yaml)).toThrow('Invalid config');
+      expect(core.error).toHaveBeenCalledWith('`noise_level` must be one of: low, medium, high');
+    });
+
+    it('defaults noise_level to "low" when absent', () => {
+      expect(loadConfigFromContent('').noise_level).toBe('low');
+      expect(loadConfigFromContent('nit_handling: issues').noise_level).toBe('low');
     });
 
     it('deep-merges models object with defaults', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -222,7 +222,8 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
   }
 
   if ('noise_level' in config) {
-    if (config.noise_level !== 'low' && config.noise_level !== 'medium' && config.noise_level !== 'high') {
+    const valid = new Set(['low', 'medium', 'high']);
+    if (typeof config.noise_level !== 'string' || !valid.has(config.noise_level)) {
       errors.push('`noise_level` must be one of: low, medium, high');
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export const DEFAULT_CONFIG: ReviewConfig = {
     repo: '',
   },
   nit_handling: 'issues',
+  noise_level: 'low',
   review_passes: 1,
   convergence: {
     max_auto_rounds: 5,
@@ -53,6 +54,7 @@ const KNOWN_KEYS = new Set([
   'models',
   'planner',
   'nit_handling',
+  'noise_level',
   'review_passes',
   'convergence',
   'stats',
@@ -216,6 +218,12 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
   if ('nit_handling' in config) {
     if (config.nit_handling !== 'issues' && config.nit_handling !== 'comments') {
       errors.push('`nit_handling` must be "issues" or "comments"');
+    }
+  }
+
+  if ('noise_level' in config) {
+    if (config.noise_level !== 'low' && config.noise_level !== 'medium' && config.noise_level !== 'high') {
+      errors.push('`noise_level` must be one of: low, medium, high');
     }
   }
 

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -2206,7 +2206,14 @@ describe('runJudgeAgent', () => {
     await runJudgeAgent(mockClient, config, input);
 
     const [systemPrompt] = mockSendMessage.mock.calls[0];
-    expect(systemPrompt).toBe(buildJudgeSystemPrompt(config, 5, undefined, false, 'medium'));
+    const expectedPrompt = buildJudgeSystemPrompt(
+      config,
+      input.agentCount,
+      input.isFollowUp,
+      (input.openThreads?.length ?? 0) > 0,
+      'medium',
+    );
+    expect(systemPrompt).toBe(expectedPrompt);
   });
 
   it('defaults to noise_level "low" when config omits it', async () => {
@@ -2225,7 +2232,14 @@ describe('runJudgeAgent', () => {
     await runJudgeAgent(mockClient, config, input);
 
     const [systemPrompt] = mockSendMessage.mock.calls[0];
-    expect(systemPrompt).toBe(buildJudgeSystemPrompt(config, 5, undefined, false, 'low'));
+    const expectedPrompt = buildJudgeSystemPrompt(
+      config,
+      input.agentCount,
+      input.isFollowUp,
+      (input.openThreads?.length ?? 0) > 0,
+      'low',
+    );
+    expect(systemPrompt).toBe(expectedPrompt);
   });
 });
 

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -236,11 +236,19 @@ describe('buildJudgeSystemPrompt', () => {
     expect(prompt).toContain('"reachable" | "hypothetical" | "unknown"');
   });
 
-  it('accepts a noiseLevel parameter without changing the prompt body', () => {
-    const base = buildJudgeSystemPrompt(makeConfig(), 5);
-    expect(buildJudgeSystemPrompt(makeConfig(), 5, undefined, undefined, 'low')).toBe(base);
-    expect(buildJudgeSystemPrompt(makeConfig(), 5, undefined, undefined, 'medium')).toBe(base);
-    expect(buildJudgeSystemPrompt(makeConfig(), 5, undefined, undefined, 'high')).toBe(base);
+  it('accepts a noiseLevel parameter without changing the prompt body across isFollowUp/hasOpenThreads combinations', () => {
+    const flagCombos: Array<[boolean, boolean]> = [
+      [false, false],
+      [false, true],
+      [true, false],
+      [true, true],
+    ];
+    for (const [isFollowUp, hasOpenThreads] of flagCombos) {
+      const base = buildJudgeSystemPrompt(makeConfig(), 5, isFollowUp, hasOpenThreads);
+      expect(buildJudgeSystemPrompt(makeConfig(), 5, isFollowUp, hasOpenThreads, 'low')).toBe(base);
+      expect(buildJudgeSystemPrompt(makeConfig(), 5, isFollowUp, hasOpenThreads, 'medium')).toBe(base);
+      expect(buildJudgeSystemPrompt(makeConfig(), 5, isFollowUp, hasOpenThreads, 'high')).toBe(base);
+    }
   });
 
 });
@@ -2181,6 +2189,43 @@ describe('runJudgeAgent', () => {
     expect(result.findings[0].severity).toBe('ignore');
     expect(result.findings[0].tags).toContain(IN_PR_SUPPRESSED_TAG);
     expect(result.inPrSuppressedCount).toBe(1);
+  });
+
+  it('forwards config.noise_level to buildJudgeSystemPrompt', async () => {
+    mockSendMessage.mockResolvedValue({ content: '{"summary":"x","findings":[]}' });
+
+    const config = makeConfig({ noise_level: 'medium' });
+    const input: JudgeInput = {
+      findings: [],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 5,
+    };
+
+    await runJudgeAgent(mockClient, config, input);
+
+    const [systemPrompt] = mockSendMessage.mock.calls[0];
+    expect(systemPrompt).toBe(buildJudgeSystemPrompt(config, 5, undefined, false, 'medium'));
+  });
+
+  it('defaults to noise_level "low" when config omits it', async () => {
+    mockSendMessage.mockResolvedValue({ content: '{"summary":"x","findings":[]}' });
+
+    const config = makeConfig();
+    delete (config as Partial<ReviewConfig>).noise_level;
+    const input: JudgeInput = {
+      findings: [],
+      diff: makeDiff(),
+      rawDiff: '',
+      repoContext: '',
+      agentCount: 5,
+    };
+
+    await runJudgeAgent(mockClient, config, input);
+
+    const [systemPrompt] = mockSendMessage.mock.calls[0];
+    expect(systemPrompt).toBe(buildJudgeSystemPrompt(config, 5, undefined, false, 'low'));
   });
 });
 

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -236,6 +236,13 @@ describe('buildJudgeSystemPrompt', () => {
     expect(prompt).toContain('"reachable" | "hypothetical" | "unknown"');
   });
 
+  it('accepts a noiseLevel parameter without changing the prompt body', () => {
+    const base = buildJudgeSystemPrompt(makeConfig(), 5);
+    expect(buildJudgeSystemPrompt(makeConfig(), 5, undefined, undefined, 'low')).toBe(base);
+    expect(buildJudgeSystemPrompt(makeConfig(), 5, undefined, undefined, 'medium')).toBe(base);
+    expect(buildJudgeSystemPrompt(makeConfig(), 5, undefined, undefined, 'high')).toBe(base);
+  });
+
 });
 
 describe('buildJudgeUserMessage', () => {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -852,7 +852,7 @@ export async function runJudgeAgent(
 
   const changedFiles = diff.files;
 
-  const systemPrompt = buildJudgeSystemPrompt(config, agentCount, isFollowUp, hasOpenThreads, config.noise_level ?? 'low');
+  const systemPrompt = buildJudgeSystemPrompt(config, agentCount, isFollowUp, hasOpenThreads, config.noise_level);
   const userMessage = buildJudgeUserMessage(findings, codeContextMap, memoryContext, prContext, linkedIssues, changedFiles, openThreads, priorRounds, interRoundDiff);
 
   const response = await client.sendMessage(systemPrompt, userMessage, { effort: input.effort ?? 'high' });

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -15,7 +15,7 @@ import { dynamicFence, LinkedIssue, titleToSlug } from './github';
 import { safeTruncate } from './utils';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
-import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingFingerprintEntry, FindingReachability, FindingSeverity, IN_PR_SUPPRESSED_TAG, InPrSuppression, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewConfig, RoundContext, ParsedDiff, PrContext, ThreadEvaluation } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingFingerprintEntry, FindingReachability, FindingSeverity, IN_PR_SUPPRESSED_TAG, InPrSuppression, NoiseLevel, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewConfig, RoundContext, ParsedDiff, PrContext, ThreadEvaluation } from './types';
 
 /** Cap on how many prior rounds we pass to the judge. */
 const PRIOR_ROUNDS_WINDOW = 3;
@@ -266,7 +266,14 @@ export interface JudgeResult {
 
 const CONTEXT_LINES = 10;
 
-export function buildJudgeSystemPrompt(config: ReviewConfig, agentCount: number, isFollowUp?: boolean, hasOpenThreads?: boolean): string {
+export function buildJudgeSystemPrompt(
+  config: ReviewConfig,
+  agentCount: number,
+  isFollowUp?: boolean,
+  hasOpenThreads?: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  noiseLevel: NoiseLevel = 'low',
+): string {
   const majorityThreshold = Math.max(1, Math.ceil(agentCount / 2));
 
   const summaryInstruction = isFollowUp
@@ -846,7 +853,7 @@ export async function runJudgeAgent(
 
   const changedFiles = diff.files;
 
-  const systemPrompt = buildJudgeSystemPrompt(config, agentCount, isFollowUp, hasOpenThreads);
+  const systemPrompt = buildJudgeSystemPrompt(config, agentCount, isFollowUp, hasOpenThreads, config.noise_level ?? 'low');
   const userMessage = buildJudgeUserMessage(findings, codeContextMap, memoryContext, prContext, linkedIssues, changedFiles, openThreads, priorRounds, interRoundDiff);
 
   const response = await client.sendMessage(systemPrompt, userMessage, { effort: input.effort ?? 'high' });

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -271,8 +271,7 @@ export function buildJudgeSystemPrompt(
   agentCount: number,
   isFollowUp?: boolean,
   hasOpenThreads?: boolean,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  noiseLevel: NoiseLevel = 'low',
+  _noiseLevel: NoiseLevel = 'low',
 ): string {
   const majorityThreshold = Math.max(1, Math.ceil(agentCount / 2));
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -887,6 +887,13 @@ describe('buildReviewerSystemPrompt', () => {
     expect(prompt).toContain('caveats');
     expect(prompt).toContain('description');
   });
+
+  it('accepts a noiseLevel parameter without changing the prompt body', () => {
+    const base = buildReviewerSystemPrompt(reviewer, makeConfig());
+    expect(buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'low')).toBe(base);
+    expect(buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium')).toBe(base);
+    expect(buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'high')).toBe(base);
+  });
 });
 
 describe('buildReviewerUserMessage', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1738,6 +1738,46 @@ describe('runReview', () => {
     expect(mockedRunJudgeAgent).toHaveBeenCalledTimes(1);
   });
 
+  it('forwards config.noise_level to buildReviewerSystemPrompt for each agent', async () => {
+    const clients = makeClients();
+    const config = makeConfig({ noise_level: 'medium' });
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    await runReview(clients, config, diff, 'raw diff', 'repo context');
+
+    const reviewerMock = clients.reviewer.sendMessage as jest.Mock;
+    expect(reviewerMock).toHaveBeenCalled();
+
+    for (const call of reviewerMock.mock.calls) {
+      const systemPrompt = call[0] as string;
+      const roleMatch = systemPrompt.match(/^Your role: (.+)$/m);
+      expect(roleMatch).not.toBeNull();
+      const agent = AGENT_POOL.find(a => a.name === roleMatch![1]);
+      expect(agent).toBeDefined();
+      expect(systemPrompt).toBe(buildReviewerSystemPrompt(agent!, config, undefined, undefined, 'medium'));
+    }
+  });
+
+  it('defaults reviewer noise_level to "low" when config omits it', async () => {
+    const clients = makeClients();
+    const config = makeConfig();
+    delete (config as Partial<ReviewConfig>).noise_level;
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    await runReview(clients, config, diff, 'raw diff', 'repo context');
+
+    const reviewerMock = clients.reviewer.sendMessage as jest.Mock;
+    expect(reviewerMock).toHaveBeenCalled();
+
+    const [firstCall] = reviewerMock.mock.calls;
+    const systemPrompt = firstCall[0] as string;
+    const roleMatch = systemPrompt.match(/^Your role: (.+)$/m);
+    expect(roleMatch).not.toBeNull();
+    const agent = AGENT_POOL.find(a => a.name === roleMatch![1]);
+    expect(agent).toBeDefined();
+    expect(systemPrompt).toBe(buildReviewerSystemPrompt(agent!, config, undefined, undefined, 'low'));
+  });
+
   it('returns COMMENT verdict when all agents fail', async () => {
     const clients: ReviewClients = {
       reviewer: {

--- a/src/review.ts
+++ b/src/review.ts
@@ -1256,7 +1256,7 @@ async function runReviewerAgent(
   options: RunReviewerAgentOptions = {},
 ): Promise<AgentResult> {
   const { effort, language, context, provenanceMap } = options;
-  const systemPrompt = buildReviewerSystemPrompt(reviewer, config, language, context, config.noise_level ?? 'low');
+  const systemPrompt = buildReviewerSystemPrompt(reviewer, config, language, context, config.noise_level);
   const userMessage = buildReviewerUserMessage(rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, provenanceMap);
 
   const sendOptions = effort ? { effort } : undefined;

--- a/src/review.ts
+++ b/src/review.ts
@@ -6,7 +6,7 @@ import { runJudgeAgent, JudgeInput, computeProvenanceMap } from './judge';
 import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
 import { LinkedIssue, titleToSlug } from './github';
 import { collectInPrSuppressions, deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
-import { ReviewConfig, ReviewerAgent, Finding, FindingFingerprintEntry, OpenThread, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, RoundContext, SpecialistOutcome, EffortLevel, AgentPick, ProvenanceEntry, ThreadEvaluation, MAX_AGENT_RETRIES, VALID_PR_TYPES, ValidPrType } from './types';
+import { ReviewConfig, ReviewerAgent, Finding, FindingFingerprintEntry, NoiseLevel, OpenThread, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, RoundContext, SpecialistOutcome, EffortLevel, AgentPick, ProvenanceEntry, ThreadEvaluation, MAX_AGENT_RETRIES, VALID_PR_TYPES, ValidPrType } from './types';
 import { extractJSON } from './json';
 
 const DISMISSED_LINE_TOLERANCE = 5;
@@ -1256,7 +1256,7 @@ async function runReviewerAgent(
   options: RunReviewerAgentOptions = {},
 ): Promise<AgentResult> {
   const { effort, language, context, provenanceMap } = options;
-  const systemPrompt = buildReviewerSystemPrompt(reviewer, config, language, context);
+  const systemPrompt = buildReviewerSystemPrompt(reviewer, config, language, context, config.noise_level ?? 'low');
   const userMessage = buildReviewerUserMessage(rawDiff, repoContext, fileContents, prContext, memoryContext, linkedIssues, provenanceMap);
 
   const sendOptions = effort ? { effort } : undefined;
@@ -1270,6 +1270,8 @@ export function buildReviewerSystemPrompt(
   config: ReviewConfig,
   language?: string,
   context?: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  noiseLevel: NoiseLevel = 'low',
 ): string {
   let prompt = `You are a code reviewer specializing in: ${reviewer.focus}
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -1270,8 +1270,7 @@ export function buildReviewerSystemPrompt(
   config: ReviewConfig,
   language?: string,
   context?: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  noiseLevel: NoiseLevel = 'low',
+  _noiseLevel: NoiseLevel = 'low',
 ): string {
   let prompt = `You are a code reviewer specializing in: ${reviewer.focus}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,8 @@ export interface PlannerRoundHint {
 
 export type ReviewLevel = 'auto' | 'small' | 'medium' | 'large';
 
+export type NoiseLevel = 'low' | 'medium' | 'high';
+
 export interface ReviewThresholds {
   small: number;
   medium: number;
@@ -239,6 +241,7 @@ export interface ReviewConfig {
     enabled?: boolean;
   };
   nit_handling?: 'issues' | 'comments';
+  noise_level?: NoiseLevel;
   review_passes?: number;
   convergence?: {
     /**


### PR DESCRIPTION
## Summary

First sub-issue of parent [#738](https://github.com/manki-review/manki/issues/738). Adds the `noise_level: 'low' | 'medium' | 'high'` config field with default `'low'`, and threads the resolved value through to `buildReviewerSystemPrompt` and `buildJudgeSystemPrompt`. Both functions accept the parameter but do not read it yet, so this PR is purely additive with no user-visible behavior change.

- `src/types.ts` adds the `NoiseLevel` type alias and the `noise_level?: NoiseLevel` field on `ReviewConfig`
- `src/config.ts` adds `noise_level: 'low'` to `DEFAULT_CONFIG`, registers the key in `KNOWN_KEYS`, and adds a validator that rejects unknown values with a clear error listing the three valid options
- `src/review.ts` and `src/judge.ts` accept the parameter in their respective prompt builders. The two callers (`runReviewerAgent` and `runJudgeAgent`) resolve `config.noise_level ?? 'low'` and pass it explicitly
- Tests cover: each valid level parses, invalid values rejected, default-when-absent resolves to `'low'`, the parameter does not change the prompt body (invariance assertion)

Reviewer prompts and judge calibration start honoring the field in #740 and #741.

Closes #739

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)