### PR TITLE
feat: in-app concurrent-submission lock (defense in depth)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -312,7 +312,7 @@ models:
 
 ### Action inputs
 
-The workflow above uses the only inputs most setups need: a provider credential (e.g. `anthropic_api_key`, `openai_api_key`, `gemini_api_key`, or one of the OAuth equivalents), `github_token` (only if you skipped the GitHub App), and optionally `memory_repo_token`. To point at a config file outside the repo root, set `config_path` (default: `.manki.yml`). For GitHub App identity, set `github_app_id`, `github_app_private_key`, and `manki_token_url`. See [`action.yml`](action.yml) for the full input reference.
+The workflow above uses the only inputs most setups need: a provider credential (e.g. `anthropic_api_key`, `openai_api_key`, `gemini_api_key`, or one of the OAuth equivalents), `github_token` (only if you skipped the GitHub App), and optionally `memory_repo_token`. To point at a config file outside the repo root, set `config_path` (default: `.manki.yml`). For GitHub App identity, set `github_app_id`, `github_app_private_key`, and `manki_token_url`. To tune the in-app concurrent-submission lock TTL (defense in depth against simultaneous-start races on top of the workflow `concurrency` group), set `concurrency_lock_ttl_seconds` (default: 600). See [`action.yml`](action.yml) for the full input reference.
 
 ### Action outputs
 
@@ -358,7 +358,7 @@ The self-trigger guard (`github.actor != 'manki-review[bot]'`) prevents the bot 
 
 The `concurrency` block keeps at most one Manki run active per PR across every PR-scoped event (`pull_request`, `pull_request_review`, `pull_request_review_comment`), serializing the vast majority of concurrent triggers so they do not race and submit conflicting reviews on the same commit. When a new PR-scoped event arrives while a run is in flight, GitHub queues it (at most one queued event per group, newer queued events replace older ones), the in-flight run completes, then the most recent queued event runs. `cancel-in-progress` is `false`, so no run is cancelled and the PR check list does not collect red crosses from superseded runs. The `issue_comment`-gated `comment.id` branch keeps distinct `/manki` invocations in separate groups so they do not serialize against each other, while `pull_request_review_comment` events fall through to the shared `pr-{N}` group alongside the other PR-scoped events.
 
