### PR TITLE
fix: align `Judge` kept counts and surface test-nit suppression

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2141,8 +2141,7 @@ describe('buildDashboard', () => {
       testNitSuppressedCount: 7,
     };
     const md = buildDashboard(data);
-    expect(md).toMatch(/suppressed/i);
-    expect(md).toContain('7');
+    expect(md).toContain('suppressed: 7 test-only nits (round ≥2 throttle)');
   });
 
   it('omits test-nit suppression line when testNitSuppressedCount is not set', () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -2134,6 +2134,26 @@ describe('buildDashboard', () => {
     expect(md).not.toContain(`${INDENT}dropped:`);
   });
 
+  it('renders test-nit suppression count in judge section when provided', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 400, agentCount: 3,
+      rawFindingCount: 10, keptCount: 0, droppedCount: 3,
+      testNitSuppressedCount: 7,
+    };
+    const md = buildDashboard(data);
+    expect(md).toMatch(/suppressed/i);
+    expect(md).toContain('7');
+  });
+
+  it('omits test-nit suppression line when testNitSuppressedCount is not set', () => {
+    const data: DashboardData = {
+      phase: 'complete', lineCount: 400, agentCount: 3,
+      rawFindingCount: 10, keptCount: 3, droppedCount: 7,
+    };
+    const md = buildDashboard(data);
+    expect(md).not.toMatch(/suppressed/i);
+  });
+
   it('renders planner duration when plannerInfo and plannerDurationMs are provided', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 200, agentCount: 5,

--- a/src/github.ts
+++ b/src/github.ts
@@ -348,6 +348,9 @@ export function buildDashboard(data: DashboardData): string {
       const breakdown = renderSeverityBreakdown(data.droppedSeverities);
       if (breakdown) judgeLines.push(`${INDENT}dropped: ${breakdown}`);
     }
+    if (data.testNitSuppressedCount != null && data.testNitSuppressedCount > 0) {
+      judgeLines.push(`${INDENT}suppressed: ${data.testNitSuppressedCount} test-only nit${data.testNitSuppressedCount === 1 ? '' : 's'} (round ≥2 throttle)`);
+    }
   }
   sections.push(judgeLines.join('\n'));
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2120,6 +2120,8 @@ describe('runFullReview orchestration', () => {
     const keptSeverities = dashboardArg?.keptSeverities ?? {};
     const keptSeveritiesSum = Object.values(keptSeverities).reduce((a, n) => a + n, 0);
     expect(dashboardArg?.keptCount).toBe(keptSeveritiesSum);
+    expect(dashboardArg?.keptCount).toBe(1);
+    expect(keptSeverities['blocker']).toBe(1);
 
     // test-nit suppression count must be surfaced in the dashboard
     expect(dashboardArg?.testNitSuppressedCount).toBe(1);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2077,6 +2077,54 @@ describe('runFullReview orchestration', () => {
     expect(statsArg!.judge.crossRoundDemoted).toBe(1);
   });
 
+  it('aligns keptCount with keptSeverities sum when test-nit suppression fires', async () => {
+    const testFiles = [
+      { path: 'src/app.ts', changeType: 'modified' as const, hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }] },
+    ];
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: testFiles, totalAdditions: 20, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue(testFiles);
+
+    // Simulate: judge kept 2 findings, but review.ts test-nit suppression already
+    // dropped 1 before returning, so result.findings has only 1.
+    const survivingFinding = {
+      severity: 'blocker' as const, title: 'Bug', file: 'src/app.ts', line: 5,
+      description: 'desc', reviewers: ['security'], judgeConfidence: 'high' as const,
+    };
+    const allJudged = [
+      survivingFinding,
+      { severity: 'suggestion' as const, title: 'Test nit (suppressed)', file: 'src/app.ts', line: 8,
+        description: 'desc', reviewers: ['general'], judgeConfidence: 'medium' as const },
+    ];
+
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'REQUEST_CHANGES', summary: 'Issues found',
+      findings: [survivingFinding],
+      highlights: [], reviewComplete: true,
+      rawFindingCount: 3,
+      agentNames: ['security', 'general'],
+      allJudgedFindings: allJudged,
+      rawFindings: [...allJudged],
+      testNitSuppressedCount: 1,
+    });
+    jest.mocked(recapModule.deduplicateFindings).mockReturnValue({ unique: [survivingFinding], duplicates: [] });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'REQUEST_CHANGES', verdictReason: 'novel_suggestion' });
+
+    await callRunFullReview();
+
+    const dashboardArg = jest.mocked(ghUtils.updateProgressComment).mock.calls.at(-1)?.[4];
+
+    // keptCount must equal the sum of keptSeverities values
+    const keptSeverities = dashboardArg?.keptSeverities ?? {};
+    const keptSeveritiesSum = Object.values(keptSeverities).reduce((a, n) => a + n, 0);
+    expect(dashboardArg?.keptCount).toBe(keptSeveritiesSum);
+
+    // test-nit suppression count must be surfaced in the dashboard
+    expect(dashboardArg?.testNitSuppressedCount).toBe(1);
+  });
+
   it('creates nit issues when nit_handling is "issues"', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1066,12 +1066,15 @@ async function runFullReview(
     for (const f of result.findings) {
       keptSeverities[f.severity] = (keptSeverities[f.severity] ?? 0) + 1;
     }
-    for (const f of allJudgedForDashboard) {
+    // judgeDecisions is built in lock-step with allJudgedForDashboard, so the
+    // index aligns and d.originalSeverity carries the pre-judge severity even
+    // when the judge merged or renamed the finding before dropping it.
+    allJudgedForDashboard.forEach((f, i) => {
       if (!keptSet.has(f)) {
-        const sev = rawForLookup.find(r => r.title === f.title && r.file === f.file && r.line === f.line)?.severity ?? f.severity;
+        const sev = judgeDecisions[i].originalSeverity;
         droppedSeverities[sev] = (droppedSeverities[sev] ?? 0) + 1;
       }
-    }
+    });
 
     const judgeDroppedCount = allJudgedForDashboard.length - keptSet.size;
     const completeDashboard: DashboardData = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1062,16 +1062,18 @@ async function runFullReview(
 
     const keptSeverities: Record<string, number> = {};
     const droppedSeverities: Record<string, number> = {};
+    const keptSet = new Set(result.findings);
     for (const f of result.findings) {
       keptSeverities[f.severity] = (keptSeverities[f.severity] ?? 0) + 1;
     }
-    for (const d of judgeDecisions) {
-      if (!d.kept) {
-        droppedSeverities[d.originalSeverity] = (droppedSeverities[d.originalSeverity] ?? 0) + 1;
+    for (const f of allJudgedForDashboard) {
+      if (!keptSet.has(f)) {
+        const sev = rawForLookup.find(r => r.title === f.title && r.file === f.file && r.line === f.line)?.severity ?? f.severity;
+        droppedSeverities[sev] = (droppedSeverities[sev] ?? 0) + 1;
       }
     }
 
-    const judgeDroppedCount = judgeDecisions.filter(d => !d.kept).length;
+    const judgeDroppedCount = allJudgedForDashboard.length - keptSet.size;
     const completeDashboard: DashboardData = {
       ...dashboard,
       phase: 'complete',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1062,10 +1062,11 @@ async function runFullReview(
 
     const keptSeverities: Record<string, number> = {};
     const droppedSeverities: Record<string, number> = {};
+    for (const f of result.findings) {
+      keptSeverities[f.severity] = (keptSeverities[f.severity] ?? 0) + 1;
+    }
     for (const d of judgeDecisions) {
-      if (d.kept) {
-        keptSeverities[d.severity] = (keptSeverities[d.severity] ?? 0) + 1;
-      } else {
+      if (!d.kept) {
         droppedSeverities[d.originalSeverity] = (droppedSeverities[d.originalSeverity] ?? 0) + 1;
       }
     }
@@ -1078,6 +1079,7 @@ async function runFullReview(
       droppedCount: judgeDroppedCount,
       keptSeverities,
       droppedSeverities,
+      ...(result.testNitSuppressedCount != null && result.testNitSuppressedCount > 0 && { testNitSuppressedCount: result.testNitSuppressedCount }),
       judgeDurationMs: judgeEndTime - reviewEndTime,
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,6 +404,7 @@ export interface DashboardData {
   };
   keptSeverities?: Record<string, number>;
   droppedSeverities?: Record<string, number>;
+  testNitSuppressedCount?: number;
   plannerDurationMs?: number;
   judgeDurationMs?: number;
 }


### PR DESCRIPTION
## Summary

Closes #772.

- Aligns the `Judge — N kept · M dropped` header and `kept:` breakdown to a single source (post all suppression). The LLM judge's raw decisions remain visible in the "Judge decisions" detail block.
- Surfaces the count of test-nit-suppressed findings in the dashboard so users can see what got filtered at round ≥2.
- Adds regression tests for both invariants.

Repro: PR #760 round 5 (commit `e91a36f7`, run-id `26171409126`) had 7 judge-kept findings, all on test files, all silently suppressed. Final review reported `📊 0 findings (none)` with no indication the suppression had fired.

Milestone: [v5.1.0](https://github.com/manki-review/manki/milestone/2). Release blocker.