### PR TITLE
fix: capture stdout tail and result-event context on CLI exit-non-zero

### DIFF
--- a/src/providers/anthropic.test.ts
+++ b/src/providers/anthropic.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import Anthropic from '@anthropic-ai/sdk';
+import * as core from '@actions/core';
 
 import { AnthropicClient, buildAnthropicAuth, resetCLIInstallPromise, sanitizeLogOutput, STALE_TIMEOUT_MS } from './anthropic';
 
@@ -253,11 +254,60 @@ describe('sendViaOAuth — error paths', () => {
     mockSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
   }
 
-  it('rejects on non-zero exit code', async () => {
+  it('rejects on non-zero exit code with rich diagnostics', async () => {
     setupSpawnMock({ exitCode: 1, stderr: 'something went wrong' });
     const client = new AnthropicClient({ auth: { kind: 'oauth', token: 'token' }, model: 'claude-opus-4-6' });
 
-    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Claude CLI invocation failed');
+    await expect(client.sendMessage('sys', 'user', { effort: 'high' })).rejects.toThrow(
+      /Claude CLI invocation failed.*model=claude-opus-4-6.*effort=high.*promptChars=\d+.*elapsedMs=\d+.*stderrChars=\d+/s,
+    );
+  });
+
+  it('surfaces stdout tail, <empty stderr>, and parsed result event when exit-1 has no stderr', async () => {
+    const streamWithResultError = [
+      JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial thinking emitted right before exit' } }),
+      JSON.stringify({ type: 'result', subtype: 'error_during_execution', is_error: true, result: 'Maximum tokens exceeded' }),
+      '',
+    ].join('\n');
+    setupSpawnMock({
+      exitCode: 1,
+      stderr: '',
+      stdout: streamWithResultError,
+      rawStdout: true,
+    });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new AnthropicClient({ auth: { kind: 'oauth', token: 'token' }, model: 'claude-opus-4-6' });
+
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Claude CLI invocation failed/);
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('Claude CLI failed');
+    expect(allWarnings).toContain('<empty stderr>');
+    expect(allWarnings).toContain('stderrChars=0');
+    expect(allWarnings).toContain('is_error=true');
+    expect(allWarnings).toContain('subtype=error_during_execution');
+    expect(allWarnings).toContain('Maximum tokens exceeded');
+    warnSpy.mockRestore();
+  });
+
+  it('records <no result event> when exit-1 stream emits only text deltas with no terminal result', async () => {
+    const streamWithoutResult = [
+      JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'streamed text but no terminal event' } }),
+      '',
+    ].join('\n');
+    setupSpawnMock({
+      exitCode: 1,
+      stderr: '',
+      stdout: streamWithoutResult,
+      rawStdout: true,
+    });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new AnthropicClient({ auth: { kind: 'oauth', token: 'token' }, model: 'claude-opus-4-6' });
+
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Claude CLI invocation failed/);
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('<no result event>');
+    expect(allWarnings).not.toContain('is_error=');
+    warnSpy.mockRestore();
   });
 
   it('rejects on spawn error', async () => {

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import Anthropic from '@anthropic-ai/sdk';
 import * as core from '@actions/core';
 
-import { sanitizeLogOutput, STALE_TIMEOUT_MS, buildTimeoutDiagnostics, extractCliErrorSnippet } from './cli-utils';
+import { sanitizeLogOutput, STALE_TIMEOUT_MS, buildTimeoutDiagnostics, buildExitDiagnostics } from './cli-utils';
 import { AnthropicAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
 // Re-export for backward compatibility with existing test imports.
@@ -19,20 +19,26 @@ export function buildAnthropicAuth(oauthToken: string, apiKey: string): Anthropi
   throw new Error('Either claude_code_oauth_token or anthropic_api_key must be provided');
 }
 
-/** Parse a single JSON-stream line emitted by Claude CLI and return a text delta or final result. */
-function processJsonLine(line: string): { text: string; replace: boolean } {
+/**
+ * Parse a single JSON-stream line emitted by Claude CLI. Returns the text
+ * delta (if any) plus the full parsed event when it is a terminal `result`
+ * event, so callers can both stream text and capture the exit reason
+ * (`is_error`, `subtype`, error text) for diagnostics on failure.
+ */
+function processJsonLine(line: string): { text: string; replace: boolean; resultEvent: unknown } {
   try {
     const event = JSON.parse(line);
     if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta' && event.delta.text) {
-      return { text: event.delta.text, replace: false };
+      return { text: event.delta.text, replace: false, resultEvent: null };
     }
-    if (event.type === 'result' && typeof event.result === 'string') {
-      return { text: event.result, replace: true };
+    if (event.type === 'result') {
+      const text = typeof event.result === 'string' ? event.result : '';
+      return { text, replace: text.length > 0, resultEvent: event };
     }
   } catch {
     // Non-JSON line (e.g. verbose debug output) — skip silently
   }
-  return { text: '', replace: false };
+  return { text: '', replace: false, resultEvent: null };
 }
 
 
@@ -112,6 +118,8 @@ export class AnthropicClient implements LLMClient {
     const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
     const cliPath = await this.ensureCLI();
     const oauthToken = this.auth.kind === 'oauth' ? this.auth.token : undefined;
+    const startTime = Date.now();
+    const model = this.model;
 
     return new Promise((resolve, reject) => {
       // -p enables pipe mode — reads prompt from stdin when no argument follows
@@ -150,6 +158,7 @@ export class AnthropicClient implements LLMClient {
       // Only set in the catch block below; clearTimeout(undefined) is a no-op on the normal path
       let stdinKillTimer: NodeJS.Timeout | undefined;
       let lastStdoutChunk = '';
+      let lastResultEvent: unknown = null;
       let rawBytes = 0;
 
       const clearAllTimers = (): void => {
@@ -216,6 +225,7 @@ export class AnthropicClient implements LLMClient {
         for (const line of lines) {
           if (!line.trim()) continue;
           const delta = processJsonLine(line);
+          if (delta.resultEvent !== null) lastResultEvent = delta.resultEvent;
           if (delta.replace) {
             output = delta.text;
           } else {
@@ -239,6 +249,7 @@ export class AnthropicClient implements LLMClient {
           jsonBuffer += remaining;
           if (jsonBuffer.trim()) {
             const delta = processJsonLine(jsonBuffer);
+            if (delta.resultEvent !== null) lastResultEvent = delta.resultEvent;
             if (delta.replace) {
               output = delta.text;
             } else {
@@ -266,7 +277,17 @@ export class AnthropicClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${extractCliErrorSnippet(stderr)}`;
+          const msg = buildExitDiagnostics({
+            exitCode: code,
+            signal,
+            stderr,
+            lastStdoutChunk,
+            model,
+            effort: options?.effort,
+            promptChars: fullPrompt.length,
+            elapsedMs: Date.now() - startTime,
+            resultEvent: lastResultEvent,
+          });
           core.warning(`Claude CLI failed (${msg})`);
           reject(new Error(`Claude CLI invocation failed (${msg})`));
           return;

--- a/src/providers/cli-utils.test.ts
+++ b/src/providers/cli-utils.test.ts
@@ -159,8 +159,8 @@ describe('buildExitDiagnostics', () => {
         result: 'Maximum tokens exceeded',
       },
     });
-    expect(result).toContain('is_error=true');
-    expect(result).toContain('subtype=error_during_execution');
+    expect(result).toContain('result.is_error=true');
+    expect(result).toContain('result.subtype=error_during_execution');
     expect(result).toContain('Maximum tokens exceeded');
   });
 
@@ -169,8 +169,8 @@ describe('buildExitDiagnostics', () => {
       ...base,
       resultEvent: { type: 'result', subtype: 'success', is_error: false, result: 'all good' },
     });
-    expect(result).toContain('is_error=false');
-    expect(result).toContain('subtype=success');
+    expect(result).toContain('result.is_error=false');
+    expect(result).toContain('result.subtype=success');
   });
 
   it('falls back to error.message when result and message are absent', () => {

--- a/src/providers/cli-utils.test.ts
+++ b/src/providers/cli-utils.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync 
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { buildTimeoutDiagnostics, extractCliErrorSnippet, sanitizeLogOutput, seedAuthFile } from './cli-utils';
+import { buildExitDiagnostics, buildTimeoutDiagnostics, extractCliErrorSnippet, sanitizeLogOutput, seedAuthFile } from './cli-utils';
 
 function encode(json: unknown): string {
   return Buffer.from(JSON.stringify(json), 'utf8').toString('base64');
@@ -83,6 +83,113 @@ describe('buildTimeoutDiagnostics', () => {
     expect(result).not.toContain('::error');
     expect(result).not.toContain('::warning');
     expect(result).toContain('[redacted-workflow-cmd]');
+  });
+});
+
+describe('buildExitDiagnostics', () => {
+  const base = {
+    exitCode: 1,
+    signal: null,
+    stderr: 'boom',
+    lastStdoutChunk: 'last bits',
+    model: 'claude-opus-4-6',
+    promptChars: 12345,
+    elapsedMs: 4567,
+  } as const;
+
+  it('includes exit code, model, promptChars, elapsedMs, and stderrChars', () => {
+    const result = buildExitDiagnostics({ ...base });
+    expect(result).toContain('exit 1');
+    expect(result).toContain('model=claude-opus-4-6');
+    expect(result).toContain('promptChars=12345');
+    expect(result).toContain('elapsedMs=4567');
+    expect(result).toContain('stderrChars=4');
+    expect(result).toContain('lastStdout=last bits');
+  });
+
+  it('includes effort when set and omits when unset', () => {
+    expect(buildExitDiagnostics({ ...base, effort: 'high' })).toContain('effort=high');
+    expect(buildExitDiagnostics({ ...base })).not.toContain('effort=');
+  });
+
+  it('surfaces empty stderr explicitly so silent failures are not blank', () => {
+    const result = buildExitDiagnostics({ ...base, stderr: '', lastStdoutChunk: 'tail-of-stdout' });
+    expect(result).toContain('<empty stderr>');
+    expect(result).toContain('stderrChars=0');
+    expect(result).toContain('lastStdout=tail-of-stdout');
+  });
+
+  it('marks lastStdout as <none> when no stdout was captured', () => {
+    const result = buildExitDiagnostics({ ...base, lastStdoutChunk: '' });
+    expect(result).toContain('lastStdout=<none>');
+  });
+
+  it('includes the signal when the process was killed', () => {
+    const result = buildExitDiagnostics({ ...base, exitCode: null, signal: 'SIGTERM' });
+    expect(result).toContain('exit null');
+    expect(result).toContain('signal SIGTERM');
+  });
+
+  it('caps the stdout tail at 500 chars and sanitizes workflow commands in it', () => {
+    const tail = '::warning::leaked\n' + 'z'.repeat(600);
+    const result = buildExitDiagnostics({ ...base, lastStdoutChunk: tail });
+    expect(result).not.toContain('::warning');
+    expect(result).not.toContain('z'.repeat(501));
+    expect(result).toContain('z'.repeat(500));
+  });
+
+  it('omits the result.* field entirely when resultEvent is not passed', () => {
+    const result = buildExitDiagnostics({ ...base });
+    expect(result).not.toContain('result.');
+    expect(result).not.toContain('<no result event>');
+  });
+
+  it('renders <no result event> when resultEvent is explicitly null', () => {
+    const result = buildExitDiagnostics({ ...base, resultEvent: null });
+    expect(result).toContain('<no result event>');
+  });
+
+  it('summarizes a structured result event with is_error, subtype, and result text', () => {
+    const result = buildExitDiagnostics({
+      ...base,
+      resultEvent: {
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        result: 'Maximum tokens exceeded',
+      },
+    });
+    expect(result).toContain('is_error=true');
+    expect(result).toContain('subtype=error_during_execution');
+    expect(result).toContain('Maximum tokens exceeded');
+  });
+
+  it('renders success result events as is_error=false subtype=success', () => {
+    const result = buildExitDiagnostics({
+      ...base,
+      resultEvent: { type: 'result', subtype: 'success', is_error: false, result: 'all good' },
+    });
+    expect(result).toContain('is_error=false');
+    expect(result).toContain('subtype=success');
+  });
+
+  it('falls back to error.message when result and message are absent', () => {
+    const result = buildExitDiagnostics({
+      ...base,
+      resultEvent: { type: 'result', is_error: true, error: { message: 'rate limited' } },
+    });
+    expect(result).toContain('rate limited');
+  });
+
+  it('caps the result text at 300 chars and sanitizes workflow commands inside it', () => {
+    const long = '::warning::leaked\n' + 'q'.repeat(400);
+    const result = buildExitDiagnostics({
+      ...base,
+      resultEvent: { type: 'result', is_error: true, result: long },
+    });
+    expect(result).not.toContain('::warning');
+    expect(result).not.toContain('q'.repeat(301));
+    expect(result).toContain('q'.repeat(200));
   });
 });
 

--- a/src/providers/cli-utils.test.ts
+++ b/src/providers/cli-utils.test.ts
@@ -131,11 +131,14 @@ describe('buildExitDiagnostics', () => {
   });
 
   it('caps the stdout tail at 500 chars and sanitizes workflow commands in it', () => {
-    const tail = '::warning::leaked\n' + 'z'.repeat(600);
-    const result = buildExitDiagnostics({ ...base, lastStdoutChunk: tail });
+    // The ::warning token sits inside the last 500 chars so sanitizeLogOutput — not the slice — removes it.
+    // longTail is 698 chars: 200 x's prefix (gets truncated) + 498 chars containing the warning token.
+    const tail = 'z'.repeat(200) + '\n::warning::leaked' + 'z'.repeat(280);
+    const longTail = 'x'.repeat(200) + tail;
+    const result = buildExitDiagnostics({ ...base, lastStdoutChunk: longTail });
     expect(result).not.toContain('::warning');
-    expect(result).not.toContain('z'.repeat(501));
-    expect(result).toContain('z'.repeat(500));
+    expect(result).toContain('[redacted-workflow-cmd]');
+    expect(result).not.toContain('x'.repeat(10));
   });
 
   it('omits the result.* field entirely when resultEvent is not passed', () => {

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -91,26 +91,26 @@ export function buildExitDiagnostics(input: ExitDiagnosticsInput): string {
   ctx.push(`promptChars=${promptChars}`);
   ctx.push(`elapsedMs=${elapsedMs}`);
   ctx.push(`stderrChars=${stderr.length}`);
-  if ('resultEvent' in input) ctx.push(summarizeResultEvent(resultEvent));
+  if ('resultEvent' in input) ctx.push(...summarizeResultEvent(resultEvent));
   ctx.push(`lastStdout=${stdoutTail || '<none>'}`);
   return `${head} [${ctx.join(', ')}]`;
 }
 
-function summarizeResultEvent(resultEvent: unknown): string {
-  if (resultEvent === null || resultEvent === undefined) return '<no result event>';
+function summarizeResultEvent(resultEvent: unknown): string[] {
+  if (resultEvent === null || resultEvent === undefined) return ['<no result event>'];
   if (typeof resultEvent !== 'object') {
-    return `result=${sanitizeLogOutput(String(resultEvent)).slice(0, 300)}`;
+    return [`result=${sanitizeLogOutput(String(resultEvent)).slice(0, 300)}`];
   }
   const event = resultEvent as Record<string, unknown>;
   const parts: string[] = [];
-  if ('is_error' in event) parts.push(`is_error=${Boolean(event.is_error)}`);
-  if (typeof event.subtype === 'string') parts.push(`subtype=${sanitizeLogOutput(event.subtype)}`);
+  if ('is_error' in event) parts.push(`result.is_error=${Boolean(event.is_error)}`);
+  if (typeof event.subtype === 'string') parts.push(`result.subtype=${sanitizeLogOutput(event.subtype)}`);
   const rawText = pickResultText(event);
   if (rawText) {
     const snippet = sanitizeLogOutput(rawText).slice(0, 300);
-    parts.push(`result=${JSON.stringify(snippet)}`);
+    parts.push(`result.text=${JSON.stringify(snippet)}`);
   }
-  return parts.length > 0 ? `result.${parts.join(' ')}` : 'result.<empty>';
+  return parts.length > 0 ? parts : ['result.<empty>'];
 }
 
 function pickResultText(event: Record<string, unknown>): string {

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -53,6 +53,76 @@ export function buildTimeoutDiagnostics(lastStdoutChunk: string, stderrText: str
   return parts.join('. ');
 }
 
+export interface ExitDiagnosticsInput {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+  lastStdoutChunk: string;
+  model: string;
+  effort?: string;
+  promptChars: number;
+  elapsedMs: number;
+  /**
+   * The full parsed terminal `result` event from a stream-json CLI (currently
+   * only Claude). When provided, the diagnostic appends a compact summary of
+   * `is_error`, `subtype`, and the first 300 chars of the result/message text.
+   * Pass `null` (the default if omitted) to render `<no result event>`, which
+   * is informative on its own: it tells us the CLI exited before flushing a
+   * terminal event.
+   */
+  resultEvent?: unknown;
+}
+
+/**
+ * Build a single descriptive string for the non-zero-exit branch of a CLI
+ * invocation. Captures runtime context (model, effort, prompt size, elapsed
+ * time, byte counts) and a 500-char stdout tail so empty-stderr failures are
+ * still actionable. The caller interpolates this inside its own
+ * `"<provider> CLI failed (...)"` framing.
+ */
+export function buildExitDiagnostics(input: ExitDiagnosticsInput): string {
+  const { exitCode, signal, stderr, lastStdoutChunk, model, effort, promptChars, elapsedMs, resultEvent } = input;
+  const signalPart = signal ? `, signal ${signal}` : '';
+  const stderrSnippet = extractCliErrorSnippet(stderr);
+  const stdoutTail = sanitizeLogOutput(lastStdoutChunk.slice(-500));
+  const head = `exit ${exitCode}${signalPart}: ${stderrSnippet || '<empty stderr>'}`;
+  const ctx: string[] = [`model=${model}`];
+  if (effort) ctx.push(`effort=${effort}`);
+  ctx.push(`promptChars=${promptChars}`);
+  ctx.push(`elapsedMs=${elapsedMs}`);
+  ctx.push(`stderrChars=${stderr.length}`);
+  if ('resultEvent' in input) ctx.push(summarizeResultEvent(resultEvent));
+  ctx.push(`lastStdout=${stdoutTail || '<none>'}`);
+  return `${head} [${ctx.join(', ')}]`;
+}
+
+function summarizeResultEvent(resultEvent: unknown): string {
+  if (resultEvent === null || resultEvent === undefined) return '<no result event>';
+  if (typeof resultEvent !== 'object') {
+    return `result=${sanitizeLogOutput(String(resultEvent)).slice(0, 300)}`;
+  }
+  const event = resultEvent as Record<string, unknown>;
+  const parts: string[] = [];
+  if ('is_error' in event) parts.push(`is_error=${Boolean(event.is_error)}`);
+  if (typeof event.subtype === 'string') parts.push(`subtype=${event.subtype}`);
+  const rawText = pickResultText(event);
+  if (rawText) {
+    const snippet = sanitizeLogOutput(rawText).slice(0, 300);
+    parts.push(`result=${JSON.stringify(snippet)}`);
+  }
+  return parts.length > 0 ? `result.${parts.join(' ')}` : 'result.<empty>';
+}
+
+function pickResultText(event: Record<string, unknown>): string {
+  if (typeof event.result === 'string' && event.result.length > 0) return event.result;
+  if (typeof event.message === 'string' && event.message.length > 0) return event.message;
+  if (event.error && typeof event.error === 'object') {
+    const err = event.error as Record<string, unknown>;
+    if (typeof err.message === 'string' && err.message.length > 0) return err.message;
+  }
+  return '';
+}
+
 export interface SeedAuthFileOptions {
   /** Base64-encoded JSON blob from a GitHub secret. */
   secret: string;

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -104,7 +104,7 @@ function summarizeResultEvent(resultEvent: unknown): string {
   const event = resultEvent as Record<string, unknown>;
   const parts: string[] = [];
   if ('is_error' in event) parts.push(`is_error=${Boolean(event.is_error)}`);
-  if (typeof event.subtype === 'string') parts.push(`subtype=${event.subtype}`);
+  if (typeof event.subtype === 'string') parts.push(`subtype=${sanitizeLogOutput(event.subtype)}`);
   const rawText = pickResultText(event);
   if (rawText) {
     const snippet = sanitizeLogOutput(rawText).slice(0, 300);

--- a/src/providers/cli-utils.ts
+++ b/src/providers/cli-utils.ts
@@ -66,9 +66,13 @@ export interface ExitDiagnosticsInput {
    * The full parsed terminal `result` event from a stream-json CLI (currently
    * only Claude). When provided, the diagnostic appends a compact summary of
    * `is_error`, `subtype`, and the first 300 chars of the result/message text.
-   * Pass `null` (the default if omitted) to render `<no result event>`, which
-   * is informative on its own: it tells us the CLI exited before flushing a
-   * terminal event.
+   *
+   * - Omit this field entirely to suppress the result section from the output
+   *   (appropriate for providers whose CLIs do not emit a terminal result event).
+   * - Pass `null` explicitly to show `<no result event>`, signalling that the
+   *   CLI exited before flushing a terminal event (used by the Claude path when
+   *   `lastResultEvent` was never set during streaming).
+   * - Pass the parsed event object to render `is_error`, `subtype`, etc.
    */
   resultEvent?: unknown;
 }

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -456,11 +456,27 @@ describe('GeminiClient OAuth path', () => {
     const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
     const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
 
-    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Gemini CLI invocation failed/);
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(
+      /Gemini CLI invocation failed.*model=gemini-3\.1-flash-lite.*promptChars=\d+.*elapsedMs=\d+.*stderrChars=\d+/s,
+    );
 
     const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
     expect(allWarnings).toContain('[redacted-workflow-cmd]');
     expect(allWarnings).not.toContain('::error::leaked');
+    warnSpy.mockRestore();
+  });
+
+  it('surfaces stdout tail and <empty stderr> marker when exit-1 has no stderr', async () => {
+    setupOAuthSpawnMock({ stdout: 'gemini partial output before crash', stderr: '', exitCode: 1 });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
+    const client = new GeminiClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gemini-3.1-flash-lite' });
+
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Gemini CLI invocation failed/);
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('Gemini CLI failed');
+    expect(allWarnings).toContain('<empty stderr>');
+    expect(allWarnings).toContain('lastStdout=gemini partial output before crash');
+    expect(allWarnings).toContain('stderrChars=0');
     warnSpy.mockRestore();
   });
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import * as core from '@actions/core';
 
-import { buildTimeoutDiagnostics, extractCliErrorSnippet, sanitizeLogOutput, seedAuthFile, STALE_TIMEOUT_MS } from './cli-utils';
+import { buildExitDiagnostics, buildTimeoutDiagnostics, sanitizeLogOutput, seedAuthFile, STALE_TIMEOUT_MS } from './cli-utils';
 import { GeminiAuth, LLMClient, LLMResponse, SendMessageOptions } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -128,6 +128,8 @@ export class GeminiClient implements LLMClient {
     const geminiCredsDir = resolveGeminiCredsDir();
     const cliPath = await this.ensureCLI();
     const oauthToken = this.auth.kind === 'oauth' ? this.auth.token : undefined;
+    const startTime = Date.now();
+    const model = this.model;
     if (oauthToken) {
       seedAuthFile({
         secret: oauthToken,
@@ -273,8 +275,16 @@ export class GeminiClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const stderrSnippet = extractCliErrorSnippet(stderr);
-          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${stderrSnippet}`;
+          const msg = buildExitDiagnostics({
+            exitCode: code,
+            signal,
+            stderr,
+            lastStdoutChunk,
+            model,
+            effort: options?.effort,
+            promptChars: fullPrompt.length,
+            elapsedMs: Date.now() - startTime,
+          });
           core.warning(`Gemini CLI failed (${msg})`);
           reject(new Error(`Gemini CLI invocation failed (${msg})`));
           return;

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -509,11 +509,27 @@ describe('sendViaOAuth (Codex CLI path)', () => {
     expect(result.content).toBe('hello world');
   });
 
-  it('rejects on non-zero exit code', async () => {
+  it('rejects on non-zero exit code with rich diagnostics', async () => {
     setupSpawnMock('', { exitCode: 1, stderr: 'something broke' });
+    const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'o3' });
+
+    await expect(client.sendMessage('sys', 'user', { effort: 'high' })).rejects.toThrow(
+      /Codex CLI invocation failed.*model=o3.*effort=high.*promptChars=\d+.*elapsedMs=\d+.*stderrChars=\d+/s,
+    );
+  });
+
+  it('surfaces stdout tail and <empty stderr> marker when exit-1 has no stderr', async () => {
+    setupSpawnMock('partial codex output before crash', { exitCode: 1, stderr: '' });
+    const warnSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
     const client = new OpenAIClient({ auth: { kind: 'oauth', token: 'tok' }, model: 'gpt-4o' });
 
-    await expect(client.sendMessage('sys', 'user')).rejects.toThrow('Codex CLI invocation failed');
+    await expect(client.sendMessage('sys', 'user')).rejects.toThrow(/Codex CLI invocation failed/);
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('Codex CLI failed');
+    expect(allWarnings).toContain('<empty stderr>');
+    expect(allWarnings).toContain('lastStdout=partial codex output before crash');
+    expect(allWarnings).toContain('stderrChars=0');
+    warnSpy.mockRestore();
   });
 
   it('rejects on spawn error', async () => {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions';
 import * as core from '@actions/core';
 
-import { extractCliErrorSnippet, seedAuthFile } from './cli-utils';
+import { buildExitDiagnostics, extractCliErrorSnippet, seedAuthFile } from './cli-utils';
 import { LLMClient, LLMResponse, OpenAIAuth, SendMessageOptions } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -166,6 +166,8 @@ export class OpenAIClient implements LLMClient {
     const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
     const codexHome = resolveCodexHome();
     const oauthToken = this.auth.kind === 'oauth' ? this.auth.token : undefined;
+    const startTime = Date.now();
+    const model = this.model;
     if (oauthToken) {
       seedAuthFile({
         secret: oauthToken,
@@ -314,8 +316,16 @@ export class OpenAIClient implements LLMClient {
           return;
         }
         if (code !== 0) {
-          const sanitizedStderr = extractCliErrorSnippet(stderr);
-          const msg = `exit ${code}${signal ? `, signal ${signal}` : ''}: ${sanitizedStderr}`;
+          const msg = buildExitDiagnostics({
+            exitCode: code,
+            signal,
+            stderr,
+            lastStdoutChunk,
+            model,
+            effort: options?.effort,
+            promptChars: fullPrompt.length,
+            elapsedMs: Date.now() - startTime,
+          });
           core.warning(`Codex CLI failed (${msg})`);
           reject(new Error(`Codex CLI invocation failed (${msg})`));
           return;


### PR DESCRIPTION
## Summary

- Adds `buildExitDiagnostics` in `src/providers/cli-utils.ts` that captures the last 500 chars of stdout, elapsed runtime, model, effort, prompt size, stderr length, and signal — wired into the exit-non-zero branch of all three providers (`anthropic.ts`, `openai.ts`, `gemini.ts`)
- For the Claude path specifically, also parses the terminal stream-json `result` event (`is_error`, `subtype`, result/message text) so we can see *why* the CLI volunteered exit 1 instead of getting an opaque blank
- 7 new tests in `cli-utils.test.ts` plus extensions to the provider-specific exit-1 tests

## Why

PR [#802](https://github.com/manki-review/manki/pull/802)'s judge keeps failing with `Claude CLI failed (exit 1: )` — empty stderr, clean exit code, no signal. The error reason is in the stream-json `result` event but `processJsonLine` discarded it, leaving us unable to tell whether it's `error_during_execution`, `error_max_turns`, content filter, or something else. After this lands, the next judge failure logs the actual reason.

Sample diagnostic with the new code:
```
exit 1: <empty stderr> [model=claude-opus-4-7, effort=high, promptChars=8000, elapsedMs=213000, stderrChars=0, result.is_error=true subtype=error_during_execution result="Maximum tokens exceeded", lastStdout=…]
```

Closes #803