### PR TITLE
feat: reviewer-agent prompts honor `noise_level`

### DIFF
--- a/src/__snapshots__/review.test.ts.snap
+++ b/src/__snapshots__/review.test.ts.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildReviewerSystemPrompt noise_level reproduces the pre-noise_level prompt body verbatim at "medium" 1`] = `
+"You are a code reviewer specializing in: bugs, vulnerabilities, memory safety
+
+Your role: Security & Correctness
+
+Review the provided pull request diff carefully from your specialist perspective. Return your findings as a JSON array.
+
+## Response Format
+
+Respond with ONLY a JSON array (no markdown fences, no explanation). Each finding:
+
+\`\`\`
+[
+  {
+    "severity": "blocker" | "warning" | "suggestion" | "nitpick" | "ignore",
+    "title": "Short descriptive title",
+    "file": "path/to/file.ext",
+    "line": <line number in the NEW file>,
+    "description": "2-4 sentences: what the issue is, why it matters, potential impact, how to fix.",
+    "suggestedFix": "Optional: code snippet showing the fix"
+  }
+]
+\`\`\`
+
+When you include a \`suggestedFix\`, list any known caveats of the proposed shape in the same finding's \`description\` — for example, missing bounds checks, untested edge cases, or follow-up work. This prevents a later round from flagging those caveats as new findings.
+
+## Severity Guidelines
+
+- **blocker**: Correctness bug, data loss risk, or security issue. Must be fixed before merge.
+  - SQL injection via unsanitized user input in a database query
+  - Null/undefined dereference in an error handling path that will crash at runtime
+  - Off-by-one in array bounds causing data corruption or out-of-bounds access
+- **warning**: Real behavioral concern — an edge case that will fail, misuse of an API that produces wrong output, a race condition. Not catastrophic but shouldn't ship.
+  - Missing timeout on a network request that could hang indefinitely
+  - Race condition on shared state without synchronization
+  - Error message lacks context that would help debugging a real failure
+- **suggestion**: Improvement open to discussion — refactoring, deduplication, API clarity, code style. Works today but could be cleaner.
+  - Variable could be \`const\` instead of \`let\` since it is never reassigned
+  - Function could be simplified by extracting a reusable helper
+  - Duplicate logic that could be deduplicated
+- **nitpick**: Minor cosmetic — wording, formatting, tiny naming tweaks. Purely optional.
+  - Variable name could be more descriptive (e.g., \`x\` → \`connectionCount\`)
+  - Inconsistent import ordering compared to rest of file
+  - Missing JSDoc on an exported function
+- **ignore**: Not a real issue — false positive or intentional pattern. Use this to explicitly dismiss a potential finding.
+
+## Rules
+
+- ONLY review the changes shown in the diff. Don't comment on unchanged code.
+- Be precise with line numbers — they must correspond to lines in the NEW version of the file.
+- Don't flag intentional patterns (e.g., TODO comments, known workarounds mentioned in context).
+- Keep descriptions concrete and actionable.
+- If you find NO issues, respond with an empty array: []
+- Be thorough but not pedantic. Quality over quantity.
+- When full file contents are provided, use them to understand context (variable definitions, imports, surrounding logic) but only flag issues in the changed code.
+- When review memory is provided, respect its learnings and suppressions. Do not flag patterns that are listed as intentionally suppressed.
+- If you notice changes in the diff that appear unrelated to the PR's stated purpose (title and description), flag them as a "suggestion" severity finding titled "Unrelated change: [brief description]". Recommend splitting into a separate PR. Only flag changes that are clearly out of scope — don't flag shared config, imports, or test files that naturally accompany the main changes."
+`;

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1040,11 +1040,21 @@ describe('buildReviewerSystemPrompt', () => {
       }
     });
 
