### PR TITLE
docs: align `docs/index.html` quickstart with `SETUP.md`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -168,14 +168,12 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - name: Manki Review
-        uses: manki-review/manki@v4
+        uses: manki-review/manki@v5
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}</code></pre>
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # github_token: ${{ secrets.GITHUB_TOKEN }}  # Only if not using the GitHub App
+          # memory_repo_token: ${{ secrets.REVIEW_MEMORY_TOKEN }}  # Only if memory repo is separate</code></pre>
             </div>
           </div>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,9 +123,9 @@
           <div class="step-number">2</div>
           <div class="step-content">
             <h3>Add your API key</h3>
-            <p>Set your Claude Code OAuth token as a repository secret. An Anthropic API key also works as an alternative.</p>
+            <p>Set your Anthropic API key as a repository secret. OpenAI, Gemini, and OAuth alternatives are documented in the <a href="https://github.com/manki-review/manki/blob/main/SETUP.md#step-2-authentication-secrets">setup guide</a>.</p>
             <div class="install-block">
-              <pre><code>gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo &lt;owner&gt;/&lt;repo&gt;</code></pre>
+              <pre><code>gh secret set ANTHROPIC_API_KEY --repo &lt;owner&gt;/&lt;repo&gt;</code></pre>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The landing-page quickstart was pinned to `@v4` and used the deprecated `claude_code_oauth_token` input, so a user copy-pasting from the landing page got a workflow that emits a deprecation warning on every run.

- `manki-review/manki@v4` → `manki-review/manki@v5`
- `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` → `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
- Removed the manual "Install Claude Code CLI" step (no equivalent in `SETUP.md` canonical workflow)
- Added optional commented `github_token` and `memory_repo_token` lines matching `SETUP.md` verbatim

The `pull_request.types` list already included `ready_for_review` (landed in [#744](https://github.com/manki-review/manki/pull/744)).

Closes #746

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)