### PR TITLE
fix: bump `PLANNER_TIMEOUT_MS` from 30s to 60s

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -11,7 +11,7 @@ import { extractJSON } from './json';
 
 const DISMISSED_LINE_TOLERANCE = 5;
 
-export const PLANNER_TIMEOUT_MS = 30_000;
+export const PLANNER_TIMEOUT_MS = 60_000;
 
 class PlannerTimeoutError extends Error {
   constructor() {


### PR DESCRIPTION
## Summary

- Raises `PLANNER_TIMEOUT_MS` in `src/review.ts` from `30_000` to `60_000`.
- Motivation: [PR #785](https://github.com/manki-review/manki/pull/785) hit the 30s planner timeout and fell back to the heuristic team. The three prior rounds on that same PR completed planning in 16 to 20 seconds, so the tail is variable and 30s is too tight. Doubling to 60s keeps the safety net for genuine hangs while absorbing normal API latency variance.
- No test changes needed. `src/review.test.ts` already imports `PLANNER_TIMEOUT_MS` for its `returns null on timeout` case, so the fake-timer advance scales automatically.