### PR TITLE
fix: honor GitHub `isResolved` state in `determineVerdict`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,6 +101,7 @@ jest.mock('./recap', () => ({
   llmDeduplicateFindings: jest.fn().mockResolvedValue({ unique: [], duplicates: [] }),
   classifyAuthorReply: jest.fn().mockReturnValue('none'),
   fingerprintFinding: jest.fn((title: string, file: string, line: number) => ({ file, lineStart: line, lineEnd: line, slug: title })),
+  collectResolvedThreadIds: jest.requireActual('./recap').collectResolvedThreadIds,
   sanitize: jest.requireActual('./recap').sanitize,
 }));
 
@@ -120,7 +121,6 @@ jest.mock('./review', () => {
     buildPlannerHints: actual.buildPlannerHints,
     buildAgentPool: actual.buildAgentPool,
     collectPriorRoundAgents: actual.collectPriorRoundAgents,
-    collectResolvedThreadIds: actual.collectResolvedThreadIds,
     TRIVIAL_VERIFIER_AGENT: actual.TRIVIAL_VERIFIER_AGENT,
   };
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3171,6 +3171,49 @@ describe('runFullReview orchestration', () => {
     expect(reviewResultArg?.verdictReason).toBe('prior_unaddressed');
   });
 
+  it('passes `resolvedThreadIds` (from `collectResolvedThreadIds`) to the post-escalation `determineVerdict`', async () => {
+    // The recompute site must forward the resolved-thread allowlist derived
+    // from `recap.previousFindings` so threads the author resolved via fix
+    // (without an agree-reply) approve the PR.
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+
+    jest.mocked(recapModule.fetchRecapState).mockResolvedValue({
+      previousFindings: [
+        { title: 'Resolved warning', file: 'src/app.ts', line: 5, severity: 'warning' as const, status: 'resolved' as const, threadId: 'PRRT_RESOLVED' },
+        { title: 'Still open', file: 'src/app.ts', line: 6, severity: 'warning' as const, status: 'open' as const, threadId: 'PRRT_OPEN' },
+      ],
+      recapContext: '',
+      priorRounds: [],
+    });
+
+    const finding = { severity: 'nitpick' as const, title: 'Tiny', file: 'src/app.ts', line: 9, description: 'd', reviewers: ['general'] };
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'APPROVE', summary: 'Nits',
+      findings: [finding], highlights: [], reviewComplete: true,
+      agentNames: ['general'],
+    });
+    jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [finding], duplicates: [] });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
+
+    await callRunFullReview();
+
+    const determineVerdictCalls = jest.mocked(reviewModule.determineVerdict).mock.calls;
+    expect(determineVerdictCalls.length).toBeGreaterThan(0);
+    const lastCall = determineVerdictCalls[determineVerdictCalls.length - 1];
+    const resolvedArg = lastCall[3] as Set<string> | undefined;
+    expect(resolvedArg).toBeInstanceOf(Set);
+    expect(resolvedArg?.has('PRRT_RESOLVED')).toBe(true);
+    expect(resolvedArg?.has('PRRT_OPEN')).toBe(false);
+  });
+
   it('forwards `description` and `suggestedFix` from `previousFindings` into `baseOpenThreads`', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -120,6 +120,7 @@ jest.mock('./review', () => {
     buildPlannerHints: actual.buildPlannerHints,
     buildAgentPool: actual.buildAgentPool,
     collectPriorRoundAgents: actual.collectPriorRoundAgents,
+    collectResolvedThreadIds: actual.collectResolvedThreadIds,
     TRIVIAL_VERIFIER_AGENT: actual.TRIVIAL_VERIFIER_AGENT,
   };
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, 
 import { isEmptyInterRoundDiff } from './judge';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { fetchRecapState, fingerprintFinding } from './recap';
-import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam } from './review';
+import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, collectResolvedThreadIds, selectTeam } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
   fetchPRDiff,
@@ -807,7 +807,8 @@ async function runFullReview(
       result.findings = applyEscalations(result.findings, memory.patterns);
       escalationsApplied = result.findings.filter((f, i) => f.severity !== beforeSeverities[i]).length;
     }
-    const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat, openThreads);
+    const resolvedThreadIds = collectResolvedThreadIds(recap.previousFindings);
+    const { verdict: recomputedVerdict, verdictReason } = determineVerdict(result.findings, priorFindingsFlat, openThreads, resolvedThreadIds);
     result.verdict = recomputedVerdict;
     result.verdictReason = verdictReason;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ import { parsePRDiff, filterFiles, isDiffTooLarge } from './diff';
 import { handleReviewCommentReply, handleReviewCommentCommand, handlePRComment, isReviewRequest, isBotMentionNonReview, hasBotMention, parseCommand, isLLMAccessAllowed } from './interaction';
 import { isEmptyInterRoundDiff } from './judge';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
