### PR TITLE
test: relax `plannerDurationMs` assertion to fix CI flake

### DIFF
--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -3619,7 +3619,7 @@ describe('runReview', () => {
     expect(fallback).toBeDefined();
     expect(fallback!.plannerResult).toBeUndefined();
     expect(fallback!.teamAgentNames).toEqual(result.agentNames);
-    expect(fallback!.plannerDurationMs).toBeGreaterThan(0);
+    expect(fallback!.plannerDurationMs).toBeGreaterThanOrEqual(0);
   });
 
   it('emits heuristic-fallback planning event when planner is disabled', async () => {


### PR DESCRIPTION
## Summary
- On low-resolution clocks the planner-call returns within the same `performance.now()` tick, making the duration `0` and failing the strict `> 0` assertion.
- Relax to `>= 0`: the field is set whether the planner succeeded or fell back, so `>= 0` still proves it was populated.

Closes #780