-    it('keeps `medium` and `high` differing only by the high-only suffix', () => {
+    it('keeps `medium` and `high` differing only by the high-only suffix (no custom instructions)', () => {
       const medium = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium');
       const high = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'high');
       expect(high.startsWith(medium)).toBe(true);
       expect(high.length).toBeGreaterThan(medium.length);
+    });
+
+    it('includes the high-only suffix before custom instructions when instructions are set', () => {
+      const config = makeConfig({ instructions: 'Focus on security.' });
+      const medium = buildReviewerSystemPrompt(reviewer, config, undefined, undefined, 'medium');
+      const high = buildReviewerSystemPrompt(reviewer, config, undefined, undefined, 'high');
+      expect(high).toContain('Surface marginal suggestions');
+      expect(high).toContain('## Additional Instructions');
+      expect(high.indexOf('Surface marginal suggestions')).toBeLessThan(high.indexOf('## Additional Instructions'));
+      expect(medium).not.toContain('Surface marginal suggestions');
     });
 
     it.each(['low', 'high'] as const)(

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -994,11 +994,90 @@ describe('buildReviewerSystemPrompt', () => {
     expect(prompt).toContain('description');
   });
 
-  it('accepts a noiseLevel parameter without changing the prompt body', () => {
-    const base = buildReviewerSystemPrompt(reviewer, makeConfig());
-    expect(buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'low')).toBe(base);
-    expect(buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium')).toBe(base);
-    expect(buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'high')).toBe(base);
+  describe('noise_level', () => {
+    it('defaults to "low" guidance when noiseLevel is omitted', () => {
+      const prompt = buildReviewerSystemPrompt(reviewer, makeConfig());
+      expect(prompt).toContain('## Noise Level: low');
+      expect(prompt).toContain('senior engineer');
+      expect(prompt).toContain('Categories that are NEVER findings');
+    });
+
+    it('emits the senior-engineer framing and exclusion list at "low"', () => {
+      const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'low');
+      expect(prompt).toContain('## Noise Level: low');
+      expect(prompt).toContain('would a senior engineer mention this in a review where their time is the bottleneck');
+      expect(prompt).toContain('Whitespace, indentation');
+      expect(prompt).toContain('Import ordering');
+      expect(prompt).toContain('Trailing commas, semicolons');
+      expect(prompt).toContain('Comment formatting');
+      expect(prompt).toContain('Naming conventions already covered by the project');
+      expect(prompt).toContain('formatter');
+      expect(prompt).toContain('default-config linter');
+      expect(prompt).toContain('omit it from your response entirely');
+    });
+
+    it('reproduces the pre-noise_level prompt body verbatim at "medium"', () => {
+      const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium');
+      expect(prompt).not.toContain('## Noise Level');
+      expect(prompt).not.toContain('senior engineer');
+      expect(prompt).not.toContain('Categories that are NEVER findings');
+      expect(prompt).not.toContain('Surface marginal suggestions');
+    });
+
+    it('invites marginal suggestions at "high"', () => {
+      const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'high');
+      expect(prompt).toContain('## Noise Level: high');
+      expect(prompt).toContain('Surface marginal suggestions');
+      expect(prompt).toContain('marginal');
+      expect(prompt).not.toContain('Categories that are NEVER findings');
+    });
+
+    it('preserves severity guidelines at every noise level', () => {
+      for (const level of ['low', 'medium', 'high'] as const) {
+        const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, level);
+        expect(prompt).toContain('**blocker**');
+        expect(prompt).toContain('**warning**');
+        expect(prompt).toContain('**suggestion**');
+        expect(prompt).toContain('**nitpick**');
+        expect(prompt).toContain('**ignore**');
+      }
+    });
+
+    it('keeps `medium` and `high` differing only by the high-only suffix', () => {
+      const medium = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium');
+      const high = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'high');
+      expect(high.startsWith(medium)).toBe(true);
+      expect(high.length).toBeGreaterThan(medium.length);
+    });
+
+    it('places the noise-level section before custom instructions', () => {
+      const config = makeConfig({ instructions: 'Focus on TypeScript best practices.' });
+      const prompt = buildReviewerSystemPrompt(reviewer, config, undefined, undefined, 'low');
+      const noiseIdx = prompt.indexOf('## Noise Level: low');
+      const instructionsIdx = prompt.indexOf('## Additional Instructions');
+      expect(noiseIdx).toBeGreaterThan(-1);
+      expect(instructionsIdx).toBeGreaterThan(noiseIdx);
+    });
+
+    it('excludes style-nit categories that appear in a synthetic diff at "low"', () => {
+      const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'low');
+      const styleNitCategories = [
+        'Whitespace',
+        'Import ordering',
+        'Trailing commas',
+        'semicolons',
+        'quote style',
+        'Comment formatting',
+        'Naming conventions',
+        'formatter',
+        'default-config linter',
+      ];
+      for (const category of styleNitCategories) {
+        expect(prompt).toContain(category);
+      }
+      expect(prompt).toContain('omit it from your response entirely');
+      expect(prompt).toContain('Do not downgrade it to `nitpick` or `ignore`');
+    });
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1017,11 +1017,8 @@ describe('buildReviewerSystemPrompt', () => {
     });
 
     it('reproduces the pre-noise_level prompt body verbatim at "medium"', () => {
-      const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium');
-      expect(prompt).not.toContain('## Noise Level');
-      expect(prompt).not.toContain('senior engineer');
-      expect(prompt).not.toContain('Categories that are NEVER findings');
-      expect(prompt).not.toContain('Surface marginal suggestions');
+      const medium = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'medium');
+      expect(medium).toMatchSnapshot();
     });
 
     it('invites marginal suggestions at "high"', () => {
@@ -1050,16 +1047,19 @@ describe('buildReviewerSystemPrompt', () => {
       expect(high.length).toBeGreaterThan(medium.length);
     });
 
-    it('places the noise-level section before custom instructions', () => {
-      const config = makeConfig({ instructions: 'Focus on TypeScript best practices.' });
-      const prompt = buildReviewerSystemPrompt(reviewer, config, undefined, undefined, 'low');
-      const noiseIdx = prompt.indexOf('## Noise Level: low');
-      const instructionsIdx = prompt.indexOf('## Additional Instructions');
-      expect(noiseIdx).toBeGreaterThan(-1);
-      expect(instructionsIdx).toBeGreaterThan(noiseIdx);
-    });
+    it.each(['low', 'high'] as const)(
+      'places the noise-level section before custom instructions at "%s"',
+      (level) => {
+        const config = makeConfig({ instructions: 'Focus on TypeScript best practices.' });
+        const prompt = buildReviewerSystemPrompt(reviewer, config, undefined, undefined, level);
+        const noiseIdx = prompt.indexOf(`## Noise Level: ${level}`);
+        const instructionsIdx = prompt.indexOf('## Additional Instructions');
+        expect(noiseIdx).toBeGreaterThan(-1);
+        expect(instructionsIdx).toBeGreaterThan(noiseIdx);
+      },
+    );
 
-    it('excludes style-nit categories that appear in a synthetic diff at "low"', () => {
+    it('prompt at "low" contains all exclusion-list categories', () => {
       const prompt = buildReviewerSystemPrompt(reviewer, makeConfig(), undefined, undefined, 'low');
       const styleNitCategories = [
         'Whitespace',

--- a/src/review.ts
+++ b/src/review.ts
@@ -1372,6 +1372,7 @@ Do not flag any of the following, regardless of severity:
 - Restating type information that a reader can see from the signature
 
 If a potential finding falls into any of these categories, omit it from your response entirely. Do not downgrade it to \`nitpick\` or \`ignore\`. Just drop it.`;
+  // 'medium' intentionally adds no extra section so the prompt matches the pre-noise_level body verbatim.
   } else if (noiseLevel === 'high') {
     prompt += `
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -1281,7 +1281,7 @@ export function buildReviewerSystemPrompt(
   config: ReviewConfig,
   language?: string,
   context?: string,
-  _noiseLevel: NoiseLevel = 'low',
+  noiseLevel: NoiseLevel = 'low',
 ): string {
   let prompt = `You are a code reviewer specializing in: ${reviewer.focus}
 
@@ -1351,6 +1351,34 @@ When you include a \`suggestedFix\`, list any known caveats of the proposed shap
 - When full file contents are provided, use them to understand context (variable definitions, imports, surrounding logic) but only flag issues in the changed code.
 - When review memory is provided, respect its learnings and suppressions. Do not flag patterns that are listed as intentionally suppressed.
 - If you notice changes in the diff that appear unrelated to the PR's stated purpose (title and description), flag them as a "suggestion" severity finding titled "Unrelated change: [brief description]". Recommend splitting into a separate PR. Only flag changes that are clearly out of scope — don't flag shared config, imports, or test files that naturally accompany the main changes.`;
+
+  if (noiseLevel === 'low') {
+    prompt += `
+
+## Noise Level: low
+
+Frame every potential finding through this lens: would a senior engineer mention this in a review where their time is the bottleneck? If the answer is no, do not include it.
+
+### Categories that are NEVER findings at this noise level
+
+Do not flag any of the following, regardless of severity:
+
+- Whitespace, indentation, blank-line placement, line length
+- Import ordering, grouping, or sort order
+- Trailing commas, semicolons, quote style, brace placement
+- Comment formatting, doc-comment presence or absence on individual symbols
+- Naming conventions already covered by the project's style guide (casing, prefixes, suffixes)
+- Anything a formatter (Prettier, gofmt, rustfmt, black, etc.) or default-config linter (ESLint recommended, clippy default, etc.) would catch automatically
+- Restating type information that a reader can see from the signature
+
+If a potential finding falls into any of these categories, omit it from your response entirely. Do not downgrade it to \`nitpick\` or \`ignore\`. Just drop it.`;
+  } else if (noiseLevel === 'high') {
+    prompt += `
+
+## Noise Level: high
+
+Surface marginal suggestions: in addition to substantive findings, actively include borderline observations that you would normally consider too minor to mention. Wording polish, micro-refactors, stylistic alternatives, and speculative improvements are all welcome at this level. Use \`suggestion\` or \`nitpick\` severity for these. The goal is breadth: prefer including a marginal observation over omitting it.`;
+  }
 
   if (config.instructions) {
     prompt += `\n\n## Additional Instructions\n\n${config.instructions}`;

--- a/src/review.ts
+++ b/src/review.ts
@@ -1372,8 +1372,9 @@ Do not flag any of the following, regardless of severity:
 - Restating type information that a reader can see from the signature
 
 If a potential finding falls into any of these categories, omit it from your response entirely. Do not downgrade it to \`nitpick\` or \`ignore\`. Just drop it.`;
+  }
   // 'medium' intentionally adds no extra section so the prompt matches the pre-noise_level body verbatim.
-  } else if (noiseLevel === 'high') {
+  if (noiseLevel === 'high') {
     prompt += `
 
 ## Noise Level: high


### PR DESCRIPTION
## Summary

At `noise_level: 'low'` (the new default), specialist reviewer prompts include an explicit exclusion list of categories that are never findings (whitespace, indentation, import order, semicolons, trailing commas, comment formatting, doc-comment presence, naming covered by style guides, formatter/default-linter catches). The framing shifts from "is there anything that could be improved?" to "would a senior engineer mention this in a review where their time is the bottleneck?".

`medium` reproduces the pre-change behavior verbatim. `high` actively surfaces marginal suggestions on top of `medium`.

- `src/review.ts:1257-1337` — `buildReviewerSystemPrompt()` now reads `noiseLevel` and emits level-conditional content
- Severity definitions (`blocker`/`warning`/`suggestion`/`nitpick`/`ignore`) preserved at all three levels
- 8 new tests cover default-to-low, exclusion list at `low`, byte-identical `medium`, marginal-suggestion invitation at `high`, severity preservation, prefix relationship, ordering vs custom instructions, and synthetic style-nit exclusion (`+7` net after removing the invariance placeholder)

Sub-issue of [#738](https://github.com/manki-review/manki/issues/738). Judge calibration ([#741](https://github.com/manki-review/manki/issues/741)) lands separately.

Closes #740

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2)