### PR TITLE
feat: surface judge per-thread and per-finding state in `RoundContext`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2697,6 +2697,95 @@ describe('runFullReview orchestration', () => {
     expect(rc!.findings.entries[0].title).toHaveLength(200);
   });
 
+  it('carries judge per-finding state into RoundContext findingEntries', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'COMMENT', summary: 'Issues',
+      findings: [{
+        severity: 'nitpick' as const,
+        title: 'Hypothetical race',
+        file: 'src/app.ts',
+        line: 5,
+        description: 'Race condition that needs a strict ordering.',
+        reviewers: ['Concurrency'],
+        judgeNotes: 'Reachable only under shutdown',
+        judgeConfidence: 'medium' as const,
+        reachability: 'hypothetical' as const,
+        reachabilityReasoning: 'Caller serializes via mutex',
+        tags: ['defensive-hardening', 'own-proposal-followup'],
+        originalSeverity: 'warning' as const,
+      }],
+      highlights: [], reviewComplete: true, agentNames: ['Concurrency'],
+    });
+
+    await callRunFullReview();
+
+    const [,,,,,,,rc] = jest.mocked(ghUtils.postReview).mock.calls[0];
+    const entry = rc!.findings.entries[0];
+    expect(entry.judgeNotes).toBe('Reachable only under shutdown');
+    expect(entry.judgeConfidence).toBe('medium');
+    expect(entry.reachability).toBe('hypothetical');
+    expect(entry.reachabilityReasoning).toBe('Caller serializes via mutex');
+    expect(entry.tags).toEqual(['defensive-hardening', 'own-proposal-followup']);
+    expect(entry.originalSeverity).toBe('warning');
+  });
+
+  it('splits judge suppression counters by tag in RoundContext.judge', async () => {
+    const testFile = {
+      path: 'src/app.ts', changeType: 'modified' as const,
+      hunks: [{ oldStart: 1, oldLines: 5, newStart: 1, newLines: 10, content: 'code' }],
+    };
+    jest.mocked(diffModule.parsePRDiff).mockReturnValue({
+      files: [testFile], totalAdditions: 10, totalDeletions: 5,
+    });
+    jest.mocked(diffModule.filterFiles).mockReturnValue([testFile]);
+    const tagged = (
+      title: string,
+      tag: string,
+      severity: 'ignore' | 'nitpick' = 'ignore',
+    ) => ({
+      severity,
+      title,
+      file: 'src/app.ts',
+      line: 5,
+      description: 'd',
+      reviewers: ['A'],
+      tags: [tag],
+    });
+    jest.mocked(reviewModule.runReview).mockResolvedValue({
+      verdict: 'COMMENT', summary: '',
+      findings: [],
+      allJudgedFindings: [
+        tagged('A', 'suppressed-by-ratchet'),
+        tagged('B', 'suppressed-by-ratchet'),
+        tagged('C', 'suppressed-by-resolved-thread'),
+        tagged('D', 'contradicts-prior-round', 'nitpick'),
+        tagged('E', 'own-proposal-followup', 'nitpick'),
+        tagged('F', 'own-proposal-followup', 'nitpick'),
+        tagged('G', 'defensive-hardening', 'nitpick'),
+      ],
+      highlights: [], reviewComplete: true, agentNames: ['A'],
+      interRoundDiffEmptyOverride: { applied: true, affectedThreadCount: 3 },
+    });
+
+    await callRunFullReview();
+
+    const [,,,,,,,rc] = jest.mocked(ghUtils.postReview).mock.calls[0];
+    expect(rc!.judge.ratchetSuppressedCount).toBe(2);
+    expect(rc!.judge.resolvedThreadSuppressedCount).toBe(1);
+    expect(rc!.judge.contradictionDemotedCount).toBe(1);
+    expect(rc!.judge.ownProposalDemotedCount).toBe(2);
+    expect(rc!.judge.defensiveHardeningCount).toBe(1);
+    expect(rc!.judge.interRoundDiffEmptyOverride).toEqual({ applied: true, affectedThreadCount: 3 });
+  });
+
   it('does not touch memory repo when memory is disabled', async () => {
     const testFile = {
       path: 'src/app.ts', changeType: 'modified' as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,14 @@ import { checkAndAutoApprove, resolveStaleThreads } from './state';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
+const ALLOWED_FINGERPRINT_TAGS = new Set<string>([
+  DEFENSIVE_HARDENING_TAG,
+  OWN_PROPOSAL_TAG,
+  CONTRADICTION_TAG,
+  RATCHET_SUPPRESSED_TAG,
+  RESOLVED_THREAD_SUPPRESSED_TAG,
+]);
+
 function readProviderInputs(): ProviderInputs {
   return {
     anthropicOauthToken: core.getInput('claude_code_oauth_token'),
@@ -907,7 +915,7 @@ async function runFullReview(
       ...(f.judgeConfidence && { judgeConfidence: f.judgeConfidence }),
       ...(f.reachability && { reachability: f.reachability }),
       ...(f.reachabilityReasoning && { reachabilityReasoning: f.reachabilityReasoning.slice(0, 500) }),
-      ...(f.tags && f.tags.length > 0 && { tags: [...f.tags] }),
+      ...(f.tags && f.tags.length > 0 && { tags: f.tags.filter(t => ALLOWED_FINGERPRINT_TAGS.has(t)) }),
       ...(f.originalSeverity && { originalSeverity: f.originalSeverity }),
     }));
     const context: RoundContext = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { isEmptyInterRoundDiff } from './judge';
 import { loadMemory, applyEscalations, updatePattern, RepoMemory } from './memory';
 import { collectResolvedThreadIds, fetchRecapState, fingerprintFinding } from './recap';
 import { buildAgentPool, collectPriorRoundAgents, runReview, determineVerdict, selectTeam } from './review';
-import { DEFENSIVE_HARDENING_TAG, DashboardData, PrContext, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DashboardData, OWN_PROPOSAL_TAG, PrContext, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewMetadata, RoundContext, roundContextToFlatAliases } from './types';
 import {
   fetchPRDiff,
   fetchConfigFile,
@@ -880,8 +880,13 @@ async function runFullReview(
         - allJudged.length
       : 0;
     const defensiveHardeningCount = allJudged.filter(f => f.tags?.includes(DEFENSIVE_HARDENING_TAG)).length;
+    const ownProposalDemotedCount = allJudged.filter(f => f.tags?.includes(OWN_PROPOSAL_TAG)).length;
+    const contradictionDemotedCount = allJudged.filter(f => f.tags?.includes(CONTRADICTION_TAG)).length;
+    const ratchetSuppressedCount = allJudged.filter(f => f.tags?.includes(RATCHET_SUPPRESSED_TAG)).length;
+    const resolvedThreadSuppressedCount = allJudged.filter(f => f.tags?.includes(RESOLVED_THREAD_SUPPRESSED_TAG)).length;
     const crossRoundSuppressed = result.crossRoundSuppressed;
     const crossRoundDemoted = result.crossRoundDemoted;
+    const interRoundDiffEmptyOverride = result.interRoundDiffEmptyOverride;
     const inPrSuppressedCount = result.inPrSuppressedCount ?? 0;
     // File analysis metrics
     const fileTypes: Record<string, number> = {};
@@ -898,6 +903,12 @@ async function runFullReview(
       ...(f.reviewers[0] && { specialist: f.reviewers[0] }),
       ...(f.suggestedFix && { suggestedFix: f.suggestedFix.slice(0, 300) }),
       ...(f.title && { title: f.title.slice(0, 200) }),
+      ...(f.judgeNotes && { judgeNotes: f.judgeNotes.slice(0, 500) }),
+      ...(f.judgeConfidence && { judgeConfidence: f.judgeConfidence }),
+      ...(f.reachability && { reachability: f.reachability }),
+      ...(f.reachabilityReasoning && { reachabilityReasoning: f.reachabilityReasoning.slice(0, 500) }),
+      ...(f.tags && f.tags.length > 0 && { tags: [...f.tags] }),
+      ...(f.originalSeverity && { originalSeverity: f.originalSeverity }),
     }));
     const context: RoundContext = {
       meta: {
@@ -947,9 +958,14 @@ async function runFullReview(
         durationMs: judgeEndTime - reviewEndTime,
         ...(verdictReason && { verdictReason }),
         ...(defensiveHardeningCount > 0 && { defensiveHardeningCount }),
+        ...(ownProposalDemotedCount > 0 && { ownProposalDemotedCount }),
+        ...(contradictionDemotedCount > 0 && { contradictionDemotedCount }),
+        ...(ratchetSuppressedCount > 0 && { ratchetSuppressedCount }),
+        ...(resolvedThreadSuppressedCount > 0 && { resolvedThreadSuppressedCount }),
         ...(inPrSuppressedCount > 0 && { inPrSuppressedCount }),
         ...(crossRoundSuppressed != null && crossRoundSuppressed > 0 && { crossRoundSuppressed }),
         ...(crossRoundDemoted != null && crossRoundDemoted > 0 && { crossRoundDemoted }),
+        ...(interRoundDiffEmptyOverride && { interRoundDiffEmptyOverride }),
         ...(result.threadEvaluations && result.threadEvaluations.length > 0 && { threadEvaluations: result.threadEvaluations }),
       },
       dedup: {

--- a/src/judge.test.ts
+++ b/src/judge.test.ts
@@ -1396,6 +1396,7 @@ describe('runJudgeAgent', () => {
       { threadId: 'PRRT_a', status: 'not_addressed', reason: 'No code changes since prior review' },
       { threadId: 'PRRT_b', status: 'not_addressed', reason: 'No code changes since prior review' },
     ]);
+    expect(result.interRoundDiffEmptyOverride).toEqual({ applied: true, affectedThreadCount: 2 });
   });
 
   it('does not override threadEvaluations when interRoundDiff is empty but no prior rounds exist', async () => {
@@ -1428,6 +1429,7 @@ describe('runJudgeAgent', () => {
     expect(result.threadEvaluations).toEqual([
       { threadId: 'PRRT_a', status: 'addressed', reason: 'Fixed' },
     ]);
+    expect(result.interRoundDiffEmptyOverride).toBeUndefined();
   });
 
   it('renders empty inter-round diff sentinel in user message', async () => {

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -16,7 +16,7 @@ import { safeTruncate } from './utils';
 import { sanitize, titlesOverlap } from './recap';
 import { validateSeverity } from './review';
 import { indexThreadEvaluations, isPriorAddressedByJudge } from './finding-fingerprint';
-import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingFingerprintEntry, FindingReachability, FindingSeverity, IN_PR_SUPPRESSED_TAG, InPrSuppression, NoiseLevel, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewConfig, RoundContext, ParsedDiff, PrContext, ThreadEvaluation } from './types';
+import { CONTRADICTION_TAG, DEFENSIVE_HARDENING_TAG, DiffFile, Finding, FindingFingerprintEntry, FindingReachability, FindingSeverity, IN_PR_SUPPRESSED_TAG, InPrSuppression, InterRoundDiffEmptyOverride, NoiseLevel, OpenThread, OWN_PROPOSAL_TAG, ProvenanceEntry, RATCHET_SUPPRESSED_TAG, RESOLVED_THREAD_SUPPRESSED_TAG, ReviewConfig, RoundContext, ParsedDiff, PrContext, ThreadEvaluation } from './types';
 
 /** Cap on how many prior rounds we pass to the judge. */
 const PRIOR_ROUNDS_WINDOW = 3;
@@ -831,7 +831,7 @@ export async function runJudgeAgent(
   crossRoundSuppressed?: number;
   crossRoundDemoted?: number;
   inPrSuppressedCount?: number;
-  interRoundDiffEmptyOverride?: { applied: boolean; affectedThreadCount: number };
+  interRoundDiffEmptyOverride?: InterRoundDiffEmptyOverride;
 }> {
   const { findings, diff, rawDiff, memory, prContext, linkedIssues, agentCount, isFollowUp, openThreads, priorRounds, inPrSuppressions, interRoundDiff, resolvedThreadIds, suppressResolvedThreads } = input;
   const provenanceMap = input.provenanceMap ?? (rawDiff ? computeProvenanceMap(priorRounds, rawDiff) : []);

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -831,6 +831,7 @@ export async function runJudgeAgent(
   crossRoundSuppressed?: number;
   crossRoundDemoted?: number;
   inPrSuppressedCount?: number;
+  interRoundDiffEmptyOverride?: { applied: boolean; affectedThreadCount: number };
 }> {
   const { findings, diff, rawDiff, memory, prContext, linkedIssues, agentCount, isFollowUp, openThreads, priorRounds, inPrSuppressions, interRoundDiff, resolvedThreadIds, suppressResolvedThreads } = input;
   const provenanceMap = input.provenanceMap ?? (rawDiff ? computeProvenanceMap(priorRounds, rawDiff) : []);
@@ -868,13 +869,17 @@ export async function runJudgeAgent(
 
   // Defense-in-depth: when the inter-round diff is empty, force every open
   // thread to `not_addressed` regardless of what the LLM returned.
-  const threadEvaluations = interRoundDiffEmpty && hasOpenThreads
+  const overrideApplied = interRoundDiffEmpty && hasOpenThreads;
+  const threadEvaluations = overrideApplied
     ? openThreads!.map(t => ({
       threadId: t.threadId,
       status: 'not_addressed' as const,
       reason: 'No code changes since prior review',
     }))
     : judgeResult.threadEvaluations;
+  const interRoundDiffEmptyOverride = overrideApplied
+    ? { applied: true, affectedThreadCount: openThreads!.length }
+    : undefined;
 
   const crossRoundOptions: CrossRoundSuppressionOptions = { resolvedThreadIds, suppressResolvedThreads, threadEvaluations };
 
@@ -894,6 +899,7 @@ export async function runJudgeAgent(
       ...(earlySuppress.suppressedCount > 0 && { crossRoundSuppressed: earlySuppress.suppressedCount }),
       ...(earlySuppress.demotedCount > 0 && { crossRoundDemoted: earlySuppress.demotedCount }),
       ...(earlyInPrCount > 0 && { inPrSuppressedCount: earlyInPrCount }),
+      ...(interRoundDiffEmptyOverride && { interRoundDiffEmptyOverride }),
     };
   }
 
@@ -908,6 +914,7 @@ export async function runJudgeAgent(
     ...(suppression.suppressedCount > 0 && { crossRoundSuppressed: suppression.suppressedCount }),
     ...(suppression.demotedCount > 0 && { crossRoundDemoted: suppression.demotedCount }),
     ...(inPrCount > 0 && { inPrSuppressedCount: inPrCount }),
+    ...(interRoundDiffEmptyOverride && { interRoundDiffEmptyOverride }),
   };
 }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -1159,6 +1159,7 @@ export async function runReview(
   let judgeThreadEvaluations: ThreadEvaluation[] | undefined;
   let judgeCrossRoundSuppressed: number | undefined;
   let judgeCrossRoundDemoted: number | undefined;
+  let judgeInterRoundDiffEmptyOverride: { applied: boolean; affectedThreadCount: number } | undefined;
   let inPrSuppressedCount = 0;
   try {
     core.info(`Running judge on ${findingsForJudge.length} findings...`);
@@ -1187,6 +1188,7 @@ export async function runReview(
     judgeThreadEvaluations = judgeResult.threadEvaluations;
     judgeCrossRoundSuppressed = judgeResult.crossRoundSuppressed;
     judgeCrossRoundDemoted = judgeResult.crossRoundDemoted;
+    judgeInterRoundDiffEmptyOverride = judgeResult.interRoundDiffEmptyOverride;
     inPrSuppressedCount = judgeResult.inPrSuppressedCount ?? 0;
     finalFindings = judgeResult.findings.filter(f => f.severity !== 'ignore');
     core.info(`Judge complete: ${finalFindings.length} findings survived (${judgeResult.findings.length - finalFindings.length} ignored)`);
@@ -1265,6 +1267,7 @@ export async function runReview(
     agentResponseLengths,
     crossRoundSuppressed: judgeCrossRoundSuppressed,
     crossRoundDemoted: judgeCrossRoundDemoted,
+    ...(judgeInterRoundDiffEmptyOverride && { interRoundDiffEmptyOverride: judgeInterRoundDiffEmptyOverride }),
     ...(testNitSuppressedCount > 0 && { testNitSuppressedCount }),
   };
 }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -165,6 +165,59 @@ describe('RoundContext', () => {
     expect(ctx.judge.summary).toMatch(/Three issues/);
     expect(ctx.reviewers.agents).toEqual(['typescript', 'security', 'tests']);
   });
+
+  it('carries split judge counters and inter-round override on `RoundJudge`', () => {
+    const ctx: RoundContext = {
+      ...fullyPopulatedContext(),
+      judge: {
+        summary: 'split counters',
+        ownProposalDemotedCount: 2,
+        contradictionDemotedCount: 1,
+        ratchetSuppressedCount: 3,
+        resolvedThreadSuppressedCount: 1,
+        interRoundDiffEmptyOverride: { applied: true, affectedThreadCount: 4 },
+        threadEvaluations: [
+          { threadId: 'PRRT_a', status: 'not_addressed', reason: 'No code changes since prior review' },
+        ],
+      },
+    };
+    expect(ctx.judge.ownProposalDemotedCount).toBe(2);
+    expect(ctx.judge.contradictionDemotedCount).toBe(1);
+    expect(ctx.judge.ratchetSuppressedCount).toBe(3);
+    expect(ctx.judge.resolvedThreadSuppressedCount).toBe(1);
+    expect(ctx.judge.interRoundDiffEmptyOverride).toEqual({ applied: true, affectedThreadCount: 4 });
+    expect(ctx.judge.threadEvaluations).toHaveLength(1);
+  });
+
+  it('carries judge per-finding state on `FindingFingerprintEntry`', () => {
+    const entry: RoundContext['findings']['entries'][number] = {
+      fingerprint: { file: 'src/a.ts', lineStart: 1, lineEnd: 1, slug: 'race-condition' },
+      severity: 'nitpick',
+      judgeNotes: 'Reachable only under shutdown',
+      judgeConfidence: 'medium',
+      reachability: 'hypothetical',
+      reachabilityReasoning: 'Caller serializes access via mutex',
+      tags: ['defensive-hardening'],
+      originalSeverity: 'warning',
+    };
+    expect(entry.judgeNotes).toMatch(/shutdown/);
+    expect(entry.judgeConfidence).toBe('medium');
+    expect(entry.reachability).toBe('hypothetical');
+    expect(entry.tags).toEqual(['defensive-hardening']);
+    expect(entry.originalSeverity).toBe('warning');
+  });
+
+  it('omits all new optional fields gracefully on minimal entry', () => {
+    const entry: RoundContext['findings']['entries'][number] = {
+      fingerprint: { file: 'x', lineStart: 1, lineEnd: 1, slug: 's' },
+      severity: 'suggestion',
+    };
+    expect(entry.judgeNotes).toBeUndefined();
+    expect(entry.judgeConfidence).toBeUndefined();
+    expect(entry.reachability).toBeUndefined();
+    expect(entry.tags).toBeUndefined();
+    expect(entry.originalSeverity).toBeUndefined();
+  });
 });
 
 describe('roundContextToFlatAliases', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export interface ReviewResult {
   agentResponseLengths?: Map<string, number>;
   crossRoundSuppressed?: number;
   crossRoundDemoted?: number;
+  /** Set when the judge stage forced every open thread to `not_addressed` because the inter-round diff was known-empty. */
+  interRoundDiffEmptyOverride?: { applied: boolean; affectedThreadCount: number };
   testNitSuppressedCount?: number;
 }
 
@@ -571,6 +573,29 @@ export interface RoundJudge {
   crossRoundSuppressed?: number;
   crossRoundDemoted?: number;
   /**
+   * Count of findings demoted to `nitpick` because they implement a prior-round
+   * `suggestedFix` (tagged `OWN_PROPOSAL_TAG`). Distinct from
+   * `defensiveHardeningCount` which covers hypothetical-reachability demotions.
+   */
+  ownProposalDemotedCount?: number;
+  /**
+   * Subset of `crossRoundDemoted` tagged `CONTRADICTION_TAG`. Currently this
+   * equals `crossRoundDemoted`, but the field is split so future demotion
+   * categories don't collapse into a single opaque counter.
+   */
+  contradictionDemotedCount?: number;
+  /** Subset of `crossRoundSuppressed` tagged `RATCHET_SUPPRESSED_TAG`. */
+  ratchetSuppressedCount?: number;
+  /** Subset of `crossRoundSuppressed` tagged `RESOLVED_THREAD_SUPPRESSED_TAG`. */
+  resolvedThreadSuppressedCount?: number;
+  /**
+   * Records the defense-in-depth path where the judge stage forced every open
+   * thread to `not_addressed` because the inter-round diff was known-empty
+   * (force-pushed rebase to identical tree). `applied: true` means the
+   * synthetic evaluations replaced whatever the LLM returned.
+   */
+  interRoundDiffEmptyOverride?: { applied: boolean; affectedThreadCount: number };
+  /**
    * Per-open-thread judgment from the judge stage. Surfaced in the embedded
    * round-context block so the resolution signal is observable post-hoc when
    * debugging stuck reviews. Producers omit this field on rounds with no open
@@ -620,6 +645,18 @@ export interface FindingFingerprintEntry {
   suggestedFix?: string;
   /** Human-readable finding title. */
   title?: string;
+  /** Judge reasoning for the verdict on this finding. Mirrors `Finding.judgeNotes`. */
+  judgeNotes?: string;
+  /** Judge confidence in the verdict. Mirrors `Finding.judgeConfidence`. */
+  judgeConfidence?: 'high' | 'medium' | 'low';
+  /** Reachability classification of the underlying issue. Mirrors `Finding.reachability`. */
+  reachability?: FindingReachability;
+  /** Free-form explanation of the reachability classification. Mirrors `Finding.reachabilityReasoning`. */
+  reachabilityReasoning?: string;
+  /** Tags applied by the judge (e.g. `DEFENSIVE_HARDENING_TAG`, `OWN_PROPOSAL_TAG`). Preserves the exact string constants from `Finding.tags`. */
+  tags?: string[];
+  /** Pre-demotion severity, when the judge demoted the finding. Mirrors `Finding.originalSeverity`. */
+  originalSeverity?: FindingSeverity;
 }
 
 export interface RoundUsage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,11 @@ export const RESOLVED_THREAD_SUPPRESSED_TAG = 'suppressed-by-resolved-thread' as
 export const OWN_PROPOSAL_TAG = 'own-proposal-followup' as const;
 export const IN_PR_SUPPRESSED_TAG = 'suppressed-in-pr' as const;
 
+export interface InterRoundDiffEmptyOverride {
+  applied: boolean;
+  affectedThreadCount: number;
+}
+
 /** Shared shape for the prose extracted from a review-thread comment body. */
 export interface FindingMetadata {
   description?: string;
@@ -135,7 +140,7 @@ export interface ReviewResult {
   crossRoundSuppressed?: number;
   crossRoundDemoted?: number;
   /** Set when the judge stage forced every open thread to `not_addressed` because the inter-round diff was known-empty. */
-  interRoundDiffEmptyOverride?: { applied: boolean; affectedThreadCount: number };
+  interRoundDiffEmptyOverride?: InterRoundDiffEmptyOverride;
   testNitSuppressedCount?: number;
 }
 
@@ -579,9 +584,10 @@ export interface RoundJudge {
    */
   ownProposalDemotedCount?: number;
   /**
-   * Subset of `crossRoundDemoted` tagged `CONTRADICTION_TAG`. Currently this
-   * equals `crossRoundDemoted`, but the field is split so future demotion
-   * categories don't collapse into a single opaque counter.
+   * Subset of `crossRoundDemoted` tagged `CONTRADICTION_TAG`. Together with
+   * `ownProposalDemotedCount`, accounts for the full `crossRoundDemoted`
+   * aggregate; split so future demotion categories don't collapse into a
+   * single opaque counter.
    */
   contradictionDemotedCount?: number;
   /** Subset of `crossRoundSuppressed` tagged `RATCHET_SUPPRESSED_TAG`. */
@@ -594,7 +600,7 @@ export interface RoundJudge {
    * (force-pushed rebase to identical tree). `applied: true` means the
    * synthetic evaluations replaced whatever the LLM returned.
    */
-  interRoundDiffEmptyOverride?: { applied: boolean; affectedThreadCount: number };
+  interRoundDiffEmptyOverride?: InterRoundDiffEmptyOverride;
   /**
    * Per-open-thread judgment from the judge stage. Surfaced in the embedded
    * round-context block so the resolution signal is observable post-hoc when


### PR DESCRIPTION
## Summary

- Extend `RoundJudge` with `interRoundDiffEmptyOverride` (records the empty-diff guard firing) and split the previously opaque `crossRoundSuppressed`/`crossRoundDemoted` aggregates into `ratchetSuppressedCount`, `resolvedThreadSuppressedCount`, `contradictionDemotedCount`, and `ownProposalDemotedCount`. All optional so replay tooling reading prior round contexts keeps working.
- Extend `FindingFingerprintEntry` with `judgeNotes`, `judgeConfidence`, `reachability`, `reachabilityReasoning`, `tags`, and `originalSeverity` so the per-round fingerprint table carries the judge's full per-finding state. `tags` preserves the exact string constants from `Finding.tags` (`DEFENSIVE_HARDENING_TAG`, `OWN_PROPOSAL_TAG`, `CONTRADICTION_TAG`, `RATCHET_SUPPRESSED_TAG`, `RESOLVED_THREAD_SUPPRESSED_TAG`).
- Wire the new fields through `runJudgeAgent` (`interRoundDiffEmptyOverride`), `review.ts` (passes the override through `ReviewResult`), and the builder in `index.ts` (derives tag-based counters from `allJudgedFindings.tags` using the same pattern as the existing `defensiveHardeningCount`).

Parent [#788](https://github.com/manki-review/manki/issues/788). Phase 1 of [#787](https://github.com/manki-review/manki/issues/787) — unblocks wiring `threadEvaluations` into `determineVerdict`.

`mankiVersion` is auto-derived from `package.json` at runtime, so the field reflects whatever version ships next. No `package.json` bump in this PR.

Closes [#789](https://github.com/manki-review/manki/issues/789).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 2024 passing, 8 skipped, no regressions
- [x] New `types.test.ts` cases for `RoundJudge` split counters and `FindingFingerprintEntry` per-finding fields
- [x] New `judge.test.ts` assertions on `runJudgeAgent` returning `interRoundDiffEmptyOverride` when the empty-diff guard fires, `undefined` otherwise
- [x] New `index.test.ts` builder cases for finding-state passthrough and tag-derived counters