### PR TITLE
chore: prevent `package.json`/`CHANGELOG.md` version drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+      - name: Check package.json and CHANGELOG.md versions agree
+        run: node scripts/check-changelog-version.js
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+# Release process
+
+This document captures the mechanics of cutting a Manki release. Keep it short, keep it accurate.
+
+## Joint version bump (enforced by CI)
+
+When you add a new `## [X.Y.Z]` heading to `CHANGELOG.md`, you MUST bump `package.json` and `package-lock.json` to the same `X.Y.Z` in the same commit.
+
+CI enforces this: `scripts/check-changelog-version.js` runs on every PR and on `main`, and fails if `package.json` `version` does not match the most recent non-`Unreleased` `## [X.Y.Z]` heading in `CHANGELOG.md`. The check was added after `v5.0.0` and `v5.0.1` shipped with `package.json` still pinned at `4.7.0` (see [#783](https://github.com/manki-review/manki/issues/783)).
+
+To run the check locally:
+
+```sh
+npm run check-changelog-version
+```
+
+## Release PR checklist
+
+1. Move entries out of `## [Unreleased]` and into a new `## [X.Y.Z] - YYYY-MM-DD` heading in `CHANGELOG.md`.
+2. Bump `version` in `package.json` to `X.Y.Z`.
+3. Refresh `package-lock.json` (`npm install` will do it).
+4. Open the release PR. CI runs `check-changelog-version` automatically.
+5. Once merged, tag `vX.Y.Z` on `main`. The `Release` workflow (`.github/workflows/release.yml`) compiles `dist/`, force-updates the major version tag (`vX`), and publishes the GitHub Release.
+
+## Why all three files in one commit
+
+The published action consumers reference the major tag (`vX`), but anyone inspecting the repo via `npm`, `package.json`, or the GitHub UI expects `package.json` and `CHANGELOG.md` to agree. Splitting the bump across PRs is what allowed the `v5.0.0` / `v5.0.1` drift in the first place. The CI check makes the joint bump non-optional.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest --passWithNoTests",
     "smoke": "tsx scripts/smoke.ts",
+    "check-changelog-version": "node scripts/check-changelog-version.js",
     "all": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "repository": {

--- a/scripts/check-changelog-version.js
+++ b/scripts/check-changelog-version.js
@@ -24,13 +24,13 @@ const changelog = fs.readFileSync(changelogPath, 'utf8');
 
 // Accept `## [X.Y.Z]`, `## [X.Y.Z] - YYYY-MM-DD`, or defensively `## X.Y.Z`.
 // Skip the `Unreleased` placeholder so the check tracks the latest real release.
-const headingRe = /^##\s+\[?([^\]\s]+)\]?(?:\s*-\s*\S+)?\s*$/gm;
+const headingRe = /^##\s+\[?([^\]\s]+)\]?(?:\s*-\s*\S.*)?\s*$/gm;
 let changelogVersion = null;
 let match;
 while ((match = headingRe.exec(changelog)) !== null) {
   const candidate = match[1];
   if (candidate.toLowerCase() === 'unreleased') continue;
-  if (!/^\d+\.\d+\.\d+/.test(candidate)) continue;
+  if (!/^\d+\.\d+\.\d+$/.test(candidate)) continue;
   changelogVersion = candidate;
   break;
 }

--- a/scripts/check-changelog-version.js
+++ b/scripts/check-changelog-version.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/*
+ * Fails if `package.json` `version` does not match the most recent
+ * non-`Unreleased` `## [X.Y.Z]` heading in `CHANGELOG.md`. Guards against
+ * shipping a release tag without bumping `package.json` (the v5.0.0 / v5.0.1
+ * drift that motivated this check).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const pkgPath = path.join(repoRoot, 'package.json');
+const changelogPath = path.join(repoRoot, 'CHANGELOG.md');
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const pkgVersion = pkg.version;
+if (typeof pkgVersion !== 'string' || pkgVersion.length === 0) {
+  console.error('error: `package.json` is missing a `version` field');
+  process.exit(2);
+}
+
+const changelog = fs.readFileSync(changelogPath, 'utf8');
+
+// Accept `## [X.Y.Z]`, `## [X.Y.Z] - YYYY-MM-DD`, or defensively `## X.Y.Z`.
+// Skip the `Unreleased` placeholder so the check tracks the latest real release.
+const headingRe = /^##\s+\[?([^\]\s]+)\]?(?:\s*-\s*\S+)?\s*$/gm;
+let changelogVersion = null;
+let match;
+while ((match = headingRe.exec(changelog)) !== null) {
+  const candidate = match[1];
+  if (candidate.toLowerCase() === 'unreleased') continue;
+  if (!/^\d+\.\d+\.\d+/.test(candidate)) continue;
+  changelogVersion = candidate;
+  break;
+}
+
+if (changelogVersion === null) {
+  console.error('error: no `## [X.Y.Z]` release heading found in `CHANGELOG.md`');
+  process.exit(2);
+}
+
+if (pkgVersion !== changelogVersion) {
+  console.error(
+    `error: \`package.json\` version (${pkgVersion}) does not match the most recent ` +
+      `\`CHANGELOG.md\` release heading (${changelogVersion}).\n` +
+      'When adding a new `## [X.Y.Z]` heading, bump `package.json` and `package-lock.json` in the same commit. ' +
+      'See RELEASE.md.',
+  );
+  process.exit(1);
+}
+
+console.log(`ok: package.json and CHANGELOG.md agree on version ${pkgVersion}`);

--- a/scripts/check-changelog-version.test.ts
+++ b/scripts/check-changelog-version.test.ts
@@ -1,0 +1,105 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const realScriptPath = path.resolve(__dirname, 'check-changelog-version.js');
+
+/**
+ * Runs the script with synthetic package.json and CHANGELOG.md by mirroring
+ * the repo layout in a temp dir: temp/scripts/check-changelog-version.js
+ * with temp/package.json and temp/CHANGELOG.md alongside it, so __dirname
+ * resolves correctly.
+ */
+function run(
+  pkgVersion: string | null,
+  changelogContent: string,
+): { exitCode: number; stdout: string; stderr: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'changelog-check-'));
+  try {
+    const scriptsDir = path.join(dir, 'scripts');
+    fs.mkdirSync(scriptsDir);
+    fs.copyFileSync(realScriptPath, path.join(scriptsDir, 'check-changelog-version.js'));
+
+    const pkg = pkgVersion === null ? {} : { version: pkgVersion };
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+    fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), changelogContent);
+
+    try {
+      const stdout = execFileSync(
+        process.execPath,
+        [path.join(scriptsDir, 'check-changelog-version.js')],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      return { exitCode: 0, stdout, stderr: '' };
+    } catch (err: unknown) {
+      const e = err as { status?: number; stdout?: string; stderr?: string };
+      return {
+        exitCode: e.status ?? 1,
+        stdout: e.stdout ?? '',
+        stderr: e.stderr ?? '',
+      };
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('check-changelog-version', () => {
+  describe('exit 0 — versions match', () => {
+    it('matches a bracketed heading without date', () => {
+      const result = run('1.2.3', '## [1.2.3]\n\n- change\n');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('1.2.3');
+    });
+
+    it('matches a bracketed heading with date', () => {
+      const result = run('1.2.3', '## [1.2.3] - 2024-01-15\n\n- change\n');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('matches a bracketed heading with trailing annotation', () => {
+      const result = run('1.2.3', '## [1.2.3] - 2024-01-15 (hotfix)\n\n- change\n');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('skips an Unreleased heading and matches the next real release', () => {
+      const changelog = '## [Unreleased]\n\n- wip\n\n## [1.2.3] - 2024-01-01\n\n- done\n';
+      const result = run('1.2.3', changelog);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('picks the first (most recent) release when multiple headings exist', () => {
+      const changelog = '## [2.0.0] - 2025-01-01\n\n## [1.0.0] - 2024-01-01\n';
+      const result = run('2.0.0', changelog);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('exit 1 — version mismatch', () => {
+    it('exits 1 when package.json version differs from CHANGELOG heading', () => {
+      const result = run('1.2.3', '## [1.2.4] - 2024-01-01\n\n- change\n');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('does not match');
+    });
+  });
+
+  describe('exit 2 — bad input', () => {
+    it('exits 2 when package.json has no version field', () => {
+      const result = run(null, '## [1.0.0] - 2024-01-01\n');
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('missing a `version` field');
+    });
+
+    it('exits 2 when CHANGELOG has no matching release heading', () => {
+      const result = run('1.0.0', '## [Unreleased]\n\n- wip\n');
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('no `## [X.Y.Z]` release heading found');
+    });
+
+    it('skips pre-release strings like 1.2.3-beta and treats as no heading found', () => {
+      const result = run('1.2.3', '## [1.2.3-beta] - 2024-01-01\n');
+      expect(result.exitCode).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `scripts/check-changelog-version.js` fails when `package.json` `version` does not match the most recent non-`Unreleased` `## [X.Y.Z]` heading in `CHANGELOG.md`. Plain Node, no dependencies, tolerates the optional ` - YYYY-MM-DD` date suffix and defensively accepts headings without brackets.
- Wired into `.github/workflows/ci.yml` as an early step (before `npm ci`) so it runs on every PR and every push to `main`. Also exposed as `npm run check-changelog-version` for local use.
- New top-level `RELEASE.md` documents the joint-bump rule. Picked a new top-level file over a comment block inside `CHANGELOG.md` because release mechanics belong next to (not embedded inside) the artifact they describe, and a top-level `RELEASE.md` is the convention contributors will look for first.

## Root cause of the v5.0.0 / v5.0.1 drift

Pure PR omission, no tooling bug.

- `v5.0.0` was tagged directly on `77fb650` (`docs: cutover documentation for v5.0.0 ...`, [#730](https://github.com/manki-review/manki/pull/730)) with no accompanying release-prep PR. `package.json` was last bumped in [#648](https://github.com/manki-review/manki/pull/648) (`v4.7.0`) and stayed there.
- `v5.0.1` prep PR [#734](https://github.com/manki-review/manki/pull/734) touched only `CHANGELOG.md` and `action.yml`, missing `package.json` again.
- `v5.1.0` prep PR [#782](https://github.com/manki-review/manki/pull/782) correctly bumped `CHANGELOG.md`, `package.json`, and `package-lock.json` together, which is what surfaced the gap.

No code fix is needed beyond the new CI check. The next release that forgets `package.json` will now fail CI.

## Verification

- `node scripts/check-changelog-version.js` on the current tree exits `0` with `ok: package.json and CHANGELOG.md agree on version 5.1.0`.
- Synthetic drift: temporarily set `package.json` `version` to `4.7.0`, re-ran the script, and confirmed exit code `1` with a clear error pointing to `RELEASE.md`. Restored and re-verified `0`.
- `npm run lint` clean, `npm test` 1908 / 1908 pass.

Closes #783