-GitHub Actions concurrency is best-effort, not atomic. Two events dispatched within the same scheduling window can transition to in-progress before either reaches the queue check, in which case both runs proceed concurrently. An in-app defense-in-depth lock that closes this residual simultaneous-start race deterministically is tracked in [#779](https://github.com/manki-review/manki/issues/779).
+GitHub Actions concurrency is best-effort, not atomic. Two events dispatched within the same scheduling window can transition to in-progress before either reaches the queue check, in which case both runs proceed concurrently. As defense in depth, the action runs an in-app lock at the review pipeline entry point: it scans existing `manki-review[bot]` comments for an "in progress" marker carrying a different `manki-run-id`, and bails (with a `core.warning`) before any LLM call when one is found within the configurable TTL. Tune the TTL with the `concurrency_lock_ttl_seconds` action input (default 600 seconds). Lowering it makes the lock recover faster from crashed runs that left a stale marker behind. Raising it tolerates longer-running reviews.
 
 ## Step 4: Configure Reviews (Optional)
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'Token service URL for GitHub App identity (default: https://manki-api.dustinface.me/token)'
     required: false
     default: 'https://manki-api.dustinface.me/token'
+  concurrency_lock_ttl_seconds:
+    description: 'TTL (in seconds) for the in-app concurrent-submission lock. If another `manki-review[bot]` run has posted an "in progress" marker comment within this window, the current run bails before any LLM call. Acts as defense in depth on top of the workflow-level concurrency group. Default: 600 (10 minutes).'
+    required: false
+    default: '600'
 
 outputs:
   review_id:

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -433,6 +433,38 @@ models:
     it('throws on non-number review_passes', () => {
       expect(() => loadConfigFromContent('review_passes: "three"')).toThrow('Invalid config');
     });
+
+    it('throws on non-number concurrency_lock_ttl_seconds', () => {
+      expect(() => loadConfigFromContent('concurrency_lock_ttl_seconds: "fast"'))
+        .toThrow(/concurrency_lock_ttl_seconds/);
+      expect(() => loadConfigFromContent('concurrency_lock_ttl_seconds: "fast"'))
+        .toThrow(/3600/);
+    });
+
+    it('throws on non-finite concurrency_lock_ttl_seconds (Infinity)', () => {
+      expect(() => loadConfigFromContent('concurrency_lock_ttl_seconds: .inf'))
+        .toThrow(/concurrency_lock_ttl_seconds/);
+    });
+
+    it('throws on non-finite concurrency_lock_ttl_seconds (NaN)', () => {
+      expect(() => loadConfigFromContent('concurrency_lock_ttl_seconds: .nan'))
+        .toThrow(/concurrency_lock_ttl_seconds/);
+    });
+
+    it('throws on negative concurrency_lock_ttl_seconds', () => {
+      expect(() => loadConfigFromContent('concurrency_lock_ttl_seconds: -1'))
+        .toThrow(/concurrency_lock_ttl_seconds/);
+    });
+
+    it('throws on concurrency_lock_ttl_seconds exceeding 3600', () => {
+      expect(() => loadConfigFromContent('concurrency_lock_ttl_seconds: 3601'))
+        .toThrow(/concurrency_lock_ttl_seconds/);
+    });
+
+    it('accepts valid concurrency_lock_ttl_seconds', () => {
+      const config = loadConfigFromContent('concurrency_lock_ttl_seconds: 300');
+      expect(config.concurrency_lock_ttl_seconds).toBe(300);
+    });
   });
 
   describe('resolveModel', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   stats: {
     hidden: false,
   },
+  concurrency_lock_ttl_seconds: 600,
 };
 
 const KNOWN_KEYS = new Set([
@@ -57,6 +58,7 @@ const KNOWN_KEYS = new Set([
   'review_passes',
   'convergence',
   'stats',
+  'concurrency_lock_ttl_seconds',
 ]);
 
 const REPO_FORMAT = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
@@ -274,6 +276,12 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
       if ('hidden' in stats && typeof stats.hidden !== 'boolean') {
         errors.push('`stats.hidden` must be a boolean');
       }
+    }
+  }
+
+  if ('concurrency_lock_ttl_seconds' in config) {
+    if (typeof config.concurrency_lock_ttl_seconds !== 'number' || !Number.isFinite(config.concurrency_lock_ttl_seconds) || config.concurrency_lock_ttl_seconds < 0) {
+      errors.push('`concurrency_lock_ttl_seconds` must be a non-negative number');
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -280,8 +280,14 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
   }
 
   if ('concurrency_lock_ttl_seconds' in config) {
-    if (typeof config.concurrency_lock_ttl_seconds !== 'number' || !Number.isFinite(config.concurrency_lock_ttl_seconds) || config.concurrency_lock_ttl_seconds < 0) {
-      errors.push('`concurrency_lock_ttl_seconds` must be a non-negative number');
+    const MAX_LOCK_TTL_SECONDS = 3600;
+    if (
+      typeof config.concurrency_lock_ttl_seconds !== 'number' ||
+      !Number.isFinite(config.concurrency_lock_ttl_seconds) ||
+      config.concurrency_lock_ttl_seconds < 0 ||
+      config.concurrency_lock_ttl_seconds > MAX_LOCK_TTL_SECONDS
+    ) {
+      errors.push(`\`concurrency_lock_ttl_seconds\` must be a non-negative number ≤ ${MAX_LOCK_TTL_SECONDS}`);
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,8 @@ import { ReviewerAgent, ReviewConfig } from './types';
 // TODO: layering, temporary import from review.ts, cleanup tracked at https://github.com/manki-review/manki/issues/676
 import { buildAgentPool } from './review';
 
+export const MAX_LOCK_TTL_SECONDS = 3600;
+
 export const DEFAULT_CONFIG: ReviewConfig = {
   auto_review: true,
   auto_approve: true,
@@ -280,7 +282,6 @@ function validateConfig(config: Record<string, unknown>): ConfigValidationResult
   }
 
   if ('concurrency_lock_ttl_seconds' in config) {
-    const MAX_LOCK_TTL_SECONDS = 3600;
     if (
       typeof config.concurrency_lock_ttl_seconds !== 'number' ||
       !Number.isFinite(config.concurrency_lock_ttl_seconds) ||

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -3686,6 +3686,17 @@ describe('findInProgressLock', () => {
 
     expect(result).toBeNull();
   });
+
+  it('returns the first (most recent) lock when multiple in-progress markers exist', async () => {
+    const { octokit } = makeOctokit([
+      { id: 20, body: makeInProgressBody(200), user: { type: 'Bot' }, updated_at: '2026-05-22T12:05:00Z' },
+      { id: 10, body: makeInProgressBody(100), user: { type: 'Bot' }, updated_at: '2026-05-22T11:55:00Z' },
+    ]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toEqual({ runId: 200, updatedAt: '2026-05-22T12:05:00Z', commentId: 20 });
+  });
 });
 
 describe('isLockExpired', () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 
-import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, findInProgressLock, isLockExpired, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, fetchPRComments, findInProgressLock, isLockExpired, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, FindingFingerprintEntry, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, roundContextToFlatAliases } from './types';
 import { DEFAULT_CONFIG } from './config';
 
@@ -3685,5 +3685,87 @@ describe('isLockExpired', () => {
   it('returns false for a fresh comment when TTL is zero only when ages match exactly', () => {
     expect(isLockExpired('2026-05-22T12:00:00Z', 0, now)).toBe(false);
     expect(isLockExpired('2026-05-22T11:59:59Z', 0, now)).toBe(true);
+  });
+});
+
+describe('fetchPRComments', () => {
+  type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
+
+  function makeMockOctokit(comments: Array<{ id: number; body: string; updated_at: string }>) {
+    const octokit = {
+      rest: {
+        issues: {
+          listComments: jest.fn().mockResolvedValue({ data: comments }),
+        },
+      },
+    } as unknown as Octokit;
+    return octokit;
+  }
+
+  it('returns an empty array when there are no comments', async () => {
+    const octokit = makeMockOctokit([]);
+
+    const result = await fetchPRComments(octokit, 'owner', 'repo', 1);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns a single-element array unchanged', async () => {
+    const comment = { id: 1, body: 'hello', updated_at: '2026-05-22T12:00:00.000Z' };
+    const octokit = makeMockOctokit([comment]);
+
+    const result = await fetchPRComments(octokit, 'owner', 'repo', 1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+  });
+
+  it('sorts multiple comments by updated_at descending (newest first)', async () => {
+    const comments = [
+      { id: 1, body: 'oldest', updated_at: '2026-05-22T10:00:00.000Z' },
+      { id: 3, body: 'newest', updated_at: '2026-05-22T12:00:00.000Z' },
+      { id: 2, body: 'middle', updated_at: '2026-05-22T11:00:00.000Z' },
+    ];
+    const octokit = makeMockOctokit(comments);
+
+    const result = await fetchPRComments(octokit, 'owner', 'repo', 1);
+
+    expect(result.map(c => c.id)).toEqual([3, 2, 1]);
+  });
+
+  it('orders correctly when timestamps differ only in milliseconds', async () => {
+    const comments = [
+      { id: 1, body: 'earlier', updated_at: '2026-05-22T12:00:00.000Z' },
+      { id: 2, body: 'later',   updated_at: '2026-05-22T12:00:00.001Z' },
+    ];
+    const octokit = makeMockOctokit(comments);
+
+    const result = await fetchPRComments(octokit, 'owner', 'repo', 1);
+
+    expect(result.map(c => c.id)).toEqual([2, 1]);
+  });
+
+  it('propagates API rejection to the caller', async () => {
+    const octokit = {
+      rest: {
+        issues: {
+          listComments: jest.fn().mockRejectedValue(new Error('API error')),
+        },
+      },
+    } as unknown as Octokit;
+
+    await expect(fetchPRComments(octokit, 'owner', 'repo', 1)).rejects.toThrow('API error');
+  });
+
+  it('passes owner, repo, and prNumber to listComments', async () => {
+    const octokit = makeMockOctokit([]);
+
+    await fetchPRComments(octokit, 'my-owner', 'my-repo', 42);
+
+    expect(octokit.rest.issues.listComments).toHaveBeenCalledWith(expect.objectContaining({
+      owner: 'my-owner',
+      repo: 'my-repo',
+      issue_number: 42,
+    }));
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 
-import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
+import { buildDashboard, formatContextBlock, formatFindingComment, formatStatsOneLiner, mapVerdictToEvent, BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, VERSION_MARKER_PREFIX, MANKI_VERSION, getSeverityLabel, postReview, resolveReferences, sanitizeMarkdown, sanitizeFilePath, truncateBody, truncateContextToFitBody, dynamicFence, fetchFileContents, fetchLinkedIssues, fetchSubdirClaudeMd, updateProgressComment, postProgressComment, updateProgressDashboard, dismissPreviousReviews, reactToIssueComment, reactToReviewComment, fetchPRDiff, fetchInterRoundDiff, fetchConfigFile, fetchRepoContext, getSeverityEmoji, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, findInProgressLock, isLockExpired, INDENT, APP_WARNING_MARKER, postAppWarningIfNeeded } from './github';
 import { DashboardData, Finding, FindingFingerprintEntry, ParsedDiff, ReviewMetadata, ReviewResult, RoundContext, roundContextToFlatAliases } from './types';
 import { DEFAULT_CONFIG } from './config';
 
@@ -3595,5 +3595,116 @@ describe('cancelActiveReviewRun', () => {
     expect(result).toBe(true);
     expect(cancelWorkflowRun).toHaveBeenCalled();
     expect(updateComment).toHaveBeenCalled();
+  });
+});
+
+describe('findInProgressLock', () => {
+  type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
+
+  function makeInProgressBody(runId: number): string {
+    return `${BOT_MARKER}\n<!-- manki-run-id:${runId} -->\n**Manki** — Review in progress`;
+  }
+
+  interface MockComment {
+    id?: number;
+    body: string;
+    user: { login?: string; type: string };
+    updated_at?: string;
+  }
+
+  function makeOctokit(comments: MockComment[]) {
+    const listComments = jest.fn().mockResolvedValue({
+      data: comments.map((c, i) => ({
+        id: c.id ?? i + 1,
+        body: c.body,
+        updated_at: c.updated_at ?? '2026-01-01T00:00:00Z',
+        user: { login: c.user.login ?? (c.user.type === 'Bot' ? BOT_LOGIN : 'someone'), type: c.user.type },
+      })),
+    });
+    const octokit = { rest: { issues: { listComments } } } as unknown as Octokit;
+    return { octokit, listComments };
+  }
+
+  it('returns null when no in-progress bot comment exists (lock acquisition)', async () => {
+    const { octokit } = makeOctokit([{ body: 'Some user comment', user: { type: 'User' } }]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the lock when a different run posted an in-progress marker (contention)', async () => {
+    const { octokit } = makeOctokit([
+      { id: 7, body: makeInProgressBody(999), user: { type: 'Bot' }, updated_at: '2026-05-22T12:00:00Z' },
+    ]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toEqual({ runId: 999, updatedAt: '2026-05-22T12:00:00Z', commentId: 7 });
+  });
+
+  it('ignores the current run\'s own in-progress marker (self re-entry)', async () => {
+    const { octokit } = makeOctokit([
+      { id: 7, body: makeInProgressBody(42), user: { type: 'Bot' } },
+    ]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toBeNull();
+  });
+
+  it('skips comments bearing terminal markers (complete, cancelled, force-review, force-cap)', async () => {
+    const { octokit } = makeOctokit([
+      { body: `${makeInProgressBody(101)}\n${REVIEW_COMPLETE_MARKER}`, user: { type: 'Bot' } },
+      { body: `${makeInProgressBody(102)}\n${CANCELLED_MARKER}`, user: { type: 'Bot' } },
+      { body: `${makeInProgressBody(103)}\n${FORCE_REVIEW_MARKER}`, user: { type: 'Bot' } },
+      { body: `${makeInProgressBody(104)}\n${FORCE_CAP_MARKER}`, user: { type: 'Bot' } },
+    ]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toBeNull();
+  });
+
+  it('skips comments without a parseable run-id marker (legacy)', async () => {
+    const { octokit } = makeOctokit([
+      { body: `${BOT_MARKER}\n**Manki** — Review in progress`, user: { type: 'Bot' } },
+    ]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toBeNull();
+  });
+
+  it('skips comments that are not from the bot login', async () => {
+    const { octokit } = makeOctokit([
+      { body: makeInProgressBody(999), user: { login: 'github-actions[bot]', type: 'Bot' } },
+      { body: makeInProgressBody(888), user: { login: 'human', type: 'User' } },
+    ]);
+
+    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('isLockExpired', () => {
+  const now = new Date('2026-05-22T12:00:00Z');
+
+  it('returns false when the comment was updated within the TTL window', () => {
+    expect(isLockExpired('2026-05-22T11:55:00Z', 600, now)).toBe(false);
+  });
+
+  it('returns true when the comment was updated more than TTL seconds ago (TTL expiry)', () => {
+    expect(isLockExpired('2026-05-22T11:40:00Z', 600, now)).toBe(true);
+  });
+
+  it('treats an unparseable timestamp as expired', () => {
+    expect(isLockExpired('not-a-date', 600, now)).toBe(true);
+  });
+
+  it('returns false for a fresh comment when TTL is zero only when ages match exactly', () => {
+    expect(isLockExpired('2026-05-22T12:00:00Z', 0, now)).toBe(false);
+    expect(isLockExpired('2026-05-22T11:59:59Z', 0, now)).toBe(true);
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -3599,103 +3599,71 @@ describe('cancelActiveReviewRun', () => {
 });
 
 describe('findInProgressLock', () => {
-  type Octokit = ReturnType<typeof import('@actions/github').getOctokit>;
-
   function makeInProgressBody(runId: number): string {
     return `${BOT_MARKER}\n<!-- manki-run-id:${runId} -->\n**Manki** — Review in progress`;
   }
 
-  interface MockComment {
-    id?: number;
-    body: string;
-    user: { login?: string; type: string };
-    updated_at?: string;
+  function makeComment(
+    id: number, body: string, login: string, type: string, updated_at: string,
+  ) {
+    return { id, body, user: { login, type }, updated_at };
   }
 
-  function makeOctokit(comments: MockComment[]) {
-    const listComments = jest.fn().mockResolvedValue({
-      data: comments.map((c, i) => ({
-        id: c.id ?? i + 1,
-        body: c.body,
-        updated_at: c.updated_at ?? '2026-01-01T00:00:00Z',
-        user: { login: c.user.login ?? (c.user.type === 'Bot' ? BOT_LOGIN : 'someone'), type: c.user.type },
-      })),
-    });
-    const octokit = { rest: { issues: { listComments } } } as unknown as Octokit;
-    return { octokit, listComments };
+  function botComment(id: number, body: string, updated_at = '2026-01-01T00:00:00Z') {
+    return makeComment(id, body, BOT_LOGIN, 'Bot', updated_at);
   }
 
-  it('returns null when no in-progress bot comment exists (lock acquisition)', async () => {
-    const { octokit } = makeOctokit([{ body: 'Some user comment', user: { type: 'User' } }]);
+  it('returns null when no in-progress bot comment exists (lock acquisition)', () => {
+    const comments = [makeComment(1, 'Some user comment', 'someone', 'User', '2026-01-01T00:00:00Z')];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toBeNull();
+    expect(findInProgressLock(comments, 42)).toBeNull();
   });
 
-  it('returns the lock when a different run posted an in-progress marker (contention)', async () => {
-    const { octokit } = makeOctokit([
-      { id: 7, body: makeInProgressBody(999), user: { type: 'Bot' }, updated_at: '2026-05-22T12:00:00Z' },
-    ]);
+  it('returns the lock when a different run posted an in-progress marker (contention)', () => {
+    const comments = [botComment(7, makeInProgressBody(999), '2026-05-22T12:00:00Z')];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toEqual({ runId: 999, updatedAt: '2026-05-22T12:00:00Z', commentId: 7 });
+    expect(findInProgressLock(comments, 42)).toEqual({ runId: 999, updatedAt: '2026-05-22T12:00:00Z', commentId: 7 });
   });
 
-  it('ignores the current run\'s own in-progress marker (self re-entry)', async () => {
-    const { octokit } = makeOctokit([
-      { id: 7, body: makeInProgressBody(42), user: { type: 'Bot' } },
-    ]);
+  it('ignores the current run\'s own in-progress marker (self re-entry)', () => {
+    const comments = [botComment(7, makeInProgressBody(42))];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toBeNull();
+    expect(findInProgressLock(comments, 42)).toBeNull();
   });
 
-  it('skips comments bearing terminal markers (complete, cancelled, force-review, force-cap)', async () => {
-    const { octokit } = makeOctokit([
-      { body: `${makeInProgressBody(101)}\n${REVIEW_COMPLETE_MARKER}`, user: { type: 'Bot' } },
-      { body: `${makeInProgressBody(102)}\n${CANCELLED_MARKER}`, user: { type: 'Bot' } },
-      { body: `${makeInProgressBody(103)}\n${FORCE_REVIEW_MARKER}`, user: { type: 'Bot' } },
-      { body: `${makeInProgressBody(104)}\n${FORCE_CAP_MARKER}`, user: { type: 'Bot' } },
-    ]);
+  it('skips comments bearing terminal markers (complete, cancelled, force-review, force-cap)', () => {
+    const comments = [
+      botComment(1, `${makeInProgressBody(101)}\n${REVIEW_COMPLETE_MARKER}`),
+      botComment(2, `${makeInProgressBody(102)}\n${CANCELLED_MARKER}`),
+      botComment(3, `${makeInProgressBody(103)}\n${FORCE_REVIEW_MARKER}`),
+      botComment(4, `${makeInProgressBody(104)}\n${FORCE_CAP_MARKER}`),
+    ];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toBeNull();
+    expect(findInProgressLock(comments, 42)).toBeNull();
   });
 
-  it('skips comments without a parseable run-id marker (legacy)', async () => {
-    const { octokit } = makeOctokit([
-      { body: `${BOT_MARKER}\n**Manki** — Review in progress`, user: { type: 'Bot' } },
-    ]);
+  it('skips comments without a parseable run-id marker (legacy)', () => {
+    const comments = [botComment(1, `${BOT_MARKER}\n**Manki** — Review in progress`)];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toBeNull();
+    expect(findInProgressLock(comments, 42)).toBeNull();
   });
 
-  it('skips comments that are not from the bot login', async () => {
-    const { octokit } = makeOctokit([
-      { body: makeInProgressBody(999), user: { login: 'github-actions[bot]', type: 'Bot' } },
-      { body: makeInProgressBody(888), user: { login: 'human', type: 'User' } },
-    ]);
+  it('skips comments that are not from the bot login', () => {
+    const comments = [
+      makeComment(1, makeInProgressBody(999), 'github-actions[bot]', 'Bot', '2026-01-01T00:00:00Z'),
+      makeComment(2, makeInProgressBody(888), 'human', 'User', '2026-01-01T00:00:00Z'),
+    ];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toBeNull();
+    expect(findInProgressLock(comments, 42)).toBeNull();
   });
 
-  it('returns the first (most recent) lock when multiple in-progress markers exist', async () => {
-    const { octokit } = makeOctokit([
-      { id: 20, body: makeInProgressBody(200), user: { type: 'Bot' }, updated_at: '2026-05-22T12:05:00Z' },
-      { id: 10, body: makeInProgressBody(100), user: { type: 'Bot' }, updated_at: '2026-05-22T11:55:00Z' },
-    ]);
+  it('returns the first (most recent) lock when multiple in-progress markers exist', () => {
+    const comments = [
+      botComment(20, makeInProgressBody(200), '2026-05-22T12:05:00Z'),
+      botComment(10, makeInProgressBody(100), '2026-05-22T11:55:00Z'),
+    ];
 
-    const result = await findInProgressLock(octokit, 'o', 'r', 1, 42);
-
-    expect(result).toEqual({ runId: 200, updatedAt: '2026-05-22T12:05:00Z', commentId: 20 });
+    expect(findInProgressLock(comments, 42)).toEqual({ runId: 200, updatedAt: '2026-05-22T12:05:00Z', commentId: 20 });
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1187,9 +1187,10 @@ async function findProgressComment(
   octokit: Octokit, owner: string, repo: string, prNumber: number,
 ): Promise<ProgressComment | null> {
   const { data: comments } = await octokit.rest.issues.listComments({
-    owner, repo, issue_number: prNumber, per_page: 100, direction: 'desc',
+    owner, repo, issue_number: prNumber, per_page: 100,
   });
-  const match = comments.find(c =>
+  const sorted = [...comments].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  const match = sorted.find(c =>
     c.user?.login === BOT_LOGIN &&
     c.user?.type === 'Bot' &&
     c.body?.includes(BOT_MARKER) &&
@@ -1281,9 +1282,10 @@ async function findInProgressLock(
   octokit: Octokit, owner: string, repo: string, prNumber: number, currentRunId: number,
 ): Promise<InProgressLock | null> {
   const { data: comments } = await octokit.rest.issues.listComments({
-    owner, repo, issue_number: prNumber, per_page: 100, direction: 'desc',
+    owner, repo, issue_number: prNumber, per_page: 100,
   });
-  for (const c of comments) {
+  const sorted = [...comments].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  for (const c of sorted) {
     if (c.user?.login !== BOT_LOGIN || c.user?.type !== 'Bot') continue;
     if (!c.body?.includes(BOT_MARKER)) continue;
     if (c.body.includes(REVIEW_COMPLETE_MARKER)) continue;
@@ -1318,7 +1320,7 @@ async function markOwnProgressCommentCancelled(
 ): Promise<boolean> {
   try {
     const { data: comments } = await octokit.rest.issues.listComments({
-      owner, repo, issue_number: prNumber, per_page: 100, direction: 'desc',
+      owner, repo, issue_number: prNumber, per_page: 100,
     });
     const target = comments.find(c =>
       c.user?.login === BOT_LOGIN &&

--- a/src/github.ts
+++ b/src/github.ts
@@ -1257,6 +1257,59 @@ async function isReviewInProgress(octokit: Octokit, owner: string, repo: string,
 }
 
 /**
+ * Lock info for an in-progress marker comment posted by a different run.
+ */
+interface InProgressLock {
+  runId: number;
+  updatedAt: string;
+  commentId: number;
+}
+
+/**
+ * Scan the PR's bot comments for an in-progress marker carrying a `manki-run-id`
+ * that differs from `currentRunId`. Returns the most recent such comment, or
+ * null when none is found. Skips terminal-state comments (complete, cancelled,
+ * force-review / force-cap stubs) and comments whose run id cannot be parsed.
+ *
+ * Used as a defense-in-depth check at the review entry point: if a sibling run
+ * has already announced "Review in progress" within the configured TTL, the
+ * current run bails before any LLM cost is incurred. This complements the
+ * workflow-level `concurrency` group, which is best-effort and can let two
+ * runs reach `in_progress` within the same scheduling window.
+ */
+async function findInProgressLock(
+  octokit: Octokit, owner: string, repo: string, prNumber: number, currentRunId: number,
+): Promise<InProgressLock | null> {
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner, repo, issue_number: prNumber, per_page: 100, direction: 'desc',
+  });
+  for (const c of comments) {
+    if (c.user?.login !== BOT_LOGIN || c.user?.type !== 'Bot') continue;
+    if (!c.body?.includes(BOT_MARKER)) continue;
+    if (c.body.includes(REVIEW_COMPLETE_MARKER)) continue;
+    if (c.body.includes(CANCELLED_MARKER)) continue;
+    if (c.body.includes(FORCE_REVIEW_MARKER)) continue;
+    if (c.body.includes(FORCE_CAP_MARKER)) continue;
+    const runId = extractRunIdFromBody(c.body);
+    if (runId === null) continue;
+    if (runId === currentRunId) continue;
+    return { runId, updatedAt: c.updated_at, commentId: c.id };
+  }
+  return null;
+}
+
+/**
+ * True when `updatedAt` is older than `ttlSeconds` relative to `now`. Used to
+ * ignore in-progress markers from runs that crashed without clearing their
+ * lock, so a single stale comment cannot wedge the PR indefinitely.
+ */
+function isLockExpired(updatedAt: string, ttlSeconds: number, now: Date): boolean {
+  const updated = Date.parse(updatedAt);
+  if (!Number.isFinite(updated)) return true;
+  return (now.getTime() - updated) / 1000 > ttlSeconds;
+}
+
+/**
  * Post-step cleanup: find our run's progress comment and mark it as cancelled.
  * Invoked when GitHub Actions cancels the main step.
  */
@@ -1386,4 +1439,5 @@ async function cancelActiveReviewRun(
   }
 }
 
-export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, findInProgressLock, isLockExpired, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export type { InProgressLock };

--- a/src/github.ts
+++ b/src/github.ts
@@ -10,6 +10,13 @@ import { safeTruncate } from './utils';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
+interface IssueComment {
+  id: number;
+  body?: string | null;
+  user?: { login?: string | null; type?: string } | null;
+  updated_at: string;
+}
+
 const BOT_LOGIN = 'manki-review[bot]';
 const ACTIONS_BOT_LOGIN = 'github-actions[bot]';
 const BOT_MARKER = '<!-- manki-bot -->';
@@ -1180,17 +1187,20 @@ interface ProgressComment {
   runId: number | null;
 }
 
+async function fetchPRComments(
+  octokit: Octokit, owner: string, repo: string, prNumber: number,
+): Promise<IssueComment[]> {
+  const { data } = await octokit.rest.issues.listComments({
+    owner, repo, issue_number: prNumber, per_page: 100,
+  });
+  return [...data].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+}
+
 /**
  * Find the most recent non-complete, non-cancelled progress comment posted by the bot.
  */
-async function findProgressComment(
-  octokit: Octokit, owner: string, repo: string, prNumber: number,
-): Promise<ProgressComment | null> {
-  const { data: comments } = await octokit.rest.issues.listComments({
-    owner, repo, issue_number: prNumber, per_page: 100,
-  });
-  const sorted = [...comments].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
-  const match = sorted.find(c =>
+function findProgressComment(comments: IssueComment[]): ProgressComment | null {
+  const match = comments.find(c =>
     c.user?.login === BOT_LOGIN &&
     c.user?.type === 'Bot' &&
     c.body?.includes(BOT_MARKER) &&
@@ -1216,7 +1226,8 @@ const ACTIVE_RUN_STATUSES = new Set([
 async function isReviewInProgress(octokit: Octokit, owner: string, repo: string, prNumber: number): Promise<boolean> {
   let progress: ProgressComment | null;
   try {
-    progress = await findProgressComment(octokit, owner, repo, prNumber);
+    const comments = await fetchPRComments(octokit, owner, repo, prNumber);
+    progress = findProgressComment(comments);
   } catch {
     return false;
   }
@@ -1278,14 +1289,8 @@ interface InProgressLock {
  * workflow-level `concurrency` group, which is best-effort and can let two
  * runs reach `in_progress` within the same scheduling window.
  */
-async function findInProgressLock(
-  octokit: Octokit, owner: string, repo: string, prNumber: number, currentRunId: number,
-): Promise<InProgressLock | null> {
-  const { data: comments } = await octokit.rest.issues.listComments({
-    owner, repo, issue_number: prNumber, per_page: 100,
-  });
-  const sorted = [...comments].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
-  for (const c of sorted) {
+function findInProgressLock(comments: IssueComment[], currentRunId: number): InProgressLock | null {
+  for (const c of comments) {
     if (c.user?.login !== BOT_LOGIN || c.user?.type !== 'Bot') continue;
     if (!c.body?.includes(BOT_MARKER)) continue;
     if (c.body.includes(REVIEW_COMPLETE_MARKER)) continue;
@@ -1402,7 +1407,8 @@ async function cancelActiveReviewRun(
 ): Promise<boolean> {
   let progress: ProgressComment | null;
   try {
-    progress = await findProgressComment(octokit, owner, repo, prNumber);
+    const comments = await fetchPRComments(octokit, owner, repo, prNumber);
+    progress = findProgressComment(comments);
   } catch {
     return false;
   }
@@ -1441,5 +1447,5 @@ async function cancelActiveReviewRun(
   }
 }
 
-export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, findInProgressLock, isLockExpired, APP_WARNING_MARKER, postAppWarningIfNeeded };
+export { dynamicFence, formatContextBlock, formatFindingComment, formatStatsOneLiner, getSeverityEmoji, getSeverityLabel, mapVerdictToEvent, resolveReferences, sanitizeFilePath, sanitizeMarkdown, truncateBody, truncateContextToFitBody, BOT_LOGIN, ACTIONS_BOT_LOGIN, BOT_MARKER, REVIEW_COMPLETE_MARKER, FORCE_REVIEW_MARKER, FORCE_CAP_MARKER, CANCELLED_MARKER, RUN_ID_MARKER_PREFIX, VERSION_MARKER_PREFIX, MANKI_VERSION, isReviewInProgress, isApprovedOnCommit, markOwnProgressCommentCancelled, cancelActiveReviewRun, extractRunIdFromBody, extractVersionFromBody, fetchPRComments, findInProgressLock, isLockExpired, APP_WARNING_MARKER, postAppWarningIfNeeded };
 export type { InProgressLock };

--- a/src/github.ts
+++ b/src/github.ts
@@ -1193,7 +1193,7 @@ async function fetchPRComments(
   const { data } = await octokit.rest.issues.listComments({
     owner, repo, issue_number: prNumber, per_page: 100,
   });
-  return [...data].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  return [...data].sort((a, b) => (a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0));
 }
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,7 +144,8 @@ jest.mock('./github', () => ({
   markOwnProgressCommentCancelled: jest.fn().mockResolvedValue(false),
   postAppWarningIfNeeded: jest.fn().mockResolvedValue(undefined),
   cancelActiveReviewRun: jest.fn().mockResolvedValue(false),
-  findInProgressLock: jest.fn().mockResolvedValue(null),
+  fetchPRComments: jest.fn().mockResolvedValue([]),
+  findInProgressLock: jest.fn().mockReturnValue(null),
   isLockExpired: jest.fn().mockReturnValue(false),
   BOT_LOGIN: 'manki-review[bot]',
   ACTIONS_BOT_LOGIN: 'github-actions[bot]',
@@ -5462,7 +5463,7 @@ describe('runFullReview concurrent-submission lock', () => {
     jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
     jest.mocked(reviewModule.selectTeam).mockReturnValue({ level: 'standard' as 'small', agents: [{ name: 'general', focus: '' }], lineCount: 0 });
     jest.mocked(ghUtils.postProgressComment).mockResolvedValue(1);
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue(null);
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue(null);
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
   });
 
@@ -5474,7 +5475,7 @@ describe('runFullReview concurrent-submission lock', () => {
   }
 
   it('proceeds when no in-progress lock exists (lock acquisition)', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue(null);
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue(null);
 
     await callRunFullReview();
 
@@ -5483,7 +5484,7 @@ describe('runFullReview concurrent-submission lock', () => {
   });
 
   it('bails before any LLM call when a different run holds a fresh lock (contention)', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
       runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
     });
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
@@ -5503,7 +5504,7 @@ describe('runFullReview concurrent-submission lock', () => {
   });
 
   it('proceeds when the other run\'s marker is older than the TTL (TTL expiry)', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
       runId: 999, updatedAt: '2026-05-22T10:00:00Z', commentId: 7,
     });
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(true);
@@ -5515,7 +5516,7 @@ describe('runFullReview concurrent-submission lock', () => {
   });
 
   it('proceeds when the lock scan throws (fail-open)', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockRejectedValue(new Error('boom'));
+    jest.mocked(ghUtils.fetchPRComments).mockRejectedValueOnce(new Error('boom'));
 
     await callRunFullReview();
 
@@ -5528,7 +5529,7 @@ describe('runFullReview concurrent-submission lock', () => {
       if (name === 'concurrency_lock_ttl_seconds') return '120';
       return '';
     });
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
       runId: 999, updatedAt: '2026-05-22T11:00:00Z', commentId: 7,
     });
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(true);
@@ -5541,7 +5542,7 @@ describe('runFullReview concurrent-submission lock', () => {
   });
 
   it('transitions the in-progress marker to a terminal complete state on success (cleanup)', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue(null);
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue(null);
 
     await callRunFullReview();
 
@@ -5560,7 +5561,7 @@ describe('runFullReview concurrent-submission lock', () => {
       if (name === 'concurrency_lock_ttl_seconds') return 'not-a-number';
       return '';
     });
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
       runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
     });
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
@@ -5582,7 +5583,7 @@ describe('runFullReview concurrent-submission lock', () => {
       memory: { enabled: false, repo: '' },
       concurrency_lock_ttl_seconds: 300,
     });
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
       runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
     });
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
@@ -5595,7 +5596,7 @@ describe('runFullReview concurrent-submission lock', () => {
   });
 
   it('warns and bails cleanly when deleteComment throws on the concurrent-submission bail path', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
       runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
     });
     jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1395,9 +1395,8 @@ describe('main', () => {
 
     await main();
 
-    expect(jest.mocked(core.warning)).toHaveBeenCalledWith(
-      'Manki encountered an error: Error: Something broke',
-    );
+    const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
+    expect(warnings.some(w => w.includes('Something broke'))).toBe(true);
   });
 
   it('does not call process.exit so exit code propagates to post step', async () => {
@@ -5606,5 +5605,16 @@ describe('runFullReview concurrent-submission lock', () => {
 
     expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalledTimes(2);
     expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not propagate uncaught when fetchConfigFile throws — catch path runs instead', async () => {
+    jest.mocked(ghUtils.fetchConfigFile).mockRejectedValueOnce(new Error('GitHub API rate limit'));
+
+    await expect(callRunFullReview()).resolves.toBeUndefined();
+
+    const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
+    expect(warnings.some(w => w.includes('Review failed'))).toBe(true);
+    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+    expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5490,10 +5490,16 @@ describe('runFullReview concurrent-submission lock', () => {
 
     await callRunFullReview();
 
-    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.deleteComment).toHaveBeenCalled();
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
     const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
     expect(warnings.some(m => m.includes('999') && m.includes('Defense-in-depth'))).toBe(true);
+    expect(jest.mocked(ghUtils.isLockExpired)).toHaveBeenCalledWith(
+      '2026-05-22T11:59:00Z',
+      600,
+      expect.any(Date),
+    );
   });
 
   it('proceeds when the other run\'s marker is older than the TTL (TTL expiry)', async () => {
@@ -5546,5 +5552,45 @@ describe('runFullReview concurrent-submission lock', () => {
     expect(jest.mocked(ghUtils.updateProgressComment)).toHaveBeenCalled();
     const [, , , commentIdArg] = jest.mocked(ghUtils.updateProgressComment).mock.calls[0];
     expect(commentIdArg).toBe(1);
+  });
+
+  it('falls back to default TTL and emits a warning for a non-numeric action input', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) => {
+      if (name === 'anthropic_api_key') return 'test-api-key';
+      if (name === 'concurrency_lock_ttl_seconds') return 'not-a-number';
+      return '';
+    });
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+      runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
+    });
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.isLockExpired)).toHaveBeenCalledWith(
+      '2026-05-22T11:59:00Z', 600, expect.any(Date),
+    );
+    const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
+    expect(warnings.some(w => w.includes('Invalid concurrency_lock_ttl_seconds'))).toBe(true);
+  });
+
+  it('reads TTL from config when action input is absent', async () => {
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, max_diff_lines: 5000,
+      exclude_paths: [], reviewers: [], instructions: '', review_level: 'auto',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: false, repo: '' },
+      concurrency_lock_ttl_seconds: 300,
+    });
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+      runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
+    });
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.isLockExpired)).toHaveBeenCalledWith(
+      '2026-05-22T11:59:00Z', 300, expect.any(Date),
+    );
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5491,8 +5491,7 @@ describe('runFullReview concurrent-submission lock', () => {
 
     await callRunFullReview();
 
-    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
-    expect(mockOctokitInstance.rest.issues.deleteComment).toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
     expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
     const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
     expect(warnings.some(m => m.includes('999') && m.includes('Defense-in-depth'))).toBe(true);
@@ -5595,17 +5594,17 @@ describe('runFullReview concurrent-submission lock', () => {
     );
   });
 
-  it('warns and bails cleanly when deleteComment throws on the concurrent-submission bail path', async () => {
-    jest.mocked(ghUtils.findInProgressLock).mockReturnValue({
-      runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
-    });
-    jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
-    mockOctokitInstance.rest.issues.deleteComment.mockRejectedValueOnce(new Error('rate limited'));
+  it('residual race window: both runs proceed when both pass the pre-post scan before either posts', async () => {
+    // Both scans see an empty comment list (neither has posted yet). The lock check
+    // returns null for both runs, so both proceed past the guard and post their
+    // own progress comments. This pins the residual semantics: when the race window
+    // is entered, both runs continue to completion rather than one bailing silently.
+    jest.mocked(ghUtils.findInProgressLock).mockReturnValue(null);
 
-    await expect(callRunFullReview()).resolves.toBeUndefined();
+    await callRunFullReview();
+    await callRunFullReview();
 
-    const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
-    expect(warnings.some(w => w.includes('Could not clean up progress comment'))).toBe(true);
-    expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,6 +144,8 @@ jest.mock('./github', () => ({
   markOwnProgressCommentCancelled: jest.fn().mockResolvedValue(false),
   postAppWarningIfNeeded: jest.fn().mockResolvedValue(undefined),
   cancelActiveReviewRun: jest.fn().mockResolvedValue(false),
+  findInProgressLock: jest.fn().mockResolvedValue(null),
+  isLockExpired: jest.fn().mockReturnValue(false),
   BOT_LOGIN: 'manki-review[bot]',
   ACTIONS_BOT_LOGIN: 'github-actions[bot]',
   BOT_MARKER: '<!-- manki-bot -->',
@@ -5430,5 +5432,119 @@ describe('force review checkbox', () => {
 
     expect(mockPullsGet).not.toHaveBeenCalled();
     expect(jest.mocked(ghUtils.reactToIssueComment)).not.toHaveBeenCalled();
+  });
+});
+
+describe('runFullReview concurrent-submission lock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetOctokitCache();
+    setContext({ eventName: 'pull_request', payload: { action: 'opened' } });
+    jest.mocked(core.getInput).mockImplementation((name: string) =>
+      name === 'anthropic_api_key' ? 'test-api-key' : '',
+    );
+    jest.mocked(configModule.loadConfig).mockReturnValue({
+      auto_review: true, auto_approve: false, max_diff_lines: 5000,
+      exclude_paths: [], reviewers: [], instructions: '', review_level: 'auto',
+      review_thresholds: { small: 200, medium: 800 },
+      memory: { enabled: false, repo: '' },
+    });
+    const testFile = { path: 'src/app.ts', changeType: 'modified' as const, hunks: [] };
+    jest.mocked(diffModule.isDiffTooLarge).mockReturnValue(false);
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({ files: [testFile], totalAdditions: 10, totalDeletions: 5 });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    jest.mocked(authModule.getMemoryToken).mockReturnValue(null);
+    jest.mocked(recapModule.fetchRecapState).mockResolvedValue({ previousFindings: [], recapContext: '', priorRounds: [] });
+    jest.mocked(stateModule.resolveStaleThreads).mockResolvedValue(0);
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'APPROVE', summary: '', findings: [], highlights: [], reviewComplete: true, agentNames: ['general'],
+    });
+    jest.mocked(reviewModule.determineVerdict).mockReturnValue({ verdict: 'APPROVE', verdictReason: 'only_nit_or_suggestion' });
+    jest.mocked(reviewModule.selectTeam).mockReturnValue({ level: 'standard' as 'small', agents: [{ name: 'general', focus: '' }], lineCount: 0 });
+    jest.mocked(ghUtils.postProgressComment).mockResolvedValue(1);
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue(null);
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
+  });
+
+  function callRunFullReview(): Promise<void> {
+    return runFullReview(
+      'test-owner', 'test-repo', 42, 'abc123', 'main',
+      { title: 'Test PR', body: '', baseBranch: 'main' },
+    );
+  }
+
+  it('proceeds when no in-progress lock exists (lock acquisition)', async () => {
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue(null);
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+    expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+  });
+
+  it('bails before any LLM call when a different run holds a fresh lock (contention)', async () => {
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+      runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
+    });
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.postProgressComment)).not.toHaveBeenCalled();
+    expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+    const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
+    expect(warnings.some(m => m.includes('999') && m.includes('Defense-in-depth'))).toBe(true);
+  });
+
+  it('proceeds when the other run\'s marker is older than the TTL (TTL expiry)', async () => {
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+      runId: 999, updatedAt: '2026-05-22T10:00:00Z', commentId: 7,
+    });
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(true);
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+    expect(jest.mocked(reviewModule.runReview)).toHaveBeenCalled();
+  });
+
+  it('proceeds when the lock scan throws (fail-open)', async () => {
+    jest.mocked(ghUtils.findInProgressLock).mockRejectedValue(new Error('boom'));
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+  });
+
+  it('reads the TTL from the `concurrency_lock_ttl_seconds` action input', async () => {
+    jest.mocked(core.getInput).mockImplementation((name: string) => {
+      if (name === 'anthropic_api_key') return 'test-api-key';
+      if (name === 'concurrency_lock_ttl_seconds') return '120';
+      return '';
+    });
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+      runId: 999, updatedAt: '2026-05-22T11:00:00Z', commentId: 7,
+    });
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(true);
+
+    await callRunFullReview();
+
+    expect(jest.mocked(ghUtils.isLockExpired)).toHaveBeenCalledWith(
+      '2026-05-22T11:00:00Z', 120, expect.any(Date),
+    );
+  });
+
+  it('transitions the in-progress marker to a terminal complete state on success (cleanup)', async () => {
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue(null);
+
+    await callRunFullReview();
+
+    // The successful run posts the progress marker, then `updateProgressComment`
+    // freezes that same comment to the terminal "Review complete" state — the
+    // existing cleanup path. Both must run on the lock-holder's happy path.
+    expect(jest.mocked(ghUtils.postProgressComment)).toHaveBeenCalled();
+    expect(jest.mocked(ghUtils.updateProgressComment)).toHaveBeenCalled();
+    const [, , , commentIdArg] = jest.mocked(ghUtils.updateProgressComment).mock.calls[0];
+    expect(commentIdArg).toBe(1);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5593,4 +5593,18 @@ describe('runFullReview concurrent-submission lock', () => {
       '2026-05-22T11:59:00Z', 300, expect.any(Date),
     );
   });
+
+  it('warns and bails cleanly when deleteComment throws on the concurrent-submission bail path', async () => {
+    jest.mocked(ghUtils.findInProgressLock).mockResolvedValue({
+      runId: 999, updatedAt: '2026-05-22T11:59:00Z', commentId: 7,
+    });
+    jest.mocked(ghUtils.isLockExpired).mockReturnValue(false);
+    mockOctokitInstance.rest.issues.deleteComment.mockRejectedValueOnce(new Error('rate limited'));
+
+    await expect(callRunFullReview()).resolves.toBeUndefined();
+
+    const warnings = jest.mocked(core.warning).mock.calls.map(c => String(c[0]));
+    expect(warnings.some(w => w.includes('Could not clean up progress comment'))).toBe(true);
+    expect(jest.mocked(reviewModule.runReview)).not.toHaveBeenCalled();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,7 +462,12 @@ async function runFullReview(
     const config = loadConfig(configContent ?? undefined);
 
     if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber, config)) {
-      await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId });
+      try {
+        await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId });
+      } catch (e) {
+        core.warning(`Could not clean up progress comment on concurrent-submission bail: ${e instanceof Error ? e.message : e}`);
+      }
+      core.warning('Defense-in-depth lock engaged — this run will not post a review. If no review appears on the PR, re-trigger with `/manki review`.');
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   isApprovedOnCommit,
   markOwnProgressCommentCancelled,
   postAppWarningIfNeeded,
+  fetchPRComments,
   findInProgressLock,
   isLockExpired,
 } from './github';
@@ -253,7 +254,8 @@ async function checkConcurrentSubmissionLock(
   const currentRunId = github.context.runId;
   let lock;
   try {
-    lock = await findInProgressLock(octokit, owner, repo, prNumber, currentRunId);
+    const comments = await fetchPRComments(octokit, owner, repo, prNumber);
+    lock = findInProgressLock(comments, currentRunId);
   } catch (error) {
     core.warning(`Concurrency lock scan failed: ${error instanceof Error ? error.message : error}`);
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,27 +440,28 @@ async function runFullReview(
     }
   }
 
-  let configContent: string | null = null;
-  if (configPathInput) {
-    configContent = await fetchConfigFile(octokit, owner, repo, baseRef, configPathInput);
-  } else {
-    configContent = await fetchConfigFile(octokit, owner, repo, baseRef, '.manki.yml');
-  }
-  const config = loadConfig(configContent ?? undefined);
-
-  // Scan for a competing in-progress marker before posting our own to shorten
-  // the race window. A residual window remains when two runs both pass this scan
-  // before either posts; tracking issue for the strict atomic fix: https://github.com/manki-review/manki/issues/798
-  if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber, config)) {
-    core.warning('Defense-in-depth lock engaged — this run will not post a review. If no review appears on the PR, re-trigger with `/manki review`.');
-    return;
-  }
-
-  const progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);
-
+  let progressCommentId: number | undefined;
   let dashboardFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   try {
+    let configContent: string | null = null;
+    if (configPathInput) {
+      configContent = await fetchConfigFile(octokit, owner, repo, baseRef, configPathInput);
+    } else {
+      configContent = await fetchConfigFile(octokit, owner, repo, baseRef, '.manki.yml');
+    }
+    const config = loadConfig(configContent ?? undefined);
+
+    // Scan for a competing in-progress marker before posting our own to shorten
+    // the race window. A residual window remains when two runs both pass this scan
+    // before either posts; tracking issue for the strict atomic fix: https://github.com/manki-review/manki/issues/798
+    if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber, config)) {
+      core.warning('Defense-in-depth lock engaged — this run will not post a review. If no review appears on the PR, re-trigger with `/manki review`.');
+      return;
+    }
+
+    progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);
+
     // Capture recap state before resolving stale threads so dedup sees
     // the original open/resolved status of each previous finding.
     const recap = await fetchRecapState(octokit, owner, repo, prNumber, prAuthorLogin);
@@ -765,7 +766,7 @@ async function runFullReview(
       if (dashboardFlushTimer) clearTimeout(dashboardFlushTimer);
       dashboardFlushTimer = setTimeout(() => {
         dashboardFlushTimer = null;
-        updateProgressDashboard(octokit, owner, repo, progressCommentId, dashboard)
+        updateProgressDashboard(octokit, owner, repo, progressCommentId!, dashboard)
           .catch(err => core.warning(`Failed to update dashboard: ${err}`));
       }, 500);
     }
@@ -830,7 +831,7 @@ async function runFullReview(
           reviewEndTime = Date.now();
           dashboard.phase = 'reviewed';
           dashboard.rawFindingCount = progress.rawFindingCount;
-          updateProgressDashboard(octokit, owner, repo, progressCommentId, dashboard)
+          updateProgressDashboard(octokit, owner, repo, progressCommentId!, dashboard)
             .catch(err => core.warning(`Failed to update dashboard: ${err}`));
         } else if (progress.phase === 'judging') {
           if (dashboardFlushTimer) {
@@ -840,7 +841,7 @@ async function runFullReview(
           dashboard.phase = 'reviewed';
           dashboard.rawFindingCount = progress.rawFindingCount;
           dashboard.judgeInputCount = progress.judgeInputCount;
-          updateProgressDashboard(octokit, owner, repo, progressCommentId, dashboard)
+          updateProgressDashboard(octokit, owner, repo, progressCommentId!, dashboard)
             .catch(err => core.warning(`Failed to update dashboard: ${err}`));
         }
       },
@@ -1179,11 +1180,13 @@ async function runFullReview(
     const msg = error instanceof Error ? error.message : String(error);
     core.warning(`Review failed: ${msg}`);
 
-    await updateProgressComment(octokit, owner, repo, progressCommentId, {
-      phase: 'complete',
-      lineCount: 0,
-      agentCount: 0,
-    });
+    if (progressCommentId !== undefined) {
+      await updateProgressComment(octokit, owner, repo, progressCommentId, {
+        phase: 'complete',
+        lineCount: 0,
+        agentCount: 0,
+      });
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { isEmptyInterRoundDiff } from './judge';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { collectResolvedThreadIds, fetchRecapState, fingerprintFinding } from './recap';
 import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam } from './review';
-import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
+import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, ReviewConfig, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -224,16 +224,19 @@ async function run(): Promise<void> {
 }
 
 const DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS = 600;
+const MAX_CONCURRENCY_LOCK_TTL_SECONDS = 3600;
 
-function readConcurrencyLockTtlSeconds(): number {
+function readConcurrencyLockTtlSeconds(config?: ReviewConfig): number {
   const raw = core.getInput('concurrency_lock_ttl_seconds');
-  if (!raw) return DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n < 0) {
-    core.warning(`Invalid concurrency_lock_ttl_seconds=${raw}, using default ${DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS}`);
-    return DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
+  if (raw) {
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0 || n > MAX_CONCURRENCY_LOCK_TTL_SECONDS) {
+      core.warning(`Invalid concurrency_lock_ttl_seconds=${raw}, using default ${DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS}`);
+      return DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
+    }
+    return n;
   }
-  return n;
+  return config?.concurrency_lock_ttl_seconds ?? DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
 }
 
 /**
@@ -246,7 +249,7 @@ function readConcurrencyLockTtlSeconds(): number {
  * Returns `true` when the caller should bail.
  */
 async function checkConcurrentSubmissionLock(
-  octokit: Octokit, owner: string, repo: string, prNumber: number,
+  octokit: Octokit, owner: string, repo: string, prNumber: number, config?: ReviewConfig,
 ): Promise<boolean> {
   const currentRunId = github.context.runId;
   let lock;
@@ -258,7 +261,7 @@ async function checkConcurrentSubmissionLock(
   }
   if (!lock) return false;
 
-  const ttlSeconds = readConcurrencyLockTtlSeconds();
+  const ttlSeconds = readConcurrencyLockTtlSeconds(config);
   const now = new Date();
   if (isLockExpired(lock.updatedAt, ttlSeconds, now)) {
     core.info(`Ignoring stale in-progress marker from run ${lock.runId} (updated_at=${lock.updatedAt}, TTL=${ttlSeconds}s)`);
@@ -436,10 +439,6 @@ async function runFullReview(
     }
   }
 
-  if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber)) {
-    return;
-  }
-
   const progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);
 
   let dashboardFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -461,6 +460,11 @@ async function runFullReview(
       configContent = await fetchConfigFile(octokit, owner, repo, baseRef, '.manki.yml');
     }
     const config = loadConfig(configContent ?? undefined);
+
+    if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber, config)) {
+      await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId });
+      return;
+    }
 
     if (github.context.eventName === 'pull_request' && !config.auto_review) {
       core.info('auto_review is disabled — skipping');

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,6 +440,22 @@ async function runFullReview(
     }
   }
 
+  let configContent: string | null = null;
+  if (configPathInput) {
+    configContent = await fetchConfigFile(octokit, owner, repo, baseRef, configPathInput);
+  } else {
+    configContent = await fetchConfigFile(octokit, owner, repo, baseRef, '.manki.yml');
+  }
+  const config = loadConfig(configContent ?? undefined);
+
+  // Scan for a competing in-progress marker before posting our own to shorten
+  // the race window. A residual window remains when two runs both pass this scan
+  // before either posts; tracking issue for the strict atomic fix: https://github.com/manki-review/manki/issues/798
+  if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber, config)) {
+    core.warning('Defense-in-depth lock engaged — this run will not post a review. If no review appears on the PR, re-trigger with `/manki review`.');
+    return;
+  }
+
   const progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);
 
   let dashboardFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -452,24 +468,6 @@ async function runFullReview(
     const staleCount = await resolveStaleThreads(octokit, owner, repo, prNumber, commitSha);
     if (staleCount > 0) {
       core.info(`Resolved ${staleCount} stale review threads from previous commits`);
-    }
-
-    let configContent: string | null = null;
-    if (configPathInput) {
-      configContent = await fetchConfigFile(octokit, owner, repo, baseRef, configPathInput);
-    } else {
-      configContent = await fetchConfigFile(octokit, owner, repo, baseRef, '.manki.yml');
-    }
-    const config = loadConfig(configContent ?? undefined);
-
-    if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber, config)) {
-      try {
-        await octokit.rest.issues.deleteComment({ owner, repo, comment_id: progressCommentId });
-      } catch (e) {
-        core.warning(`Could not clean up progress comment on concurrent-submission bail: ${e instanceof Error ? e.message : e}`);
-      }
-      core.warning('Defense-in-depth lock engaged — this run will not post a review. If no review appears on the PR, re-trigger with `/manki review`.');
-      return;
     }
 
     if (github.context.eventName === 'pull_request' && !config.auto_review) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ import {
   isApprovedOnCommit,
   markOwnProgressCommentCancelled,
   postAppWarningIfNeeded,
+  findInProgressLock,
+  isLockExpired,
 } from './github';
 import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
@@ -221,6 +223,52 @@ async function run(): Promise<void> {
   }
 }
 
+const DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS = 600;
+
+function readConcurrencyLockTtlSeconds(): number {
+  const raw = core.getInput('concurrency_lock_ttl_seconds');
+  if (!raw) return DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    core.warning(`Invalid concurrency_lock_ttl_seconds=${raw}, using default ${DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS}`);
+    return DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
+  }
+  return n;
+}
+
+/**
+ * Defense-in-depth check before any LLM call. When another `manki-review[bot]`
+ * run has posted an in-progress marker comment whose `manki-run-id` differs
+ * from ours and whose `updated_at` is within the configured TTL, bail to avoid
+ * a double review. The workflow-level `concurrency` group is best-effort and
+ * can let two runs reach `in_progress` within the same scheduling window.
+ *
+ * Returns `true` when the caller should bail.
+ */
+async function checkConcurrentSubmissionLock(
+  octokit: Octokit, owner: string, repo: string, prNumber: number,
+): Promise<boolean> {
+  const currentRunId = github.context.runId;
+  let lock;
+  try {
+    lock = await findInProgressLock(octokit, owner, repo, prNumber, currentRunId);
+  } catch (error) {
+    core.warning(`Concurrency lock scan failed: ${error instanceof Error ? error.message : error}`);
+    return false;
+  }
+  if (!lock) return false;
+
+  const ttlSeconds = readConcurrencyLockTtlSeconds();
+  const now = new Date();
+  if (isLockExpired(lock.updatedAt, ttlSeconds, now)) {
+    core.info(`Ignoring stale in-progress marker from run ${lock.runId} (updated_at=${lock.updatedAt}, TTL=${ttlSeconds}s)`);
+    return false;
+  }
+  const ageSeconds = Math.round((now.getTime() - Date.parse(lock.updatedAt)) / 1000);
+  core.warning(`Bailing: another Manki run (id=${lock.runId}) posted an in-progress marker ${ageSeconds}s ago (TTL=${ttlSeconds}s). Defense-in-depth lock engaged before LLM call.`);
+  return true;
+}
+
 async function postReviewSkippedComment(
   octokit: Octokit, owner: string, repo: string, prNumber: number,
 ): Promise<void> {
@@ -386,6 +434,10 @@ async function runFullReview(
     } catch (error) {
       core.warning(`Failed to post app warning: ${error}`);
     }
+  }
+
+  if (await checkConcurrentSubmissionLock(octokit, owner, repo, prNumber)) {
+    return;
   }
 
   const progressCommentId = await postProgressComment(octokit, owner, repo, prNumber);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 import { createAuthenticatedOctokit, getMemoryToken } from './auth';
-import { loadConfig, resolveModel } from './config';
+import { loadConfig, resolveModel, MAX_LOCK_TTL_SECONDS } from './config';
 import { buildAuthForProvider, createLLMClient, hasAnyProviderCredentials, parseModelSpec, sanitizeLogOutput } from './providers';
 import type { LLMClient, ProviderAuth, ProviderInputs } from './providers';
 import { extractCurrentCodeWindow } from './code-window';
@@ -224,13 +224,12 @@ async function run(): Promise<void> {
 }
 
 const DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS = 600;
-const MAX_CONCURRENCY_LOCK_TTL_SECONDS = 3600;
 
 function readConcurrencyLockTtlSeconds(config?: ReviewConfig): number {
   const raw = core.getInput('concurrency_lock_ttl_seconds');
   if (raw) {
     const n = Number(raw);
-    if (!Number.isFinite(n) || n < 0 || n > MAX_CONCURRENCY_LOCK_TTL_SECONDS) {
+    if (!Number.isFinite(n) || n < 0 || n > MAX_LOCK_TTL_SECONDS) {
       core.warning(`Invalid concurrency_lock_ttl_seconds=${raw}, using default ${DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS}`);
       return DEFAULT_CONCURRENCY_LOCK_TTL_SECONDS;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,13 @@ export interface ReviewConfig {
      */
     hidden?: boolean;
   };
+  /**
+   * TTL (in seconds) for the in-app concurrent-submission lock. When another
+   * `manki-review[bot]` run has posted an in-progress marker comment that was
+   * updated within this window, the current run bails before any LLM call.
+   * Acts as defense in depth on top of the workflow-level concurrency group.
+   */
+  concurrency_lock_ttl_seconds?: number;
 }
 
 export interface DiffFile {


### PR DESCRIPTION
## Summary

- New in-app lock at the review pipeline entry point bails when another `manki-review[bot]` run is already in progress (different `manki-run-id` within the configurable TTL), before any LLM call.
- New input `concurrency_lock_ttl_seconds` (default 600) controls how stale an in-progress marker can be before it is ignored.
- Bail path emits `core.warning` with the conflicting run id and stale-seconds delta.

Defense in depth on top of #776 / #777 (workflow-level concurrency collapse).

Closes #779