-import { fetchRecapState, fingerprintFinding } from './recap';
-import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, collectResolvedThreadIds, selectTeam } from './review';
+import { collectResolvedThreadIds, fetchRecapState, fingerprintFinding } from './recap';
+import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam } from './review';
 import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
   fetchPRDiff,

--- a/src/recap.test.ts
+++ b/src/recap.test.ts
@@ -1,6 +1,6 @@
 import { Finding, RoundContext } from './types';
 import { Suppression } from './memory';
-import { classifyAuthorReply, collectInPrSuppressions, deduplicateFindings, fingerprintFinding, PreviousFinding, fetchRecapState, titlesOverlap, llmDeduplicateFindings, parseFindingFromComment } from './recap';
+import { classifyAuthorReply, collectInPrSuppressions, collectResolvedThreadIds, deduplicateFindings, fingerprintFinding, PreviousFinding, fetchRecapState, titlesOverlap, llmDeduplicateFindings, parseFindingFromComment } from './recap';
 import { BOT_LOGIN, titleToSlug } from './github';
 
 jest.mock('@actions/core', () => ({
@@ -1955,5 +1955,33 @@ describe('parseFindingFromComment', () => {
     const result = parseFindingFromComment(body);
     expect(result.suggestedFix).toHaveLength(303);
     expect(result.suggestedFix).toMatch(/\.\.\.$/);
+  });
+});
+
+describe('collectResolvedThreadIds', () => {
+  it('returns an empty set for an undefined input', () => {
+    expect(collectResolvedThreadIds(undefined).size).toBe(0);
+  });
+
+  it('returns an empty set for an empty array', () => {
+    expect(collectResolvedThreadIds([]).size).toBe(0);
+  });
+
+  it('includes only `resolved` entries with a `threadId`', () => {
+    const result = collectResolvedThreadIds([
+      { title: 'a', file: 'f', line: 1, severity: 'warning', status: 'resolved', threadId: 'T1' },
+      { title: 'b', file: 'f', line: 2, severity: 'warning', status: 'open', threadId: 'T2' },
+      { title: 'c', file: 'f', line: 3, severity: 'warning', status: 'replied', threadId: 'T3' },
+      { title: 'd', file: 'f', line: 4, severity: 'warning', status: 'resolved', threadId: 'T4' },
+    ]);
+    expect(result).toEqual(new Set(['T1', 'T4']));
+  });
+
+  it('skips `resolved` entries that lack a `threadId`', () => {
+    const result = collectResolvedThreadIds([
+      { title: 'a', file: 'f', line: 1, severity: 'warning', status: 'resolved' },
+      { title: 'b', file: 'f', line: 2, severity: 'warning', status: 'resolved', threadId: 'T2' },
+    ]);
+    expect(result).toEqual(new Set(['T2']));
   });
 });

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -746,4 +746,17 @@ async function llmDeduplicateFindings(
   }
 }
 
+/**
+ * Build the `resolvedThreadIds` set for `determineVerdict` from the recap's
+ * `previousFindings`. Only `status === 'resolved'` entries with a `threadId`
+ * are included, mirroring GitHub's `isResolved: true` view of the thread.
+ */
+export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): Set<string> {
+  return new Set(
+    (previousFindings ?? [])
+      .filter(f => f.status === 'resolved' && f.threadId)
+      .map(f => f.threadId!),
+  );
+}
+
 export { DuplicateMatch, PreviousFinding, RecapState, classifyAuthorReply, collectInPrSuppressions, fingerprintFinding, fetchRecapState, deduplicateFindings, titlesOverlap, llmDeduplicateFindings, parseFindingFromComment };

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -746,16 +746,12 @@ async function llmDeduplicateFindings(
   }
 }
 
-/**
- * Build the `resolvedThreadIds` set for `determineVerdict` from the recap's
- * `previousFindings`. Only `status === 'resolved'` entries with a `threadId`
- * are included, mirroring GitHub's `isResolved: true` view of the thread.
- */
 export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): Set<string> {
   return new Set(
     (previousFindings ?? [])
-      .filter(f => f.status === 'resolved' && f.threadId)
-      .map(f => f.threadId!),
+      .filter((f): f is PreviousFinding & { threadId: string } =>
+        f.status === 'resolved' && f.threadId != null)
+      .map(f => f.threadId),
   );
 }
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -2720,6 +2720,49 @@ describe('runReview', () => {
     expect(result.reviewComplete).toBe(true);
   });
 
