### PR TITLE
fix: drop `CORE_AGENTS` invariant, trust planner's team selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `determineVerdict` now grounds its addressed/not-addressed decision in the GitHub `isResolved` state, preventing zero-diff force-pushes from auto-resolving open warnings incorrectly (#758).
 - `Judge` kept counts and test-nit suppression surface accurately in the stats block (#773).
 - CI test flake in `plannerDurationMs` assertion resolved by relaxing the assertion to `>= 0` (#781).
+- The planner's team selection is now trusted. `selectTeam` no longer post-injects `{Security, Architecture, Correctness}` on top of the planner's picks, so a 3-agent plan stays a 3-agent review. The dashboard `Planner` line reports the actual resolved roster size instead of the planner-requested `teamSize`, matching the per-category breakdown. When the planner is unavailable, manki falls back to a conservative fixed `{Security, Architecture, Correctness}` roster. Closes [#784](https://github.com/manki-review/manki/issues/784).
 
 ### Action required for downstream installs
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1925,9 +1925,8 @@ describe('buildDashboard', () => {
   });
 
   it('renders the resolved roster size on the Planner line, not the planner-requested teamSize', () => {
-    // Regression for #784: the dashboard used to print `plannerResult.teamSize`,
-    // which could disagree with the per-category breakdown when prior-round
-    // pinning grew the actual roster beyond the planner's request.
+    // The dashboard must show the actual resolved roster count, not the planner-requested
+    // teamSize, which can diverge when prior-round pinning grows the roster.
     const data: DashboardData = {
       phase: 'started', lineCount: 120, agentCount: 5,
       plannerInfo: { agentCount: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'fix' },

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1916,7 +1916,7 @@ describe('buildDashboard', () => {
   it('renders plannerInfo with structured details', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 200, agentCount: 5,
-      plannerInfo: { teamSize: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'feat' },
+      plannerInfo: { agentCount: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'feat' },
     };
     const md = buildDashboard(data);
     expect(md).toContain('**Planner**');
@@ -1924,10 +1924,23 @@ describe('buildDashboard', () => {
     expect(md).toContain(`${INDENT}review effort: medium · judge effort: high`);
   });
 
+  it('renders the resolved roster size on the Planner line, not the planner-requested teamSize', () => {
+    // Regression for #784: the dashboard used to print `plannerResult.teamSize`,
+    // which could disagree with the per-category breakdown when prior-round
+    // pinning grew the actual roster beyond the planner's request.
+    const data: DashboardData = {
+      phase: 'started', lineCount: 120, agentCount: 5,
+      plannerInfo: { agentCount: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'fix' },
+    };
+    const md = buildDashboard(data);
+    expect(md).toContain(`${INDENT}fix · 120 lines · 5 agents`);
+    expect(md).not.toContain('3 agents');
+  });
+
   it('omits the prType chip when the value is off-vocab and never leaks the raw value', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 100, agentCount: 3,
-      plannerInfo: { teamSize: 3, reviewerEffort: 'low', judgeEffort: 'low', prType: '<script>alert(1)</script>' },
+      plannerInfo: { agentCount: 3, reviewerEffort: 'low', judgeEffort: 'low', prType: '<script>alert(1)</script>' },
     };
     const md = buildDashboard(data);
     expect(md).toContain(`${INDENT}100 lines · 3 agents`);
@@ -1938,7 +1951,7 @@ describe('buildDashboard', () => {
   it('omits the prType chip when the value is the `unknown` sentinel', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 100, agentCount: 3,
-      plannerInfo: { teamSize: 3, reviewerEffort: 'low', judgeEffort: 'low', prType: 'unknown' },
+      plannerInfo: { agentCount: 3, reviewerEffort: 'low', judgeEffort: 'low', prType: 'unknown' },
     };
     const md = buildDashboard(data);
     expect(md).toContain(`${INDENT}100 lines · 3 agents`);
@@ -1951,7 +1964,7 @@ describe('buildDashboard', () => {
     prType => {
       const data: DashboardData = {
         phase: 'started', lineCount: 50, agentCount: 2,
-        plannerInfo: { teamSize: 2, reviewerEffort: 'low', judgeEffort: 'low', prType },
+        plannerInfo: { agentCount: 2, reviewerEffort: 'low', judgeEffort: 'low', prType },
       };
       const md = buildDashboard(data);
       expect(md).toContain(`${INDENT}${prType} · 50 lines · 2 agents`);
@@ -1987,7 +2000,7 @@ describe('buildDashboard', () => {
     const data: DashboardData = {
       phase: 'complete', lineCount: 400, agentCount: 5,
       keptCount: 3, droppedCount: 5, rawFindingCount: 8,
-      plannerInfo: { teamSize: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'fix' },
+      plannerInfo: { agentCount: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'fix' },
     };
     const md = buildDashboard(data);
     expect(md).toContain('**Planner**');
@@ -1998,7 +2011,7 @@ describe('buildDashboard', () => {
   it('sanitizes unknown effort values in plannerInfo', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 100, agentCount: 3,
-      plannerInfo: { teamSize: 3, reviewerEffort: 'injected' as unknown as 'low', judgeEffort: 'high', prType: 'feat' },
+      plannerInfo: { agentCount: 3, reviewerEffort: 'injected' as unknown as 'low', judgeEffort: 'high', prType: 'feat' },
     };
     const md = buildDashboard(data);
     expect(md).toContain('review effort: unknown');
@@ -2039,7 +2052,7 @@ describe('buildDashboard', () => {
   it('renders planner duration when plannerInfo and plannerDurationMs are provided', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 200, agentCount: 5,
-      plannerInfo: { teamSize: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'feat' },
+      plannerInfo: { agentCount: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'feat' },
       plannerDurationMs: 1200,
     };
     const md = buildDashboard(data);
@@ -2058,7 +2071,7 @@ describe('buildDashboard', () => {
   it('omits planner duration when plannerDurationMs is not set', () => {
     const data: DashboardData = {
       phase: 'started', lineCount: 200, agentCount: 5,
-      plannerInfo: { teamSize: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'feat' },
+      plannerInfo: { agentCount: 5, reviewerEffort: 'medium', judgeEffort: 'high', prType: 'feat' },
     };
     const md = buildDashboard(data);
     expect(md).toContain('**Planner**');
@@ -2140,7 +2153,7 @@ describe('buildDashboard', () => {
     const data: DashboardData = {
       phase: 'complete', lineCount: 400, agentCount: 5,
       rawFindingCount: 10, keptCount: 6, droppedCount: 4,
-      plannerInfo: { teamSize: 5, reviewerEffort: 'low', judgeEffort: 'medium', prType: 'fix' },
+      plannerInfo: { agentCount: 5, reviewerEffort: 'low', judgeEffort: 'medium', prType: 'fix' },
       plannerDurationMs: 2500,
       judgeDurationMs: 65000,
     };

--- a/src/github.ts
+++ b/src/github.ts
@@ -298,7 +298,7 @@ export function buildDashboard(data: DashboardData): string {
     const summaryParts = [
       ...(prType ? [prType] : []),
       `${data.lineCount} lines`,
-      `${data.plannerInfo.teamSize} agents`,
+      `${data.plannerInfo.agentCount} agents`,
     ];
     plannerLines.push(`${INDENT}${summaryParts.join(' · ')}`);
     plannerLines.push(`${INDENT}review effort: ${sanitizeEffort(data.plannerInfo.reviewerEffort)} · judge effort: ${sanitizeEffort(data.plannerInfo.judgeEffort)}`);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3075,7 +3075,7 @@ describe('runFullReview orchestration', () => {
     expect(firstDashboard.heuristicFallback).toBeFalsy();
     expect(firstDashboard.phase).toBe('started');
     expect(firstDashboard.plannerInfo).toEqual(
-      expect.objectContaining({ teamSize: 2, reviewerEffort: 'medium' }),
+      expect.objectContaining({ agentCount: 2, reviewerEffort: 'medium' }),
     );
   });
 
@@ -3525,7 +3525,7 @@ describe('runFullReview orchestration', () => {
     const dashboardWithPlanner = dashboardCalls.find(call => call[4]?.plannerInfo !== undefined);
     expect(dashboardWithPlanner).toBeDefined();
     expect(dashboardWithPlanner![4].plannerInfo).toEqual({
-      teamSize: 3, reviewerEffort: 'low', judgeEffort: 'low', prType: 'chore',
+      agentCount: 3, reviewerEffort: 'low', judgeEffort: 'low', prType: 'chore',
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -724,13 +724,13 @@ async function runFullReview(
         if (progress.phase === 'planning') {
           core.info('Planner analyzing PR content...');
           if (progress.plannerResult) {
+            const plannerTeam = selectTeam(diff, config, config.reviewers, progress.plannerResult.teamSize, progress.plannerResult.agents, priorRoundAgents, true);
             dashboard.plannerInfo = {
-              teamSize: progress.plannerResult.teamSize,
+              agentCount: plannerTeam.agents.length,
               reviewerEffort: progress.plannerResult.reviewerEffort,
               judgeEffort: progress.plannerResult.judgeEffort,
               prType: progress.plannerResult.prType,
             };
-            const plannerTeam = selectTeam(diff, config, config.reviewers, progress.plannerResult.teamSize, progress.plannerResult.agents, priorRoundAgents, true);
             dashboard.agentCount = plannerTeam.agents.length;
             dashboard.agentProgress = plannerTeam.agents.map(a => ({ name: a.name, status: 'reviewing' as const }));
             dashboard.plannerDurationMs = progress.plannerDurationMs;
@@ -1015,20 +1015,21 @@ async function runFullReview(
       }
     }
 
-    if (result.plannerResult) {
-      dashboard.plannerInfo = {
-        teamSize: result.plannerResult.teamSize,
-        reviewerEffort: result.plannerResult.reviewerEffort,
-        judgeEffort: result.plannerResult.judgeEffort,
-        prType: result.plannerResult.prType,
-      };
-    }
     // Reconcile the dashboard with the actual resolved team. On round 2+ the
     // initial dashboard was built without priorRoundAgents (not yet loaded),
     // so the agent list would otherwise show a stale, too-small count. On
     // round 1 without a planner, agents may fail and drop out, so reconcile
     // unconditionally to keep agentCount and agentProgress accurate.
     reconcileDashboardAgents(dashboard, result.agentNames);
+
+    if (result.plannerResult) {
+      dashboard.plannerInfo = {
+        agentCount: result.agentNames.length,
+        reviewerEffort: result.plannerResult.reviewerEffort,
+        judgeEffort: result.plannerResult.judgeEffort,
+        prType: result.plannerResult.prType,
+      };
+    }
 
     const allJudgedForDashboard = result.allJudgedFindings || result.findings;
     const rawForLookup = result.rawFindings ?? allJudgedForDashboard;

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -5788,9 +5788,7 @@ describe('selectTeam planner-driven path', () => {
   });
 
   it('does not silently inflate the roster when the planner picks fewer than the requested size', () => {
-    // Regression for #784: the planner requested 3 agents but only picked 2.
-    // The roster must reflect what the planner actually picked, not get
-    // padded back up to teamSize.
+    // The roster must reflect what the planner actually picked, not get padded back up to teamSize.
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const picks: AgentPick[] = [

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1268,7 +1268,7 @@ describe('selectTeam', () => {
     expect(large.level).toBe('large');
   });
 
-  it('always includes core agents (Security, Architecture, Correctness)', () => {
+  it('always includes the fallback agents (Security, Architecture, Correctness) on the heuristic path', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const roster = selectTeam(diff, config);
@@ -1277,7 +1277,7 @@ describe('selectTeam', () => {
     expect(roster.agents.map(a => a.name)).toContain('Correctness & Logic');
   });
 
-  it('includes custom reviewers in pool and gives them a scoring boost', () => {
+  it('includes explicitly configured custom reviewers on the heuristic path', () => {
     const custom: ReviewerAgent = { name: 'Protocol Expert', focus: 'protocol compliance' };
     const diff = makeDiff({
       totalAdditions: 300,
@@ -1286,7 +1286,6 @@ describe('selectTeam', () => {
     });
     const config = makeConfig({ review_level: 'medium' });
     const roster = selectTeam(diff, config, [custom]);
-    // The +1 scoring boost should place a custom reviewer among the top candidates
     expect(roster.agents.map(a => a.name)).toContain('Protocol Expert');
   });
 
@@ -1317,7 +1316,7 @@ describe('selectTeam', () => {
     expect(roster.agents).toHaveLength(7);
   });
 
-  it('scores testing agent higher when test files are in the diff', () => {
+  it('fills heuristic roster from the pool in declared order up to teamSize', () => {
     const diff = makeDiff({
       totalAdditions: 300,
       totalDeletions: 300,
@@ -1328,7 +1327,14 @@ describe('selectTeam', () => {
     });
     const config = makeConfig({ review_level: 'medium' });
     const roster = selectTeam(diff, config);
-    expect(roster.agents.map(a => a.name)).toContain('Testing & Coverage');
+    expect(roster.agents).toHaveLength(5);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+      'Testing & Coverage',
+      'Performance & Efficiency',
+    ]);
   });
 
   it('does not add scored agents beyond teamSize when custom reviewers are present', () => {
@@ -1434,7 +1440,7 @@ describe('titlesMatch boundary', () => {
   });
 });
 
-describe('selectTeam dependency file scoring', () => {
+describe('selectTeam fallback behavior', () => {
   it('falls back to auto sizing for unrecognized review_level values', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     // Force an invalid review_level at runtime (e.g. from misconfigured YAML)
@@ -1445,7 +1451,7 @@ describe('selectTeam dependency file scoring', () => {
     expect(roster.agents).toHaveLength(3);
   });
 
-  it('scores Dependencies agent higher when package.json is in the diff', () => {
+  it('does not bias the roster toward path-keyword matches (no scoring)', () => {
     const diff = makeDiff({
       totalAdditions: 300,
       totalDeletions: 300,
@@ -1456,20 +1462,15 @@ describe('selectTeam dependency file scoring', () => {
     });
     const config = makeConfig({ review_level: 'medium' });
     const roster = selectTeam(diff, config);
-    expect(roster.agents.map(a => a.name)).toContain('Dependencies & Integration');
-  });
-
-  it('scores Dependencies agent higher when Cargo.toml is in the diff', () => {
-    const diff = makeDiff({
-      totalAdditions: 300,
-      totalDeletions: 300,
-      files: [
-        { path: 'Cargo.toml', changeType: 'modified', hunks: [] },
-      ],
-    });
-    const config = makeConfig({ review_level: 'medium' });
-    const roster = selectTeam(diff, config);
-    expect(roster.agents.map(a => a.name)).toContain('Dependencies & Integration');
+    expect(roster.agents).toHaveLength(5);
+    // Pool fill is in declared order, regardless of which files appear in the diff.
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+      'Testing & Coverage',
+      'Performance & Efficiency',
+    ]);
   });
 });
 
@@ -1810,9 +1811,8 @@ describe('intersectFindings', () => {
   });
 });
 
-describe('selectTeam maintainability scoring', () => {
-  it('scores Maintainability agent higher when diff has many files', () => {
-    // Use generic filenames that do not trigger test/server/dependency scoring
+describe('selectTeam large heuristic fill', () => {
+  it('fills the full pool in declared order when review_level is large', () => {
     const files: DiffFile[] = Array.from({ length: 8 }, (_, i) => ({
       path: `src/module${i}/handler.ts`,
       changeType: 'modified' as const,
@@ -1821,18 +1821,9 @@ describe('selectTeam maintainability scoring', () => {
     const diff = makeDiff({ totalAdditions: 600, totalDeletions: 600, files });
     const config = makeConfig({ review_level: 'large' });
     const roster = selectTeam(diff, config);
-    expect(roster.agents.map(a => a.name)).toContain('Maintainability & Readability');
-  });
-
-  it('scores Performance agent higher when server files are in the diff', () => {
-    const diff = makeDiff({
-      totalAdditions: 600,
-      totalDeletions: 600,
-      files: [{ path: 'src/server/app.ts', changeType: 'modified', hunks: [] }],
-    });
-    const config = makeConfig({ review_level: 'large' });
-    const roster = selectTeam(diff, config);
-    expect(roster.agents.map(a => a.name)).toContain('Performance & Efficiency');
+    expect(roster.agents).toHaveLength(7);
+    // teamSize=7 means the whole pool is included.
+    expect(roster.agents.map(a => a.name)).toEqual(AGENT_POOL.map(a => a.name));
   });
 });
 
@@ -4802,7 +4793,7 @@ describe('selectTeam with teamSizeOverride', () => {
     expect(roster.agents.map(a => a.name)).toContain('Correctness & Logic');
   });
 
-  it('injects all core agents when planner omits all of them', () => {
+  it('keeps planner picks as-is when none of them are fallback agents', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const picks: AgentPick[] = [
@@ -4810,80 +4801,33 @@ describe('selectTeam with teamSizeOverride', () => {
       { name: 'Maintainability & Readability', effort: 'medium' },
       { name: 'Performance & Efficiency', effort: 'low' },
     ];
-    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
-    try {
-      const roster = selectTeam(diff, config, undefined, 3, picks);
-      expect(roster.agents.map(a => a.name)).toEqual([
-        'Security & Safety',
-        'Architecture & Design',
-        'Correctness & Logic',
-        'Testing & Coverage',
-        'Maintainability & Readability',
-        'Performance & Efficiency',
-      ]);
-      expect(roster.agents).toHaveLength(6);
-      expect(roster.level).toBe('large');
-      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Security & Safety"; injecting');
-      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Architecture & Design"; injecting');
-      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Correctness & Logic"; injecting');
-    } finally {
-      infoSpy.mockRestore();
-    }
+    const roster = selectTeam(diff, config, undefined, 3, picks);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Testing & Coverage',
+      'Maintainability & Readability',
+      'Performance & Efficiency',
+    ]);
+    expect(roster.agents).toHaveLength(3);
+    expect(roster.level).toBe('small');
   });
 
-  it('injects only missing core agents when planner picks a subset', () => {
+  it('keeps a two-agent planner pick as exactly two agents', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const picks: AgentPick[] = [
       { name: 'Security & Safety', effort: 'high' },
       { name: 'Testing & Coverage', effort: 'medium' },
     ];
-    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
-    try {
-      const roster = selectTeam(diff, config, undefined, 2, picks);
-      const names = roster.agents.map(a => a.name);
-      expect(names).toEqual([
-        'Security & Safety',
-        'Architecture & Design',
-        'Correctness & Logic',
-        'Testing & Coverage',
-      ]);
-      expect(roster.agents).toHaveLength(4);
-      expect(roster.level).toBe('medium');
-      expect(names.filter(n => n === 'Security & Safety')).toHaveLength(1);
-      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Architecture & Design"; injecting');
-      expect(infoSpy).toHaveBeenCalledWith('planner omitted core agent "Correctness & Logic"; injecting');
-      expect(infoSpy).not.toHaveBeenCalledWith('planner omitted core agent "Security & Safety"; injecting');
-    } finally {
-      infoSpy.mockRestore();
-    }
+    const roster = selectTeam(diff, config, undefined, 2, picks);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Testing & Coverage',
+    ]);
+    expect(roster.agents).toHaveLength(2);
+    expect(roster.level).toBe('small');
   });
 
-  it('does not inject when planner already picks all core agents', () => {
-    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
-    const config = makeConfig();
-    const picks: AgentPick[] = [
-      { name: 'Security & Safety', effort: 'high' },
-      { name: 'Architecture & Design', effort: 'medium' },
-      { name: 'Correctness & Logic', effort: 'low' },
-    ];
-    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
-    try {
-      const roster = selectTeam(diff, config, undefined, 3, picks);
-      expect(roster.agents.map(a => a.name)).toEqual([
-        'Security & Safety',
-        'Architecture & Design',
-        'Correctness & Logic',
-      ]);
-      expect(roster.agents).toHaveLength(3);
-      expect(roster.level).toBe('small');
-      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('planner omitted core agent'));
-    } finally {
-      infoSpy.mockRestore();
-    }
-  });
-
-  it('reorders core agents to CORE_AGENTS sequence when planner picks them out of order', () => {
+  it('preserves planner pick order, including for fallback agents', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const picks: AgentPick[] = [
@@ -4891,20 +4835,32 @@ describe('selectTeam with teamSizeOverride', () => {
       { name: 'Security & Safety', effort: 'high' },
       { name: 'Architecture & Design', effort: 'medium' },
     ];
-    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
-    try {
-      const roster = selectTeam(diff, config, undefined, 3, picks);
-      expect(roster.agents.map(a => a.name)).toEqual([
-        'Security & Safety',
-        'Architecture & Design',
-        'Correctness & Logic',
-      ]);
-      expect(roster.agents).toHaveLength(3);
-      expect(roster.level).toBe('small');
-      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('planner omitted core agent'));
-    } finally {
-      infoSpy.mockRestore();
-    }
+    const roster = selectTeam(diff, config, undefined, 3, picks);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Correctness & Logic',
+      'Security & Safety',
+      'Architecture & Design',
+    ]);
+    expect(roster.agents).toHaveLength(3);
+    expect(roster.level).toBe('small');
+  });
+
+  it('does not duplicate fallback agents when the planner picks them', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 3, picks);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+    ]);
+    expect(roster.agents).toHaveLength(3);
+    expect(roster.level).toBe('small');
   });
 
   it('round 2 reuses round 1 team verbatim when planner adds nothing', () => {
@@ -5757,7 +5713,7 @@ describe('parseAgentPicks', () => {
 });
 
 describe('selectTeam planner-driven path', () => {
-  it('uses specified agents instead of heuristic scoring', () => {
+  it('uses the planner picks as the final roster, with no core injection', () => {
     const diff = makeDiff({ totalAdditions: 50, totalDeletions: 10 });
     const config = makeConfig();
     const picks: AgentPick[] = [
@@ -5766,18 +5722,16 @@ describe('selectTeam planner-driven path', () => {
       { name: 'Maintainability & Readability', effort: 'low' },
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
-    // Core agents are injected at the front, planner picks follow.
     expect(roster.agents.map(a => a.name)).toEqual([
-      'Security & Safety',
-      'Architecture & Design',
-      'Correctness & Logic',
       'Performance & Efficiency',
       'Dependencies & Integration',
       'Maintainability & Readability',
     ]);
+    expect(roster.agents).toHaveLength(3);
+    expect(roster.level).toBe('small');
   });
 
-  it('deduplicates agent picks', () => {
+  it('deduplicates repeated names in the planner picks', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const picks: AgentPick[] = [
@@ -5786,14 +5740,13 @@ describe('selectTeam planner-driven path', () => {
       { name: 'Correctness & Logic', effort: 'low' },
     ];
     const roster = selectTeam(diff, config, undefined, 3, picks);
-    // Duplicate Security pick is dropped. Architecture is injected as missing core.
-    // Core agents appear in CORE_AGENTS order (Security, Architecture, Correctness).
-    expect(roster.agents).toHaveLength(3);
+    // The duplicate Security pick is dropped; no other agent is added on top.
+    expect(roster.agents).toHaveLength(2);
     expect(roster.agents.map(a => a.name)).toEqual([
       'Security & Safety',
-      'Architecture & Design',
       'Correctness & Logic',
     ]);
+    expect(roster.level).toBe('small');
   });
 
   it('assigns correct level based on resolved count', () => {
@@ -5817,18 +5770,39 @@ describe('selectTeam planner-driven path', () => {
     expect(selectTeam(diff, config, undefined, 7, picks7).level).toBe('large');
   });
 
-  it('falls back to heuristic when all picks resolve to unknown names', () => {
+  it('falls back to the fixed roster when all picks resolve to unknown names', () => {
     const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
     const config = makeConfig();
     const picks: AgentPick[] = [
       { name: 'Fake Agent A', effort: 'high' },
       { name: 'Fake Agent B', effort: 'medium' },
     ];
-    // agentPicks entries won't resolve from pool, resolved is empty, falls through
+    // None of the picks resolve, so the planner-success branch is skipped and
+    // the heuristic path runs with teamSizeOverride=3 (yielding the fallback roster).
     const roster = selectTeam(diff, config, undefined, 3, picks);
-    // Falls through to heuristic — should get 3 agents from scoring
-    expect(roster.agents).toHaveLength(3);
-    expect(roster.agents.every(a => AGENT_POOL.some(p => p.name === a.name))).toBe(true);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+    ]);
+  });
+
+  it('does not silently inflate the roster when the planner picks fewer than the requested size', () => {
+    // Regression for #784: the planner requested 3 agents but only picked 2.
+    // The roster must reflect what the planner actually picked, not get
+    // padded back up to teamSize.
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Performance & Efficiency', effort: 'high' },
+      { name: 'Testing & Coverage', effort: 'medium' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 3, picks);
+    expect(roster.agents).toHaveLength(2);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Performance & Efficiency',
+      'Testing & Coverage',
+    ]);
   });
 });
 

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -5804,6 +5804,37 @@ describe('selectTeam planner-driven path', () => {
       'Testing & Coverage',
     ]);
   });
+
+  it('keeps all planner picks when the LLM returns more agents than teamSize', () => {
+    const diff = makeDiff({ totalAdditions: 10, totalDeletions: 5 });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Architecture & Design', effort: 'medium' },
+      { name: 'Correctness & Logic', effort: 'low' },
+      { name: 'Testing & Coverage', effort: 'low' },
+      { name: 'Performance & Efficiency', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 3, picks);
+    expect(roster.agents).toHaveLength(5);
+    expect(roster.agents.map(a => a.name)).toEqual([
+      'Security & Safety',
+      'Architecture & Design',
+      'Correctness & Logic',
+      'Testing & Coverage',
+      'Performance & Efficiency',
+    ]);
+  });
+});
+
+describe('selectTeam heuristic path (planner disabled)', () => {
+  it('honors review_level when planner is disabled, not failed', () => {
+    const diff = makeDiff({ totalAdditions: 600, totalDeletions: 600 });
+    const config = makeConfig({ review_level: 'large' });
+    const roster = selectTeam(diff, config, undefined, undefined, undefined);
+    expect(roster.agents).toHaveLength(7);
+    expect(roster.level).toBe('large');
+  });
 });
 
 describe('buildReviewerSystemPrompt sanitized context', () => {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -5825,6 +5825,52 @@ describe('selectTeam planner-driven path', () => {
       'Performance & Efficiency',
     ]);
   });
+
+  it('force-adds Security & Safety when planner omits it and diff touches security-sensitive paths', () => {
+    const diff = makeDiff({
+      totalAdditions: 10,
+      totalDeletions: 5,
+      files: [{ path: 'src/auth/login.ts', changeType: 'modified', hunks: [] }],
+    });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Correctness & Logic', effort: 'medium' },
+      { name: 'Architecture & Design', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 2, picks);
+    expect(roster.agents.map(a => a.name)).toContain('Security & Safety');
+  });
+
+  it('does not force-add Security & Safety when diff has no security-sensitive paths', () => {
+    const diff = makeDiff({
+      totalAdditions: 10,
+      totalDeletions: 5,
+      files: [{ path: 'src/formatting/pretty-print.ts', changeType: 'modified', hunks: [] }],
+    });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Correctness & Logic', effort: 'medium' },
+      { name: 'Architecture & Design', effort: 'low' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 2, picks);
+    expect(roster.agents.map(a => a.name)).not.toContain('Security & Safety');
+  });
+
+  it('does not duplicate Security & Safety when it is already in the planner picks', () => {
+    const diff = makeDiff({
+      totalAdditions: 10,
+      totalDeletions: 5,
+      files: [{ path: 'src/auth/session.ts', changeType: 'modified', hunks: [] }],
+    });
+    const config = makeConfig();
+    const picks: AgentPick[] = [
+      { name: 'Security & Safety', effort: 'high' },
+      { name: 'Correctness & Logic', effort: 'medium' },
+    ];
+    const roster = selectTeam(diff, config, undefined, 2, picks);
+    const secCount = roster.agents.filter(a => a.name === 'Security & Safety').length;
+    expect(secCount).toBe(1);
+  });
 });
 
 describe('selectTeam heuristic path (planner disabled)', () => {

--- a/src/review.ts
+++ b/src/review.ts
@@ -62,6 +62,26 @@ export const AGENT_POOL: readonly ReviewerAgent[] = Object.freeze([
 // only a conservative default when no planner judgment is available.
 const FALLBACK_AGENTS: readonly number[] = Object.freeze([0, 1, 2]);
 
+// Path substrings that indicate security-sensitive files. Used as a code-level
+// backstop: if the planner omits Security & Safety but the diff touches one of
+// these paths, the agent is force-added regardless of planner output. This
+// guard is narrow by design: it only targets the Security agent and only fires
+// when a sensitive path is detected, so it cannot be silenced by prompt
+// injection in the PR content.
+const SECURITY_SENSITIVE_SUBSTRINGS: readonly string[] = Object.freeze([
+  'auth', 'oauth', 'token', 'secret', 'credential', 'password', 'passwd',
+  'crypto', 'cipher', 'encrypt', 'decrypt', 'hash', 'hmac', 'sign', 'verify',
+  'jwt', 'session', 'cookie', 'permission', 'acl', 'rbac', 'privilege',
+  'key', 'cert', 'tls', 'ssl', 'https',
+]);
+
+function hasSensitivePaths(diff: ParsedDiff): boolean {
+  return diff.files.some(f => {
+    const lower = f.path.toLowerCase();
+    return SECURITY_SENSITIVE_SUBSTRINGS.some(sub => lower.includes(sub));
+  });
+}
+
 export const TRIVIAL_VERIFIER_AGENT: ReviewerAgent = Object.freeze({
   name: 'Trivial Change Verifier',
   focus: 'Review this trivial change on two fronts: (1) check the actual content for issues appropriate to the change type — typos, stale references, broken markdown/links, incomplete renames; (2) verify the change is actually trivial as classified and flag any hidden behavior change, security implication, broken invariant, or missing test that would contradict that assessment.',
@@ -159,13 +179,23 @@ export function selectTeam(
     if (resolved.length > 0) {
       // Pin prior-round agents first (preserving their order), then append
       // any new planner picks. Deduplication keeps the prior order stable.
-      // The planner's selection stands as-is: no post-hoc injection of
-      // additional agents. The planner sees the full PR context and is
-      // trusted to pick the right specialists.
       const final: ReviewerAgent[] = [...priorAgents];
       for (const agent of resolved) {
         if (!final.some(u => u.name === agent.name)) final.push(agent);
       }
+
+      // Code-level security backstop: if the planner omitted Security & Safety
+      // but the diff touches security-sensitive paths, force-add it. The planner
+      // receives untrusted PR content and prompt injection in diff comments or
+      // string literals could suppress the security specialist on a sensitive
+      // change. This guard is path-based, not prompt-based, so it cannot be
+      // bypassed by injected instructions.
+      const securityAgent = pool.find(a => a.name === 'Security & Safety');
+      if (securityAgent && !final.some(a => a.name === 'Security & Safety') && hasSensitivePaths(diff)) {
+        if (!silent) core.info('Security & Safety force-added: planner omitted it but diff touches security-sensitive paths');
+        final.push(securityAgent);
+      }
+
       logPinAudit(final, priorNames, silent);
 
       let level: 'trivial' | 'small' | 'medium' | 'large';

--- a/src/review.ts
+++ b/src/review.ts
@@ -580,6 +580,11 @@ export async function runPlanner(
 function heuristicFallback(
   diff: ParsedDiff,
   config: ReviewConfig,
+  /**
+   * Agents from prior rounds to carry forward for continuity. Intentionally
+   * ignored when `forceFixedRoster=true` — the fixed failure roster must be
+   * exact, so prior-round pinning is suppressed on the planner-failure path.
+   */
   priorRoundAgents?: string[],
   /**
    * When `true`, ignore `review_level` and force the conservative fixed roster

--- a/src/review.ts
+++ b/src/review.ts
@@ -614,7 +614,7 @@ function heuristicFallback(
   config: ReviewConfig,
   /**
    * Agents from prior rounds to carry forward for continuity. Intentionally
-   * ignored when `forceFixedRoster=true` — the fixed failure roster must be
+   * ignored when `forceFixedRoster=true`: the fixed failure roster must be
    * exact, so prior-round pinning is suppressed on the planner-failure path.
    */
   priorRoundAgents?: string[],

--- a/src/review.ts
+++ b/src/review.ts
@@ -706,7 +706,7 @@ export async function runReview(
       }
     } else {
       // Planner was attempted and failed. Force the fixed three-core roster.
-      team = heuristicFallback(diff, config, priorRoundAgents, true);
+      team = heuristicFallback(diff, config, undefined, true);
       if (onProgress) {
         emitHeuristicFallbackPlanning(onProgress, team, plannerDurationMs);
       }

--- a/src/review.ts
+++ b/src/review.ts
@@ -590,7 +590,7 @@ function heuristicFallback(
   forceFixedRoster?: boolean,
 ): TeamRoster {
   const team = forceFixedRoster
-    ? selectTeam(diff, config, config.reviewers, 3, undefined, priorRoundAgents)
+    ? selectTeam(diff, config, undefined, 3, undefined, undefined)
     : selectTeam(diff, config, config.reviewers, undefined, undefined, priorRoundAgents);
   core.info(`Review team (${team.level}): ${team.agents.map(a => a.name).join(', ')}`);
   return team;

--- a/src/review.ts
+++ b/src/review.ts
@@ -56,7 +56,11 @@ export const AGENT_POOL: readonly ReviewerAgent[] = Object.freeze([
   },
 ]);
 
-const CORE_AGENTS: readonly number[] = Object.freeze([0, 1, 2]);
+// Fixed fallback roster used when the planner LLM is unavailable. Indexes into
+// `AGENT_POOL`: Security & Safety, Architecture & Design, Correctness & Logic.
+// The planner is trusted to pick agents on the success path; these three are
+// only a conservative default when no planner judgment is available.
+const FALLBACK_AGENTS: readonly number[] = Object.freeze([0, 1, 2]);
 
 export const TRIVIAL_VERIFIER_AGENT: ReviewerAgent = Object.freeze({
   name: 'Trivial Change Verifier',
@@ -69,29 +73,6 @@ export function buildAgentPool(customReviewers?: ReviewerAgent[]): ReviewerAgent
     if (!pool.some(p => p.name === custom.name)) pool.push(custom);
   }
   return pool;
-}
-
-// Ensures all CORE_AGENTS are present in the resolved team. Returns the agents
-// reordered so that core agents come first in CORE_AGENTS order (injecting any
-// that the planner omitted), followed by non-core planner picks in their
-// original planner order. Core inviolability supersedes teamSizeOverride.
-// The final roster may exceed the planner-requested size.
-function injectMissingCoreAgents(
-  resolved: ReviewerAgent[],
-  pool: ReviewerAgent[],
-): ReviewerAgent[] {
-  const coreSet = new Set(CORE_AGENTS.map(i => pool[i].name));
-  const orderedCore: ReviewerAgent[] = CORE_AGENTS.map(i => {
-    const coreAgent = pool[i];
-    const plannerPicked = resolved.find(r => r.name === coreAgent.name);
-    if (plannerPicked) {
-      return plannerPicked;
-    }
-    core.info(`planner omitted core agent "${coreAgent.name}"; injecting`);
-    return coreAgent;
-  });
-  const nonCore = resolved.filter(r => !coreSet.has(r.name));
-  return [...orderedCore, ...nonCore];
 }
 
 // Resolves prior-round agent names against the current pool. Names that no
@@ -178,18 +159,17 @@ export function selectTeam(
     if (resolved.length > 0) {
       // Pin prior-round agents first (preserving their order), then append
       // any new planner picks. Deduplication keeps the prior order stable.
-      const unioned: ReviewerAgent[] = [...priorAgents];
+      // The planner's selection stands as-is: no post-hoc injection of
+      // additional agents. The planner sees the full PR context and is
+      // trusted to pick the right specialists.
+      const final: ReviewerAgent[] = [...priorAgents];
       for (const agent of resolved) {
-        if (!unioned.some(u => u.name === agent.name)) unioned.push(agent);
+        if (!final.some(u => u.name === agent.name)) final.push(agent);
       }
-      // Core inviolability: CORE_AGENTS are always present regardless of
-      // teamSizeOverride, so the final roster may exceed that value.
-      const final = injectMissingCoreAgents(unioned, pool);
       logPinAudit(final, priorNames, silent);
 
       let level: 'trivial' | 'small' | 'medium' | 'large';
-      if (final.length === 1) level = 'small';
-      else if (final.length <= 3) level = 'small';
+      if (final.length <= 3) level = 'small';
       else if (final.length <= 5) level = 'medium';
       else level = 'large';
       return { level, agents: final, lineCount };
@@ -218,60 +198,33 @@ export function selectTeam(
     teamSize = level === 'small' ? 3 : level === 'medium' ? 5 : 7;
   }
 
-  // Core agents always included, then prior-round agents (so prior order matches
-  // the planner path: prior-first, new additions last), then custom reviewers.
-  const selected: ReviewerAgent[] = CORE_AGENTS.map(i => pool[i]);
+  // Heuristic / fallback roster: start from the fixed fallback specialists,
+  // then pin prior-round agents, then add explicitly configured custom
+  // reviewers. Any remaining slots up to `teamSize` are filled from the pool
+  // in declared order. No path-keyword scoring lives here: the planner is the
+  // only place where PR context drives agent selection. When the planner is
+  // unavailable, the fallback stays conservative and predictable.
+  const selected: ReviewerAgent[] = FALLBACK_AGENTS.map(i => pool[i]);
 
-  // Pin prior-round agents next so the heuristic path preserves the same
-  // "prior first, new last" insertion order as the planner path.
   for (const agent of priorAgents) {
     if (!selected.some(s => s.name === agent.name)) {
       selected.push(agent);
     }
   }
 
-  // Custom reviewers always included (they were explicitly configured)
   for (const custom of (customReviewers || [])) {
     if (!selected.some(s => s.name === custom.name)) {
       selected.push(custom);
     }
   }
 
-  // Custom reviewers may push count above teamSize (intentional — they were explicitly configured).
-  // Only fill remaining slots if we haven't already reached teamSize.
   if (selected.length < teamSize) {
-    const paths = diff.files.map(f => f.path.toLowerCase());
-    const selectedNames = new Set(selected.map(s => s.name));
-
-    const candidates = pool.filter(a => !selectedNames.has(a.name)).map(agent => {
-      let score = 0;
-      const focus = agent.focus.toLowerCase();
-
-      if (focus.includes('test') && paths.some(p => p.includes('test'))) score += 3;
-
-      if ((focus.includes('performance') || focus.includes('efficiency')) &&
-        paths.some(p =>
-          p === 'index.ts' || p === 'index.js' || p === 'main.ts' || p === 'main.rs' ||
-          p.endsWith('/index.ts') || p.endsWith('/index.js') ||
-          p.endsWith('/main.ts') || p.endsWith('/main.rs') ||
-          p.includes('/server')
-        )) score += 2;
-
-      if (focus.includes('maintainab') && diff.files.length > 5) score += 2;
-
-      if ((focus.includes('dependencies') || focus.includes('dependency')) && paths.some(p =>
-        p.includes('package.json') || p.includes('cargo.toml') || p.includes('requirements')
-      )) score += 3;
-
-      const isCustom = !AGENT_POOL.some(p => p.name === agent.name);
-      if (isCustom) score += 1;
-
-      return { agent, score };
-    });
-
-    candidates.sort((a, b) => b.score - a.score);
-    const additional = candidates.slice(0, teamSize - selected.length).map(c => c.agent);
-    selected.push(...additional);
+    for (const agent of pool) {
+      if (selected.length >= teamSize) break;
+      if (!selected.some(s => s.name === agent.name)) {
+        selected.push(agent);
+      }
+    }
   }
 
   logPinAudit(selected, priorNames, silent);
@@ -462,6 +415,7 @@ ${hintsBlock}Decide:
    - 6-7: security/crypto-critical, architectural overhauls
 2. agents: pick exactly teamSize agents from the pool below, each with an effort level ("low", "medium", or "high"):
 ${agentList}
+   Your picks stand as-is, no agent is auto-added on top. Include "Security & Safety" whenever the change could plausibly affect a security surface (authentication, authorization, parsers, deserialization, network handlers, file or process operations, permission checks, token or secret handling, cryptography). Judge the change, not the filename: a small auth tweak warrants Security even when the diff is tiny.
    Effort controls thinking depth and cost. low = fast pass, no extended reasoning. medium = moderate reasoning (~5K thinking tokens). high = deep analysis (~10K thinking tokens). Higher effort catches subtle bugs but costs more. Match effort to the risk level of each agent's assignment — security on auth code needs high, maintainability on a rename needs low.
    - low: the agent's specialty is not very relevant to this PR
    - medium: standard relevance
@@ -627,8 +581,17 @@ function heuristicFallback(
   diff: ParsedDiff,
   config: ReviewConfig,
   priorRoundAgents?: string[],
+  /**
+   * When `true`, ignore `review_level` and force the conservative fixed roster
+   * of {Security, Architecture, Correctness}. Used when the planner is
+   * unavailable so failures stay predictable. When `false`, honor the
+   * configured `review_level` (the user explicitly opted out of the planner).
+   */
+  forceFixedRoster?: boolean,
 ): TeamRoster {
-  const team = selectTeam(diff, config, config.reviewers, undefined, undefined, priorRoundAgents);
+  const team = forceFixedRoster
+    ? selectTeam(diff, config, config.reviewers, 3, undefined, priorRoundAgents)
+    : selectTeam(diff, config, config.reviewers, undefined, undefined, priorRoundAgents);
   core.info(`Review team (${team.level}): ${team.agents.map(a => a.name).join(', ')}`);
   return team;
 }
@@ -737,13 +700,16 @@ export async function runReview(
         onProgress({ phase: 'planning', rawFindingCount: 0, plannerResult, plannerDurationMs });
       }
     } else {
-      team = heuristicFallback(diff, config, priorRoundAgents);
+      // Planner was attempted and failed. Force the fixed three-core roster.
+      team = heuristicFallback(diff, config, priorRoundAgents, true);
       if (onProgress) {
         emitHeuristicFallbackPlanning(onProgress, team, plannerDurationMs);
       }
     }
   } else {
-    team = heuristicFallback(diff, config, priorRoundAgents);
+    // Planner is disabled (either no client or user pinned `review_level`).
+    // Honor the configured `review_level` so explicit user choice is preserved.
+    team = heuristicFallback(diff, config, priorRoundAgents, false);
     if (onProgress) {
       emitHeuristicFallbackPlanning(onProgress, team);
     }

--- a/src/review.ts
+++ b/src/review.ts
@@ -590,7 +590,7 @@ function heuristicFallback(
   forceFixedRoster?: boolean,
 ): TeamRoster {
   const team = forceFixedRoster
-    ? selectTeam(diff, config, undefined, 3, undefined, undefined)
+    ? selectTeam(diff, config, undefined, FALLBACK_AGENTS.length as 1 | 2 | 3 | 4 | 5 | 6 | 7, undefined, undefined)
     : selectTeam(diff, config, config.reviewers, undefined, undefined, priorRoundAgents);
   core.info(`Review team (${team.level}): ${team.agents.map(a => a.name).join(', ')}`);
   return team;

--- a/src/review.ts
+++ b/src/review.ts
@@ -62,24 +62,26 @@ export const AGENT_POOL: readonly ReviewerAgent[] = Object.freeze([
 // only a conservative default when no planner judgment is available.
 const FALLBACK_AGENTS: readonly number[] = Object.freeze([0, 1, 2]);
 
-// Path substrings that indicate security-sensitive files. Used as a code-level
+// Path segment prefixes that indicate security-sensitive files. Used as a code-level
 // backstop: if the planner omits Security & Safety but the diff touches one of
 // these paths, the agent is force-added regardless of planner output. This
 // guard is narrow by design: it only targets the Security agent and only fires
 // when a sensitive path is detected, so it cannot be silenced by prompt
 // injection in the PR content.
-const SECURITY_SENSITIVE_SUBSTRINGS: readonly string[] = Object.freeze([
+const SECURITY_SENSITIVE_PREFIXES: readonly string[] = Object.freeze([
   'auth', 'oauth', 'token', 'secret', 'credential', 'password', 'passwd',
-  'crypto', 'cipher', 'encrypt', 'decrypt', 'hash', 'hmac', 'sign', 'verify',
+  'crypto', 'cipher', 'encrypt', 'decrypt', 'hmac', 'sign',
   'jwt', 'session', 'cookie', 'permission', 'acl', 'rbac', 'privilege',
   'key', 'cert', 'tls', 'ssl', 'https',
 ]);
 
 function hasSensitivePaths(diff: ParsedDiff): boolean {
-  return diff.files.some(f => {
-    const lower = f.path.toLowerCase();
-    return SECURITY_SENSITIVE_SUBSTRINGS.some(sub => lower.includes(sub));
-  });
+  return diff.files.some(f =>
+    f.path.toLowerCase().split('/').some(segment => {
+      const base = segment.replace(/\.[^.]+$/, '');
+      return SECURITY_SENSITIVE_PREFIXES.some(prefix => base.startsWith(prefix));
+    }),
+  );
 }
 
 export const TRIVIAL_VERIFIER_AGENT: ReviewerAgent = Object.freeze({

--- a/src/types.ts
+++ b/src/types.ts
@@ -397,7 +397,13 @@ export interface DashboardData {
   droppedCount?: number;
   agentProgress?: AgentProgressEntry[];
   plannerInfo?: {
-    teamSize: PlannerResult['teamSize'];
+    /**
+     * Size of the final resolved roster (after prior-round pinning and any
+     * other adjustments), not the raw `teamSize` the planner asked for. The
+     * dashboard `Planner` line renders this so users see the actual number of
+     * agents that ran.
+     */
+    agentCount: number;
     reviewerEffort: EffortLevel;
     judgeEffort: EffortLevel;
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,9 +399,7 @@ export interface DashboardData {
   plannerInfo?: {
     /**
      * Size of the final resolved roster (after prior-round pinning and any
-     * other adjustments), not the raw `teamSize` the planner asked for. The
-     * dashboard `Planner` line renders this so users see the actual number of
-     * agents that ran.
+     * other adjustments), not the raw `teamSize` the planner asked for.
      */
     agentCount: number;
     reviewerEffort: EffortLevel;


### PR DESCRIPTION
## Summary

- `selectTeam` no longer post-injects `{Security, Architecture, Correctness}` on top of a successful planner result. A 3-agent plan now stays a 3-agent review.
- Dashboard `Planner` line reports the resolved roster size (`team.agents.length`) instead of the planner-requested `teamSize`, matching the per-category breakdown.
- When the planner LLM is unavailable (timeout / error), manki falls back to a conservative fixed `{Security, Architecture, Correctness}` roster. Explicit `review_level` config still controls roster size for users who opted in.

Visible symptom (now fixed): patchly PR #46 round at `2026-05-21T11:28:02Z` showed "3 agents" while five categories ran with real per-agent timings.

Closes #784