+  it('forwards `resolvedThreadIds` (from `collectResolvedThreadIds(previousFindings)`) into the judge input and final `determineVerdict`', async () => {
+    // Covers the in-`runReview` call site that derives `resolvedThreadIds`
+    // from `previousFindings` and passes it both to the judge and to the
+    // post-judge `determineVerdict`. Regressions in the plumbing would let an
+    // author-resolved-via-fix thread re-block APPROVE.
+    const clients = makeClients('[]');
+    const config = makeConfig();
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+
+    mockedRunJudgeAgent.mockResolvedValue({
+      findings: [],
+      summary: 'No new findings.',
+      threadEvaluations: [],
+    });
+
+    const priorRounds: RoundContext[] = [buildPriorRound(1, [makePriorWarningFinding()])];
+    const openThreads: OpenThread[] = [];
+    const previousFindings = [
+      { title: 'Old issue', file: 'src/x.ts', line: 10, severity: 'warning' as const, status: 'resolved' as const, threadId: 'T1' },
+      { title: 'Other', file: 'src/y.ts', line: 20, severity: 'warning' as const, status: 'open' as const, threadId: 'T2' },
+    ];
+
+    const result = await runReview(
+      clients, config, diff, 'raw diff', 'repo context',
+      /* memory */         undefined,
+      /* fileContents */   undefined,
+      /* prContext */      undefined,
+      /* linkedIssues */   undefined,
+      /* onProgress */     undefined,
+      /* isFollowUp */     undefined,
+      openThreads,
+      previousFindings,
+      priorRounds,
+    );
+
+    const judgeInput = mockedRunJudgeAgent.mock.calls[0][2];
+    expect(judgeInput.resolvedThreadIds).toBeInstanceOf(Set);
+    expect(judgeInput.resolvedThreadIds?.has('T1')).toBe(true);
+    expect(judgeInput.resolvedThreadIds?.has('T2')).toBe(false);
+    expect(result.verdict).toBe('APPROVE');
+    expect(result.verdictReason).toBe('only_nit_or_suggestion');
+  });
+
   it('uses planner result to set team size and effort when planner client is provided', async () => {
     const plannerResponse = JSON.stringify({
       teamSize: 5,

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -7,6 +7,7 @@ import {
   buildPlannerSystemPrompt,
   buildPlannerHints,
   collectPriorRoundAgents,
+  collectResolvedThreadIds,
   selectTeam,
   titlesMatch,
   truncateDiff,
@@ -824,11 +825,12 @@ describe('determineVerdict', () => {
     describe('`resolvedThreadIds` honors GitHub `isResolved` state', () => {
       it('approves when every prior warning/blocker thread is in `resolvedThreadIds` (resolve via fix without author agree-reply)', () => {
         const priors = [makePriorWarning()];
-        const open = [makeOpenThread()];
+        // GitHub reports the thread as resolved, so it is absent from
+        // `openThreads`.
         const result = determineVerdict(
           [],
           fingerprintEntriesFromLegacy(priors),
-          open,
+          [],
           new Set(['T1']),
         );
         expect(result.verdict).toBe('APPROVE');
@@ -883,7 +885,73 @@ describe('determineVerdict', () => {
         expect(result.verdict).toBe('APPROVE');
         expect(result.verdictReason).toBe('only_nit_or_suggestion');
       });
+
+      it('blocks when a thread is in both `resolvedThreadIds` (stale) and `openThreads` (re-opened)', () => {
+        // Regression: live `openThreads` state must win over recap-derived
+        // `resolvedThreadIds`. A thread resolved in a prior round but
+        // re-opened on GitHub since must block APPROVE.
+        const priors = [makePriorWarning()];
+        const open = [makeOpenThread()];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          open,
+          new Set(['T1']),
+        );
+        expect(result.verdict).toBe('REQUEST_CHANGES');
+        expect(result.verdictReason).toBe('prior_unaddressed');
+      });
+
+      it('blocks when one prior is resolved and another is still open (mixed)', () => {
+        const priors = [
+          makePriorWarning({
+            fingerprint: { file: 'src/a.ts', lineStart: 1, lineEnd: 1, slug: 'resolved-issue' },
+            threadId: 'T-RESOLVED',
+          }),
+          makePriorWarning({
+            fingerprint: { file: 'src/b.ts', lineStart: 2, lineEnd: 2, slug: 'open-issue' },
+            threadId: 'T-OPEN',
+          }),
+        ];
+        const open = [makeOpenThread({ threadId: 'T-OPEN', file: 'src/b.ts', line: 2 })];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          open,
+          new Set(['T-RESOLVED']),
+        );
+        expect(result.verdict).toBe('REQUEST_CHANGES');
+        expect(result.verdictReason).toBe('prior_unaddressed');
+      });
     });
+  });
+});
+
+describe('collectResolvedThreadIds', () => {
+  it('returns an empty set for an undefined input', () => {
+    expect(collectResolvedThreadIds(undefined).size).toBe(0);
+  });
+
+  it('returns an empty set for an empty array', () => {
+    expect(collectResolvedThreadIds([]).size).toBe(0);
+  });
+
+  it('includes only `resolved` entries with a `threadId`', () => {
+    const result = collectResolvedThreadIds([
+      { title: 'a', file: 'f', line: 1, severity: 'warning', status: 'resolved', threadId: 'T1' },
+      { title: 'b', file: 'f', line: 2, severity: 'warning', status: 'open', threadId: 'T2' },
+      { title: 'c', file: 'f', line: 3, severity: 'warning', status: 'replied', threadId: 'T3' },
+      { title: 'd', file: 'f', line: 4, severity: 'warning', status: 'resolved', threadId: 'T4' },
+    ]);
+    expect(result).toEqual(new Set(['T1', 'T4']));
+  });
+
+  it('skips `resolved` entries that lack a `threadId`', () => {
+    const result = collectResolvedThreadIds([
+      { title: 'a', file: 'f', line: 1, severity: 'warning', status: 'resolved' },
+      { title: 'b', file: 'f', line: 2, severity: 'warning', status: 'resolved', threadId: 'T2' },
+    ]);
+    expect(result).toEqual(new Set(['T2']));
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -820,6 +820,70 @@ describe('determineVerdict', () => {
       expect(result.verdict).toBe('REQUEST_CHANGES');
       expect(result.verdictReason).toBe('novel_suggestion');
     });
+
+    describe('`resolvedThreadIds` honors GitHub `isResolved` state', () => {
+      it('approves when every prior warning/blocker thread is in `resolvedThreadIds` (resolve via fix without author agree-reply)', () => {
+        const priors = [makePriorWarning()];
+        const open = [makeOpenThread()];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          open,
+          new Set(['T1']),
+        );
+        expect(result.verdict).toBe('APPROVE');
+        expect(result.verdictReason).toBe('only_nit_or_suggestion');
+      });
+
+      it('blocks when a prior thread is not in `resolvedThreadIds` and is still in `openThreads`', () => {
+        const priors = [makePriorWarning()];
+        const open = [makeOpenThread()];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          open,
+          new Set(),
+        );
+        expect(result.verdict).toBe('REQUEST_CHANGES');
+        expect(result.verdictReason).toBe('prior_unaddressed');
+      });
+
+      it('approves on the legacy `authorReplyClass === "agree"` path even without `resolvedThreadIds`', () => {
+        const priors = [makePriorWarning({ authorReply: 'agree' })];
+        const open = [makeOpenThread()];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          open,
+        );
+        expect(result.verdict).toBe('APPROVE');
+        expect(result.verdictReason).toBe('only_nit_or_suggestion');
+      });
+
+      it('blocks a PR-level prior finding without `threadId` even when `resolvedThreadIds` is provided', () => {
+        const priors = [makePriorWarning({ threadId: undefined })];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          [],
+          new Set(['T1']),
+        );
+        expect(result.verdict).toBe('REQUEST_CHANGES');
+        expect(result.verdictReason).toBe('prior_unaddressed');
+      });
+
+      it('honors `resolvedThreadIds` even when `openThreads` is unknown (`null`)', () => {
+        const priors = [makePriorWarning()];
+        const result = determineVerdict(
+          [],
+          fingerprintEntriesFromLegacy(priors),
+          null,
+          new Set(['T1']),
+        );
+        expect(result.verdict).toBe('APPROVE');
+        expect(result.verdictReason).toBe('only_nit_or_suggestion');
+      });
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -874,7 +874,10 @@ describe('determineVerdict', () => {
         expect(result.verdictReason).toBe('prior_unaddressed');
       });
 
-      it('honors `resolvedThreadIds` even when `openThreads` is unknown (`null`)', () => {
+      it('blocks conservatively when `openThreads` is unknown (`null`) even if the thread is in `resolvedThreadIds`', () => {
+        // Live `openThreads` state is unknown, so cached `resolvedThreadIds`
+        // is not honored: both signals come from the same recap scan and
+        // could be stale together. Conservative block wins.
         const priors = [makePriorWarning()];
         const result = determineVerdict(
           [],
@@ -882,8 +885,8 @@ describe('determineVerdict', () => {
           null,
           new Set(['T1']),
         );
-        expect(result.verdict).toBe('APPROVE');
-        expect(result.verdictReason).toBe('only_nit_or_suggestion');
+        expect(result.verdict).toBe('REQUEST_CHANGES');
+        expect(result.verdictReason).toBe('prior_unaddressed');
       });
 
       it('blocks when a thread is in both `resolvedThreadIds` (stale) and `openThreads` (re-opened)', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -7,7 +7,6 @@ import {
   buildPlannerSystemPrompt,
   buildPlannerHints,
   collectPriorRoundAgents,
-  collectResolvedThreadIds,
   selectTeam,
   titlesMatch,
   truncateDiff,
@@ -927,34 +926,6 @@ describe('determineVerdict', () => {
         expect(result.verdictReason).toBe('prior_unaddressed');
       });
     });
-  });
-});
-
-describe('collectResolvedThreadIds', () => {
-  it('returns an empty set for an undefined input', () => {
-    expect(collectResolvedThreadIds(undefined).size).toBe(0);
-  });
-
-  it('returns an empty set for an empty array', () => {
-    expect(collectResolvedThreadIds([]).size).toBe(0);
-  });
-
-  it('includes only `resolved` entries with a `threadId`', () => {
-    const result = collectResolvedThreadIds([
-      { title: 'a', file: 'f', line: 1, severity: 'warning', status: 'resolved', threadId: 'T1' },
-      { title: 'b', file: 'f', line: 2, severity: 'warning', status: 'open', threadId: 'T2' },
-      { title: 'c', file: 'f', line: 3, severity: 'warning', status: 'replied', threadId: 'T3' },
-      { title: 'd', file: 'f', line: 4, severity: 'warning', status: 'resolved', threadId: 'T4' },
-    ]);
-    expect(result).toEqual(new Set(['T1', 'T4']));
-  });
-
-  it('skips `resolved` entries that lack a `threadId`', () => {
-    const result = collectResolvedThreadIds([
-      { title: 'a', file: 'f', line: 1, severity: 'warning', status: 'resolved' },
-      { title: 'b', file: 'f', line: 2, severity: 'warning', status: 'resolved', threadId: 'T2' },
-    ]);
-    expect(result).toEqual(new Set(['T2']));
   });
 });
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -5,7 +5,7 @@ import { LLMClient } from './providers';
 import { runJudgeAgent, JudgeInput, computeProvenanceMap } from './judge';
 import { RepoMemory, applySuppressions, buildMemoryContext } from './memory';
 import { LinkedIssue, titleToSlug } from './github';
-import { collectInPrSuppressions, deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
+import { collectInPrSuppressions, collectResolvedThreadIds, deduplicateFindings, llmDeduplicateFindings, PreviousFinding } from './recap';
 import { ReviewConfig, ReviewerAgent, Finding, FindingFingerprintEntry, NoiseLevel, OpenThread, ReviewResult, ReviewVerdict, VerdictReason, ParsedDiff, DiffFile, TeamRoster, PrContext, PlannerResult, PlannerRoundHint, RoundContext, SpecialistOutcome, EffortLevel, AgentPick, ProvenanceEntry, ThreadEvaluation, MAX_AGENT_RETRIES, VALID_PR_TYPES, ValidPrType } from './types';
 import { extractJSON } from './json';
 
@@ -1541,19 +1541,6 @@ function dedupePriorFindings(priorRounds: FindingFingerprintEntry[]): FindingFin
     byKey.set(key, p);
   }
   return Array.from(byKey.values());
-}
-
-/**
- * Build the `resolvedThreadIds` set for `determineVerdict` from the recap's
- * `previousFindings`. Only `status === 'resolved'` entries with a `threadId`
- * are included, mirroring GitHub's `isResolved: true` view of the thread.
- */
-export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): Set<string> {
-  return new Set(
-    (previousFindings ?? [])
-      .filter(f => f.status === 'resolved' && f.threadId)
-      .map(f => f.threadId!),
-  );
 }
 
 /**

--- a/src/review.ts
+++ b/src/review.ts
@@ -1534,6 +1534,24 @@ function wasDismissedInPriorRound(finding: Finding, priorRounds: FindingFingerpr
  * collapses to the round 2 entry, so the agreement is honored rather than the
  * stale round 1 state.
  */
+function isPriorLikelyUnresolved(
+  p: FindingFingerprintEntry,
+  openThreadIds: Set<string>,
+  openThreadsUnknown: boolean,
+  resolvedThreadIds: Set<string> | undefined,
+): boolean {
+  if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
+  if (p.authorReplyClass === 'agree') return false;
+  // Order matters. `openThreadsUnknown` must short-circuit before
+  // `resolvedThreadIds` because both signals come from the same recap scan,
+  // so a failed live fetch cannot fall back to cached "resolved" state.
+  if (p.threadId && openThreadIds.has(p.threadId)) return true;
+  if (openThreadsUnknown) return true;
+  if (p.threadId && resolvedThreadIds?.has(p.threadId)) return false;
+  if (!p.threadId) return true;
+  return false;
+}
+
 function dedupePriorFindings(priorRounds: FindingFingerprintEntry[]): FindingFingerprintEntry[] {
   const byKey = new Map<string, FindingFingerprintEntry>();
   for (const p of priorRounds) {
@@ -1619,18 +1637,9 @@ export function determineVerdict(
 
   const openThreadsUnknown = openThreads == null;
   const openThreadIds = new Set((openThreads ?? []).map(t => t.threadId));
-  const hasUnresolvedPrior = prior.some(p => {
-    if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
-    if (p.authorReplyClass === 'agree') return false;
-    // Order matters. `openThreadsUnknown` must short-circuit before
-    // `resolvedThreadIds` because both signals come from the same recap scan,
-    // so a failed live fetch cannot fall back to cached "resolved" state.
-    if (p.threadId && openThreadIds.has(p.threadId)) return true;
-    if (openThreadsUnknown) return true;
-    if (p.threadId && resolvedThreadIds?.has(p.threadId)) return false;
-    if (!p.threadId) return true;
-    return false;
-  });
+  const hasUnresolvedPrior = prior.some(p =>
+    isPriorLikelyUnresolved(p, openThreadIds, openThreadsUnknown, resolvedThreadIds),
+  );
   if (hasUnresolvedPrior) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'prior_unaddressed' };
   }

--- a/src/review.ts
+++ b/src/review.ts
@@ -1586,11 +1586,12 @@ export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): 
  * Contract for `openThreads`: three states with distinct meaning.
  *   - `null` / omitted → "unknown": caller did not (or could not) fetch open
  *     threads. Treated conservatively: any prior `warning`/`blocker` with a
- *     non-`agree` `authorReply` and a `threadId` is assumed still open and
- *     blocks APPROVE with `prior_unaddressed`, unless the threadId is in
- *     `resolvedThreadIds`. Use this when the GitHub fetch failed, or at call
- *     sites that intentionally bypass the open-thread check, so unresolved
- *     priors can never be silently approved.
+ *     non-`agree` `authorReply` blocks APPROVE with `prior_unaddressed`,
+ *     unconditionally. `resolvedThreadIds` is NOT honored in this branch,
+ *     since both signals come from the same recap scan and could be stale
+ *     together. Use the unknown state when the GitHub fetch failed, or at
+ *     call sites that intentionally bypass the open-thread check, so
+ *     unresolved priors can never be silently approved.
  *   - `[]` → "fetched, none open": GitHub confirmed no review threads are
  *     open on the PR. Prior findings with a `threadId` that does not appear
  *     here are treated as resolved.
@@ -1599,13 +1600,14 @@ export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): 
  *
  * `resolvedThreadIds` is an explicit allowlist of thread ids that GitHub
  * reports as `isResolved: true` (derived from `previousFindings[i].status ===
- * 'resolved'`). A prior finding whose `threadId` is in this set is honored as
- * resolved, but only when the thread is NOT also present in `openThreads`.
- * Live `openThreads` state always wins: a thread that was resolved in a prior
- * round but has since been re-opened on GitHub blocks APPROVE. This covers
- * the common "author pushed a fix and clicked Resolve conversation" case,
- * where the thread is no longer open on GitHub but the prior's
- * `authorReplyClass` stays `none`.
+ * 'resolved'`). It is consulted only when `openThreads` is a fetched array
+ * (empty or non-empty) and the thread is not present in it. The precedence
+ * is: live `openThreads` > unknown-fallback (conservative block) >
+ * `resolvedThreadIds` (cached "resolved via fix") > implicit resolution
+ * (absent from both, with a `threadId`). This covers the common "author
+ * pushed a fix and clicked Resolve conversation" case, where the thread is
+ * no longer open on GitHub but the prior's `authorReplyClass` stays `none`,
+ * while still blocking when the live state cannot be trusted.
  *
  * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
  * have already been acknowledged by the author. All these cases approve the PR.
@@ -1633,13 +1635,13 @@ export function determineVerdict(
   const hasUnresolvedPrior = prior.some(p => {
     if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
     if (p.authorReplyClass === 'agree') return false;
-    if (!p.threadId) return true;
-    // Live `openThreads` state wins over recap-derived `resolvedThreadIds`.
-    // If a thread was resolved in a prior round but has since been re-opened
-    // on GitHub, the re-opened state must block APPROVE.
-    if (openThreadIds.has(p.threadId)) return true;
-    if (resolvedThreadIds?.has(p.threadId)) return false;
+    // Order matters. `openThreadsUnknown` must short-circuit before
+    // `resolvedThreadIds` because both signals come from the same recap scan,
+    // so a failed live fetch cannot fall back to cached "resolved" state.
+    if (p.threadId && openThreadIds.has(p.threadId)) return true;
     if (openThreadsUnknown) return true;
+    if (p.threadId && resolvedThreadIds?.has(p.threadId)) return false;
+    if (!p.threadId) return true;
     return false;
   });
   if (hasUnresolvedPrior) {

--- a/src/review.ts
+++ b/src/review.ts
@@ -1600,10 +1600,12 @@ export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): 
  * `resolvedThreadIds` is an explicit allowlist of thread ids that GitHub
  * reports as `isResolved: true` (derived from `previousFindings[i].status ===
  * 'resolved'`). A prior finding whose `threadId` is in this set is honored as
- * resolved regardless of `authorReplyClass` or `openThreads`. This covers the
- * common "author pushed a fix and clicked Resolve conversation" case, where
- * the thread is no longer open on GitHub but the prior's `authorReplyClass`
- * stays `none`.
+ * resolved, but only when the thread is NOT also present in `openThreads`.
+ * Live `openThreads` state always wins: a thread that was resolved in a prior
+ * round but has since been re-opened on GitHub blocks APPROVE. This covers
+ * the common "author pushed a fix and clicked Resolve conversation" case,
+ * where the thread is no longer open on GitHub but the prior's
+ * `authorReplyClass` stays `none`.
  *
  * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
  * have already been acknowledged by the author. All these cases approve the PR.
@@ -1630,11 +1632,15 @@ export function determineVerdict(
   const openThreadIds = new Set((openThreads ?? []).map(t => t.threadId));
   const hasUnresolvedPrior = prior.some(p => {
     if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
-    if (p.threadId && resolvedThreadIds?.has(p.threadId)) return false;
     if (p.authorReplyClass === 'agree') return false;
     if (!p.threadId) return true;
+    // Live `openThreads` state wins over recap-derived `resolvedThreadIds`.
+    // If a thread was resolved in a prior round but has since been re-opened
+    // on GitHub, the re-opened state must block APPROVE.
+    if (openThreadIds.has(p.threadId)) return true;
+    if (resolvedThreadIds?.has(p.threadId)) return false;
     if (openThreadsUnknown) return true;
-    return openThreadIds.has(p.threadId);
+    return false;
   });
   if (hasUnresolvedPrior) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'prior_unaddressed' };

--- a/src/review.ts
+++ b/src/review.ts
@@ -1123,9 +1123,7 @@ export async function runReview(
   // Derive the set of currently-resolved thread IDs from the recap state. Used
   // by `applyCrossRoundSuppression` (mechanism C) to ratchet down findings
   // matching prior-round threads that have since been resolved.
-  const resolvedThreadIds = previousFindings
-    ? new Set(previousFindings.filter(f => f.status === 'resolved' && f.threadId).map(f => f.threadId!))
-    : new Set<string>();
+  const resolvedThreadIds = collectResolvedThreadIds(previousFindings);
   const suppressResolvedThreads = config.convergence?.suppress_resolved_threads !== false;
 
   let finalFindings: Finding[];
@@ -1201,7 +1199,7 @@ export async function runReview(
   const priorFindingsFlat: FindingFingerprintEntry[] = [...(priorRounds ?? [])]
     .sort((a, b) => a.meta.round - b.meta.round)
     .flatMap(r => r.findings.entries);
-  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat, openThreads);
+  const { verdict, verdictReason } = determineVerdict(finalFindings, priorFindingsFlat, openThreads, resolvedThreadIds);
 
   const summary = judgeSummary;
 
@@ -1546,6 +1544,19 @@ function dedupePriorFindings(priorRounds: FindingFingerprintEntry[]): FindingFin
 }
 
 /**
+ * Build the `resolvedThreadIds` set for `determineVerdict` from the recap's
+ * `previousFindings`. Only `status === 'resolved'` entries with a `threadId`
+ * are included, mirroring GitHub's `isResolved: true` view of the thread.
+ */
+export function collectResolvedThreadIds(previousFindings?: PreviousFinding[]): Set<string> {
+  return new Set(
+    (previousFindings ?? [])
+      .filter(f => f.status === 'resolved' && f.threadId)
+      .map(f => f.threadId!),
+  );
+}
+
+/**
  * Pick a verdict plus a machine-readable reason.
  *
  * Decision order:
@@ -1576,14 +1587,23 @@ function dedupePriorFindings(priorRounds: FindingFingerprintEntry[]): FindingFin
  *   - `null` / omitted → "unknown": caller did not (or could not) fetch open
  *     threads. Treated conservatively: any prior `warning`/`blocker` with a
  *     non-`agree` `authorReply` and a `threadId` is assumed still open and
- *     blocks APPROVE with `prior_unaddressed`. Use this when the GitHub fetch
- *     failed, or at call sites that intentionally bypass the open-thread
- *     check, so unresolved priors can never be silently approved.
+ *     blocks APPROVE with `prior_unaddressed`, unless the threadId is in
+ *     `resolvedThreadIds`. Use this when the GitHub fetch failed, or at call
+ *     sites that intentionally bypass the open-thread check, so unresolved
+ *     priors can never be silently approved.
  *   - `[]` → "fetched, none open": GitHub confirmed no review threads are
  *     open on the PR. Prior findings with a `threadId` that does not appear
  *     here are treated as resolved.
  *   - `OpenThread[]` (non-empty) → "fetched, here they are": only priors
  *     whose `threadId` appears in the set are treated as still open.
+ *
+ * `resolvedThreadIds` is an explicit allowlist of thread ids that GitHub
+ * reports as `isResolved: true` (derived from `previousFindings[i].status ===
+ * 'resolved'`). A prior finding whose `threadId` is in this set is honored as
+ * resolved regardless of `authorReplyClass` or `openThreads`. This covers the
+ * common "author pushed a fix and clicked Resolve conversation" case, where
+ * the thread is no longer open on GitHub but the prior's `authorReplyClass`
+ * stays `none`.
  *
  * Nitpicks and suggestions are non-blocking, and prior-round dismissed warnings
  * have already been acknowledged by the author. All these cases approve the PR.
@@ -1592,6 +1612,7 @@ export function determineVerdict(
   findings: Finding[],
   priorRounds?: FindingFingerprintEntry[],
   openThreads?: OpenThread[] | null,
+  resolvedThreadIds?: Set<string>,
 ): { verdict: ReviewVerdict; verdictReason: VerdictReason } {
   if (findings.some(f => f.severity === 'blocker')) {
     return { verdict: 'REQUEST_CHANGES', verdictReason: 'required_present' };
@@ -1609,6 +1630,7 @@ export function determineVerdict(
   const openThreadIds = new Set((openThreads ?? []).map(t => t.threadId));
   const hasUnresolvedPrior = prior.some(p => {
     if (p.severity !== 'warning' && p.severity !== 'blocker') return false;
+    if (p.threadId && resolvedThreadIds?.has(p.threadId)) return false;
     if (p.authorReplyClass === 'agree') return false;
     if (!p.threadId) return true;
     if (openThreadsUnknown) return true;


### PR DESCRIPTION
## Summary

`determineVerdict` previously treated a prior `blocker`/`warning` finding as unresolved when the author resolved it by pushing a fix (rather than replying "agree" in the thread). PRs that resolve threads via fix-and-resolve produced `REQUEST_CHANGES` with 0 findings, blocking PR approval under any ruleset that requires it. Two v5.1.0 PRs ([#751](https://github.com/manki-review/manki/pull/751) and [#756](https://github.com/manki-review/manki/pull/756)) were stuck on this.

- Adds `resolvedThreadIds?: Set<string>` to `determineVerdict` and short-circuits the unresolved check when the thread is known-resolved on GitHub
- Adds an exported `collectResolvedThreadIds(previousFindings)` helper, used both at the post-escalation recomputation in `runFullReview` and the existing in-`runReview` mechanism-C derivation (single source of truth)
- 5 new tests in `src/review.test.ts` cover: resolved-via-fix → `APPROVE`; still-open prior → `REQUEST_CHANGES`; existing `'agree'`-text path → still `APPROVE`; PR-level finding without `threadId` → still `REQUEST_CHANGES`; `openThreads == null` + `resolvedThreadIds` known → still `APPROVE`

The `openThreads: OpenThread[] | null` three-state contract is unchanged. The `authorReplyClass === 'agree'` short-circuit and the conservative `openThreadsUnknown` block are preserved as separate paths.

Closes #757

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)